### PR TITLE
Scala 3 Refactor - Enablers First Batch

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/enablers/Aggregating.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Aggregating.scala
@@ -227,7 +227,7 @@ trait AggregatingJavaImplicits extends AggregatingImpls {
   // SKIP-DOTTY-START
   implicit def aggregatingNatureOfJavaCollection[E, JCOL[e] <: java.util.Collection[e]](implicit equality: Equality[E]): Aggregating[JCOL[E]] =
   // SKIP-DOTTY-END
-  //DOTTY-ONLY def aggregatingNatureOfJavaCollection[E, JCOL[e] <: java.util.Collection[e]](implicit equality: Equality[E]): Aggregating[JCOL[E]] =
+  //DOTTY-ONLY def aggregatingNatureOfJavaCollection[E, JCOL[e] <: java.util.Collection[e]](using equality: Equality[E]): Aggregating[JCOL[E]] =
     convertEqualityToJavaCollectionAggregating(equality)
 
   /**
@@ -322,7 +322,7 @@ trait AggregatingJavaImplicits extends AggregatingImpls {
   // SKIP-DOTTY-START
   implicit def aggregatingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]](implicit equality: Equality[java.util.Map.Entry[K, V]]): Aggregating[JMAP[K, V]] =
   // SKIP-DOTTY-END
-  //DOTTY-ONLY def aggregatingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]](implicit equality: Equality[java.util.Map.Entry[K, V]]): Aggregating[JMAP[K, V]] =
+  //DOTTY-ONLY def aggregatingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]](using equality: Equality[java.util.Map.Entry[K, V]]): Aggregating[JMAP[K, V]] =
     convertEqualityToJavaMapAggregating(equality)
 
   /**

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Aggregating.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Aggregating.scala
@@ -214,14 +214,48 @@ trait AggregatingImpls {
 trait AggregatingJavaImplicits extends AggregatingImpls {
 
   /**
+    // SKIP-DOTTY-START
     * Implicit to support <code>Aggregating</code> nature of <code>java.util.Collection</code>.
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY   * To support <code>Aggregating</code> nature of <code>java.util.Collection</code>.
     *
     * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>java.util.Collection</code>
     * @tparam E the type of the element in the <code>java.util.Collection</code>
     * @tparam JCOL any subtype of <code>java.util.Collection</code>
     * @return <code>Aggregating[JCOL[E]]</code> that supports <code>java.util.Collection</code> in relevant <code>contain</code> syntax
     */
+  // SKIP-DOTTY-START
   implicit def aggregatingNatureOfJavaCollection[E, JCOL[e] <: java.util.Collection[e]](implicit equality: Equality[E]): Aggregating[JCOL[E]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def aggregatingNatureOfJavaCollection[E, JCOL[e] <: java.util.Collection[e]](implicit equality: Equality[E]): Aggregating[JCOL[E]] =
+    convertEqualityToJavaCollectionAggregating(equality)
+
+  /**
+    // SKIP-DOTTY-START
+    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY * converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+    * into <code>Aggregating</code> of type <code>JCOL[E]</code>, where <code>JCOL</code> is a subtype of <code>java.util.Collection</code>.
+    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+    *
+    * <pre class="stHighlight">
+    * val javaList = new java.util.ArrayList[String]()
+    * javaList.add("hi")
+    * (javaList should contain ("HI")) (after being lowerCased)
+    * </pre>
+    *
+    * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+    * and this implicit conversion will convert it into <code>Aggregating[java.util.ArrayList[String]]</code>.
+    *
+    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+    * @tparam E type of elements in the <code>java.util.Collection</code>
+    * @tparam JCOL subtype of <code>java.util.Collection</code>
+    * @return <code>Aggregating</code> of type <code>JCOL[E]</code>
+    */
+  // SKIP-DOTTY-START
+  implicit def convertEqualityToJavaCollectionAggregating[E, JCOL[e] <: java.util.Collection[e]](equality: Equality[E]): Aggregating[JCOL[E]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToJavaCollectionAggregating[E, JCOL[e] <: java.util.Collection[e]](equality: Equality[E]): Aggregating[JCOL[E]] =
     new Aggregating[JCOL[E]] {
       def containsAtLeastOneOf(col: JCOL[E], elements: scala.collection.Seq[Any]): Boolean = {
         col.asScala.exists((e: E) => elements.exists((ele: Any) => equality.areEqual(e, ele)))
@@ -240,30 +274,44 @@ trait AggregatingJavaImplicits extends AggregatingImpls {
       }
     }
 
-  /**
-    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
-    * into <code>Aggregating</code> of type <code>JCOL[E]</code>, where <code>JCOL</code> is a subtype of <code>java.util.Collection</code>.
-    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
-    *
-    * <pre class="stHighlight">
-    * val javaList = new java.util.ArrayList[String]()
-    * javaList.add("hi")
-    * (javaList should contain ("HI")) (after being lowerCased)
-    * </pre>
-    *
-    * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
-    * and this implicit conversion will convert it into <code>Aggregating[java.util.ArrayList[String]]</code>.
-    *
-    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
-    * @tparam E type of elements in the <code>java.util.Collection</code>
-    * @tparam JCOL subtype of <code>java.util.Collection</code>
-    * @return <code>Aggregating</code> of type <code>JCOL[E]</code>
-    */
-  implicit def convertEqualityToJavaCollectionAggregating[E, JCOL[e] <: java.util.Collection[e]](equality: Equality[E]): Aggregating[JCOL[E]] =
-    aggregatingNatureOfJavaCollection(equality)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Aggregating</code> nature of <code>java.util.Collection</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>java.util.Collection</code>
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>java.util.Collection</code>
+  //DOTTY-ONLY   * @tparam JCOL any subtype of <code>java.util.Collection</code>
+  //DOTTY-ONLY   * @return <code>Aggregating[JCOL[E]]</code> that supports <code>java.util.Collection</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E, JCOL[e] <: java.util.Collection[e]] (using equality: Equality[E]): Aggregating[JCOL[E]] = convertEqualityToJavaCollectionAggregating(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * into <code>Aggregating</code> of type <code>JCOL[E]</code>, where <code>JCOL</code> is a subtype of <code>java.util.Collection</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * val javaList = new java.util.ArrayList[String]()
+  //DOTTY-ONLY   * javaList.add("hi")
+  //DOTTY-ONLY   * (javaList should contain ("HI")) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Aggregating[java.util.ArrayList[String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * @tparam E type of elements in the <code>java.util.Collection</code>
+  //DOTTY-ONLY   * @tparam JCOL subtype of <code>java.util.Collection</code>
+  //DOTTY-ONLY   * @return <code>Aggregating</code> of type <code>JCOL[E]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityJavaCollectionAggregating[E, JCOL[e] <: java.util.Collection[e]]: Conversion[Equality[E], Aggregating[JCOL[E]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[E]): Aggregating[JCOL[E]] = convertEqualityToJavaCollectionAggregating(equality)
+  //DOTTY-ONLY }  
 
   /**
+    // SKIP-DOTTY-START
     * Implicit to support <code>Aggregating</code> nature of <code>java.util.Map</code>.
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY * To support <code>Aggregating</code> nature of <code>java.util.Map</code>.
     *
     * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of entry in the <code>java.util.Map</code>
     * @tparam K the type of the key in the <code>java.util.Map</code>
@@ -271,7 +319,40 @@ trait AggregatingJavaImplicits extends AggregatingImpls {
     * @tparam JMAP any subtype of <code>java.util.Map</code>
     * @return <code>Aggregating[JMAP[K, V]]</code> that supports <code>java.util.Map</code> in relevant <code>contain</code> syntax
     */
+  // SKIP-DOTTY-START
   implicit def aggregatingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]](implicit equality: Equality[java.util.Map.Entry[K, V]]): Aggregating[JMAP[K, V]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def aggregatingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]](implicit equality: Equality[java.util.Map.Entry[K, V]]): Aggregating[JMAP[K, V]] =
+    convertEqualityToJavaMapAggregating(equality)
+
+  /**
+    // SKIP-DOTTY-START
+    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
+    * into <code>Aggregating</code> of type <code>JMAP[K, V]</code>, where <code>JMAP</code> is a subtype of <code>java.util.Map</code>.
+    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+    *
+    * <pre class="stHighlight">
+    * val javaMap = new java.util.HashMap[Int, String]()
+    * javaMap.put(1, "one")
+    * // lowerCased needs to be implemented as Normalization[java.util.Map.Entry[K, V]]
+    * (javaMap should contain (Entry(1, "ONE"))) (after being lowerCased)
+    * </pre>
+    *
+    * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>java.util.Map.Entry[Int, String]</code></a>
+    * and this implicit conversion will convert it into <code>Aggregating[java.util.HashMap[Int, String]]</code>.
+    *
+    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
+    * @tparam K the type of the key in the <code>java.util.Map</code>
+    * @tparam V the type of the value in the <code>java.util.Map</code>
+    * @tparam JMAP any subtype of <code>java.util.Map</code>
+    * @return <code>Aggregating</code> of type <code>JMAP[K, V]</code>
+    */
+  // SKIP-DOTTY-START
+  implicit def convertEqualityToJavaMapAggregating[K, V, JMAP[k, v] <: java.util.Map[k, v]](equality: Equality[java.util.Map.Entry[K, V]]): Aggregating[JMAP[K, V]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToJavaMapAggregating[K, V, JMAP[k, v] <: java.util.Map[k, v]](equality: Equality[java.util.Map.Entry[K, V]]): Aggregating[JMAP[K, V]] =
     new Aggregating[JMAP[K, V]] {
 
       import scala.collection.JavaConverters._
@@ -292,30 +373,41 @@ trait AggregatingJavaImplicits extends AggregatingImpls {
       }
     }
 
-  /**
-    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
-    * into <code>Aggregating</code> of type <code>JMAP[K, V]</code>, where <code>JMAP</code> is a subtype of <code>java.util.Map</code>.
-    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
-    *
-    * <pre class="stHighlight">
-    * val javaMap = new java.util.HashMap[Int, String]()
-    * javaMap.put(1, "one")
-    * // lowerCased needs to be implemented as Normalization[java.util.Map.Entry[K, V]]
-    * (javaMap should contain (Entry(1, "ONE"))) (after being lowerCased)
-    * </pre>
-    *
-    * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>java.util.Map.Entry[Int, String]</code></a>
-    * and this implicit conversion will convert it into <code>Aggregating[java.util.HashMap[Int, String]]</code>.
-    *
-    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
-    * @tparam K the type of the key in the <code>java.util.Map</code>
-    * @tparam V the type of the value in the <code>java.util.Map</code>
-    * @tparam JMAP any subtype of <code>java.util.Map</code>
-    * @return <code>Aggregating</code> of type <code>JMAP[K, V]</code>
-    */
-  implicit def convertEqualityToJavaMapAggregating[K, V, JMAP[k, v] <: java.util.Map[k, v]](equality: Equality[java.util.Map.Entry[K, V]]): Aggregating[JMAP[K, V]] =
-    aggregatingNatureOfJavaMap(equality)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Aggregating</code> nature of <code>java.util.Map</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of entry in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam JMAP any subtype of <code>java.util.Map</code>
+  //DOTTY-ONLY   * @return <code>Aggregating[JMAP[K, V]]</code> that supports <code>java.util.Map</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [K, V, JMAP[k, v] <: java.util.Map[k, v]] (using equality: Equality[java.util.Map.Entry[K, V]]): Aggregating[JMAP[K, V]] = convertEqualityToJavaMapAggregating(equality)
 
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
+  //DOTTY-ONLY   * into <code>Aggregating</code> of type <code>JMAP[K, V]</code>, where <code>JMAP</code> is a subtype of <code>java.util.Map</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * val javaMap = new java.util.HashMap[Int, String]()
+  //DOTTY-ONLY   * javaMap.put(1, "one")
+  //DOTTY-ONLY   * // lowerCased needs to be implemented as Normalization[java.util.Map.Entry[K, V]]
+  //DOTTY-ONLY   * (javaMap should contain (Entry(1, "ONE"))) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>java.util.Map.Entry[Int, String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Aggregating[java.util.HashMap[Int, String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam JMAP any subtype of <code>java.util.Map</code>
+  //DOTTY-ONLY   * @return <code>Aggregating</code> of type <code>JMAP[K, V]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityJavaMapAggregating[K, V, JMAP[k, v] <: java.util.Map[k, v]]: Conversion[Equality[java.util.Map.Entry[K, V]], Aggregating[JMAP[K, V]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[java.util.Map.Entry[K, V]]): Aggregating[JMAP[K, V]] = convertEqualityToJavaMapAggregating(equality)
+  //DOTTY-ONLY }  
 
 }
 

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Collecting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Collecting.scala
@@ -85,13 +85,19 @@ trait Collecting[E, C] {
 object Collecting {
 
   /**
+   // SKIP-DOTTY-START
    * Implicit to support <code>Collecting</code> nature of <code>Iterable</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY   * To support <code>Collecting</code> nature of <code>Iterable</code>.
    *
    * @tparam E the type of the element in the <code>Iterable</code>
    * @tparam ITR any subtype of <code>Iterable</code>
    * @return <code>Collecting[E, TRAV[E]]</code> that supports <code>Iterable</code> in <code>loneElement</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def collectingNatureOfIterable[E, ITR[e] <: Iterable[e]]: Collecting[E, ITR[E]] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def collectingNatureOfIterable[E, ITR[e] <: Iterable[e]]: Collecting[E, ITR[E]] = 
     new Collecting[E, ITR[E]] {
       def loneElementOf(trav: ITR[E]): Option[E] = {
         if (trav.size == 1) Some(trav.head) else None
@@ -99,14 +105,28 @@ object Collecting {
       def sizeOf(trav: ITR[E]): Int = trav.size
       def iterableFrom(collection: ITR[E]): Iterable[E] = collection
     }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Collecting</code> nature of <code>Iterable</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>Iterable</code>
+  //DOTTY-ONLY   * @tparam ITR any subtype of <code>Iterable</code>
+  //DOTTY-ONLY   * @return <code>Collecting[E, TRAV[E]]</code> that supports <code>Iterable</code> in <code>loneElement</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E, ITR[e] <: Iterable[e]]: Collecting[E, ITR[E]] = collectingNatureOfIterable
 
   /**
+   // SKIP-DOTTY-START 
    * Implicit to support <code>Collecting</code> nature of <code>Array</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY   * To support <code>Collecting</code> nature of <code>Array</code>.
    *
    * @tparam E the type of the element in the <code>Array</code>
    * @return <code>Collecting[E, Array[E]]</code> that supports <code>Array</code> in <code>loneElement</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def collectingNatureOfArray[E]: Collecting[E, Array[E]] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def collectingNatureOfArray[E]: Collecting[E, Array[E]] = 
     new Collecting[E, Array[E]] {
       def loneElementOf(array: Array[E]): Option[E] = {
         if (array.size == 1) Some(array.head) else None
@@ -114,13 +134,26 @@ object Collecting {
       def sizeOf(array: Array[E]): Int = array.length
       def iterableFrom(collection: Array[E]): Iterable[E] = collection
     }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Collecting</code> nature of <code>Array</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>Array</code>
+  //DOTTY-ONLY   * @return <code>Collecting[E, Array[E]]</code> that supports <code>Array</code> in <code>loneElement</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E]: Collecting[E, Array[E]] = collectingNatureOfArray
 
   /**
+   // SKIP-DOTTY-START
    * Implicit to support <code>Collecting</code> nature of <code>String</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY   * To support <code>Collecting</code> nature of <code>String</code>.
    *
    * @return <code>Collecting[Char, String]</code> that supports <code>String</code> in <code>loneElement</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def collectingNatureOfString: Collecting[Char, String] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def collectingNatureOfString: Collecting[Char, String] = 
     new Collecting[Char, String] {
       def loneElementOf(string: String): Option[Char] = {
         if (string.size == 1) Some(string.head) else None
@@ -128,15 +161,27 @@ object Collecting {
       def sizeOf(string: String): Int = string.length
       def iterableFrom(collection: String): Iterable[Char] = collection.toVector
     }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Collecting</code> nature of <code>String</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @return <code>Collecting[Char, String]</code> that supports <code>String</code> in <code>loneElement</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given Collecting[Char, String] = collectingNatureOfString
 
   /**
+   // SKIP-DOTTY-START
    * Implicit to support <code>Collecting</code> nature of <code>java.util.Collection</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY To support <code>Collecting</code> nature of <code>java.util.Collection</code>.
    *
    * @tparam E the type of the element in the <code>java.util.Collection</code>
    * @tparam JCOL any subtype of <code>java.util.Collection</code>
    * @return <code>Collecting[E, JCOL[E]]</code> that supports <code>java.util.Collection</code> in <code>loneElement</code> syntax
    */
+  // SKIP-DOTTY-START 
   implicit def collectingNatureOfJavaCollection[E, JCOL[e] <: java.util.Collection[e]]: Collecting[E, JCOL[E]] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def collectingNatureOfJavaCollection[E, JCOL[e] <: java.util.Collection[e]]: Collecting[E, JCOL[E]] = 
     new Collecting[E, JCOL[E]] {
       def loneElementOf(coll: JCOL[E]): Option[E] = {
         if (coll.size == 1) Some(coll.iterator.next) else None
@@ -156,17 +201,31 @@ object Collecting {
         }
       }
     }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Collecting</code> nature of <code>java.util.Collection</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>java.util.Collection</code>
+  //DOTTY-ONLY   * @tparam JCOL any subtype of <code>java.util.Collection</code>
+  //DOTTY-ONLY   * @return <code>Collecting[E, JCOL[E]]</code> that supports <code>java.util.Collection</code> in <code>loneElement</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E, JCOL[e] <: java.util.Collection[e]]: Collecting[E, JCOL[E]] = collectingNatureOfJavaCollection
 
   // Wrap the extracted entry in an org.scalatest.Entry so people can call key and value methods instead of getKey and getValue
   /**
+   // SKIP-DOTTY-START 
    * Implicit to support <code>Collecting</code> nature of <code>java.util.Map</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY   * To support <code>Collecting</code> nature of <code>java.util.Map</code>.
    *
    * @tparam K the type of the key in the <code>java.util.Map</code>
    * @tparam V the type of the value in the <code>java.util.Map</code>
    * @tparam JMAP any subtype of <code>java.util.Map</code>
    * @return <code>Collecting[org.scalatest.Entry[K, V], JMAP[K, V]]</code> that supports <code>java.util.Map</code> in <code>loneElement</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def collectingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]]: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def collectingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]]: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]] = 
     new Collecting[org.scalatest.Entry[K, V], JMAP[K, V]] {
       def loneElementOf(jmap: JMAP[K, V]): Option[org.scalatest.Entry[K, V]] = {
         if (jmap.size == 1) {
@@ -183,20 +242,43 @@ object Collecting {
         collection.entrySet.iterator.asScala.map(entry => org.scalatest.Entry(entry.getKey, entry.getValue)).toList
       }
     }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Collecting</code> nature of <code>java.util.Map</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam JMAP any subtype of <code>java.util.Map</code>
+  //DOTTY-ONLY   * @return <code>Collecting[org.scalatest.Entry[K, V], JMAP[K, V]]</code> that supports <code>java.util.Map</code> in <code>loneElement</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [K, V, JMAP[k, v] <: java.util.Map[k, v]]: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]] = collectingNatureOfJavaMap  
 
   /**
+   // SKIP-DOTTY-START
    * Implicit to support <code>Collecting</code> nature of <code>Every</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY   * To support <code>Collecting</code> nature of <code>Every</code>.
    *
    * @tparam E the type of the element in the <code>Every</code>
    * @tparam EVERY any subtype of <code>Every</code>
    * @return <code>Collecting[EVERY[E]]</code> that supports <code>Every</code> in <code>loneElement</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def collectingNatureOfEvery[E, EVERY[e] <: Every[e]]: Collecting[E, EVERY[E]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def collectingNatureOfEvery[E, EVERY[e] <: Every[e]]: Collecting[E, EVERY[E]] =
     new Collecting[E, EVERY[E]] {
       def loneElementOf(every: EVERY[E]): Option[E] =
         if (every.size == 1) Some(every.head) else None
       def sizeOf(every: EVERY[E]): Int = every.size
       def iterableFrom(collection: EVERY[E]): Iterable[E] = collection.toVector
     }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Collecting</code> nature of <code>Every</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>Every</code>
+  //DOTTY-ONLY   * @tparam EVERY any subtype of <code>Every</code>
+  //DOTTY-ONLY   * @return <code>Collecting[EVERY[E]]</code> that supports <code>Every</code> in <code>loneElement</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E, EVERY[e] <: Every[e]]: Collecting[E, EVERY[E]] = collectingNatureOfEvery
 
 }

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Containing.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Containing.scala
@@ -277,7 +277,7 @@ trait JavaContainingImplicits extends ContainingImpls {
   // SKIP-DOTTY-START  
   implicit def containingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]](implicit equality: Equality[java.util.Map.Entry[K, V]]): Containing[JMAP[K, V]] =
   // SKIP-DOTTY-END
-  //DOTTY-ONLY def containingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]](implicit equality: Equality[java.util.Map.Entry[K, V]]): Containing[JMAP[K, V]] =
+  //DOTTY-ONLY def containingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]](using equality: Equality[java.util.Map.Entry[K, V]]): Containing[JMAP[K, V]] =
     convertEqualityToJavaMapContaining(equality)
 
   /**
@@ -383,7 +383,7 @@ trait ContainingStandardImplicits extends JavaContainingImplicits {
   // SKIP-DOTTY-START
   implicit def containingNatureOfIterable[E, ITR[e] <: Iterable[e]](implicit equality: Equality[E]): Containing[ITR[E]] =
   // SKIP-DOTTY-END
-  //DOTTY-ONLY def containingNatureOfIterable[E, ITR[e] <: Iterable[e]](implicit equality: Equality[E]): Containing[ITR[E]] =
+  //DOTTY-ONLY def containingNatureOfIterable[E, ITR[e] <: Iterable[e]](using equality: Equality[E]): Containing[ITR[E]] =
     convertEqualityToIterableContaining(equality)
 
   /**
@@ -475,7 +475,7 @@ trait ContainingStandardImplicits extends JavaContainingImplicits {
   // SKIP-DOTTY-START
   implicit def containingNatureOfOption[E, OPT[e] <: Option[e]](implicit equality: Equality[E]): Containing[OPT[E]] =
   // SKIP-DOTTY-END
-  //DOTTY-ONLY def containingNatureOfOption[E, OPT[e] <: Option[e]](implicit equality: Equality[E]): Containing[OPT[E]] =
+  //DOTTY-ONLY def containingNatureOfOption[E, OPT[e] <: Option[e]](using equality: Equality[E]): Containing[OPT[E]] =
     convertEqualityToOptionContaining(equality)
 
   /**
@@ -560,7 +560,7 @@ trait ContainingStandardImplicits extends JavaContainingImplicits {
   // SKIP-DOTTY-START
   implicit def containingNatureOfArray[E](implicit equality: Equality[E]): Containing[Array[E]] =
   // SKIP-DOTTY-END
-  //DOTTY-ONLY def containingNatureOfArray[E](implicit equality: Equality[E]): Containing[Array[E]] =
+  //DOTTY-ONLY def containingNatureOfArray[E](using equality: Equality[E]): Containing[Array[E]] =
     convertEqualityToArrayContaining(equality)
 
   /**
@@ -640,7 +640,7 @@ trait ContainingStandardImplicits extends JavaContainingImplicits {
   // SKIP-DOTTY-START
   implicit def containingNatureOfString(implicit equality: Equality[Char]): Containing[String] =
   // SKIP-DOTTY-END
-  //DOTTY-ONLY def containingNatureOfString(implicit equality: Equality[Char]): Containing[String] =
+  //DOTTY-ONLY def containingNatureOfString(using equality: Equality[Char]): Containing[String] =
     convertEqualityToStringContaining(equality)
 
   /**
@@ -720,7 +720,7 @@ trait ContainingStandardImplicits extends JavaContainingImplicits {
   // SKIP-DOTTY-START
   implicit def containingNatureOfEvery[E](implicit equality: Equality[E]): Containing[Every[E]] =
   // SKIP-DOTTY-END
-  //DOTTY-ONLY def containingNatureOfEvery[E](implicit equality: Equality[E]): Containing[Every[E]] =
+  //DOTTY-ONLY def containingNatureOfEvery[E](using equality: Equality[E]): Containing[Every[E]] =
     convertEqualityToEveryContaining(equality)
 
   /**
@@ -811,7 +811,7 @@ trait ContainingHighPriorityImplicits extends ContainingStandardImplicits {
   // SKIP-DOTTY-START
   implicit def containingNatureOfMap[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](implicit equality: Equality[(K, V)]): Containing[MAP[K, V]] =
   // SKIP-DOTTY-END
-  //DOTTY-ONLY def containingNatureOfMap[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](implicit equality: Equality[(K, V)]): Containing[MAP[K, V]] =
+  //DOTTY-ONLY def containingNatureOfMap[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](using equality: Equality[(K, V)]): Containing[MAP[K, V]] =
     convertEqualityToMapContaining(equality)
 
   /**

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Containing.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Containing.scala
@@ -166,14 +166,48 @@ trait ContainingImpls {
 trait JavaContainingImplicits extends ContainingImpls {
 
   /**
+    // SKIP-DOTTY-START
     * Implicit to support <code>Containing</code> nature of <code>java.util.Collection</code>.
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY   * To support <code>Containing</code> nature of <code>java.util.Collection</code>.
     *
     * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>java.util.Collection</code>
     * @tparam E the type of the element in the <code>java.util.Collection</code>
     * @tparam JCOL any subtype of <code>java.util.Collection</code>
     * @return <code>Containing[JCOL[E]]</code> that supports <code>java.util.Collection</code> in relevant <code>contain</code> syntax
     */
+  // SKIP-DOTTY-START
   implicit def containingNatureOfJavaCollection[E, JCOL[e] <: java.util.Collection[e]](implicit equality: Equality[E]): Containing[JCOL[E]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def containingNatureOfJavaCollection[E, JCOL[e] <: java.util.Collection[e]](using equality: Equality[E]): Containing[JCOL[E]] =
+    convertEqualityToJavaCollectionContaining(equality)
+  
+  /**
+    // SKIP-DOTTY-START
+    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY   * converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+    * into <code>Containing</code> of type <code>JCOL[E]</code>, where <code>JCOL</code> is a subtype of <code>java.util.Collection</code>.
+    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+    *
+    * <pre class="stHighlight">
+    * val javaList = new java.util.ArrayList[String]()
+    * javaList.add("hi")
+    * (javaList should contain oneOf ("HI")) (after being lowerCased)
+    * </pre>
+    *
+    * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+    * and this implicit conversion will convert it into <code>Containing[java.util.ArrayList[String]]</code>.
+    *
+    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+    * @tparam E type of elements in the <code>java.util.Collection</code>
+    * @tparam JCOL subtype of <code>java.util.Collection</code>
+    * @return <code>Containing</code> of type <code>JCOL[E]</code>
+    */
+  // SKIP-DOTTY-START  
+  implicit def convertEqualityToJavaCollectionContaining[E, JCOL[e] <: java.util.Collection[e]](equality: Equality[E]): Containing[JCOL[E]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToJavaCollectionContaining[E, JCOL[e] <: java.util.Collection[e]](equality: Equality[E]): Containing[JCOL[E]] =
     new Containing[JCOL[E]] {
       def contains(javaColl: JCOL[E], ele: Any): Boolean = {
         val it: java.util.Iterator[E] = javaColl.iterator
@@ -195,30 +229,44 @@ trait JavaContainingImplicits extends ContainingImpls {
       }
     }
 
-  /**
-    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
-    * into <code>Containing</code> of type <code>JCOL[E]</code>, where <code>JCOL</code> is a subtype of <code>java.util.Collection</code>.
-    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
-    *
-    * <pre class="stHighlight">
-    * val javaList = new java.util.ArrayList[String]()
-    * javaList.add("hi")
-    * (javaList should contain oneOf ("HI")) (after being lowerCased)
-    * </pre>
-    *
-    * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
-    * and this implicit conversion will convert it into <code>Containing[java.util.ArrayList[String]]</code>.
-    *
-    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
-    * @tparam E type of elements in the <code>java.util.Collection</code>
-    * @tparam JCOL subtype of <code>java.util.Collection</code>
-    * @return <code>Containing</code> of type <code>JCOL[E]</code>
-    */
-  implicit def convertEqualityToJavaCollectionContaining[E, JCOL[e] <: java.util.Collection[e]](equality: Equality[E]): Containing[JCOL[E]] =
-    containingNatureOfJavaCollection(equality)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Containing</code> nature of <code>java.util.Collection</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>java.util.Collection</code>
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>java.util.Collection</code>
+  //DOTTY-ONLY   * @tparam JCOL any subtype of <code>java.util.Collection</code>
+  //DOTTY-ONLY   * @return <code>Containing[JCOL[E]]</code> that supports <code>java.util.Collection</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E, JCOL[e] <: java.util.Collection[e]] (using equality: Equality[E]): Containing[JCOL[E]] = convertEqualityToJavaCollectionContaining(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * into <code>Containing</code> of type <code>E</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * val javaList = new java.util.ArrayList[String]()
+  //DOTTY-ONLY   * javaList.add("hi")
+  //DOTTY-ONLY   * (javaList should contain oneOf ("HI")) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Containing[java.util.ArrayList[String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * @tparam E type of elements in the <code>java.util.Collection</code>
+  //DOTTY-ONLY   * @tparam JCOL subtype of <code>java.util.Collection</code>
+  //DOTTY-ONLY   * @return <code>Containing</code> of type <code>JCOL[E]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityJavaCollectionContaining[E, JCOL[e] <: java.util.Collection[e]]: Conversion[Equality[E], Containing[JCOL[E]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[E]): Containing[JCOL[E]] = convertEqualityToJavaCollectionContaining(equality)
+  //DOTTY-ONLY }  
 
   /**
+    // SKIP-DOTTY-START
     * Implicit to support <code>Containing</code> nature of <code>java.util.Map</code>.
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY   * To support <code>Containing</code> nature of <code>java.util.Map</code>.
     *
     * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of entry in the <code>java.util.Map</code>
     * @tparam K the type of the key in the <code>java.util.Map</code>
@@ -226,24 +274,17 @@ trait JavaContainingImplicits extends ContainingImpls {
     * @tparam JMAP any subtype of <code>java.util.Map</code>
     * @return <code>Containing[JMAP[K, V]]</code> that supports <code>java.util.Map</code> in relevant <code>contain</code> syntax
     */
+  // SKIP-DOTTY-START  
   implicit def containingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]](implicit equality: Equality[java.util.Map.Entry[K, V]]): Containing[JMAP[K, V]] =
-    new Containing[JMAP[K, V]] {
-      import scala.collection.JavaConverters._
-      def contains(map: JMAP[K, V], ele: Any): Boolean = {
-        map.entrySet.asScala.exists((e: java.util.Map.Entry[K, V]) => equality.areEqual(e, ele))
-      }
-      def containsOneOf(map: JMAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
-        val foundSet = checkOneOf[java.util.Map.Entry[K, V]](map.entrySet.asScala, elements, equality)
-        foundSet.size == 1
-      }
-      def containsNoneOf(map: JMAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
-        val found = checkNoneOf[java.util.Map.Entry[K, V]](map.entrySet.asScala, elements, equality)
-        !found.isDefined
-      }
-    }
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def containingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]](implicit equality: Equality[java.util.Map.Entry[K, V]]): Containing[JMAP[K, V]] =
+    convertEqualityToJavaMapContaining(equality)
 
   /**
+    // SKIP-DOTTY-START
     * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY   * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
     * into <code>Containing</code> of type <code>JMAP[K, V]</code>, where <code>JMAP</code> is a subtype of <code>java.util.Map</code>.
     * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
     *
@@ -263,25 +304,112 @@ trait JavaContainingImplicits extends ContainingImpls {
     * @tparam JMAP any subtype of <code>java.util.Map</code>
     * @return <code>Containing</code> of type <code>JMAP[K, V]</code>
     */
+  // SKIP-DOTTY-START
   implicit def convertEqualityToJavaMapContaining[K, V, JMAP[k, v] <: java.util.Map[k, v]](equality: Equality[java.util.Map.Entry[K, V]]): Containing[JMAP[K, V]] =
-    containingNatureOfJavaMap(equality)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToJavaMapContaining[K, V, JMAP[k, v] <: java.util.Map[k, v]](equality: Equality[java.util.Map.Entry[K, V]]): Containing[JMAP[K, V]] =
+    new Containing[JMAP[K, V]] {
+      import scala.collection.JavaConverters._
+      def contains(map: JMAP[K, V], ele: Any): Boolean = {
+        map.entrySet.asScala.exists((e: java.util.Map.Entry[K, V]) => equality.areEqual(e, ele))
+      }
+      def containsOneOf(map: JMAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
+        val foundSet = checkOneOf[java.util.Map.Entry[K, V]](map.entrySet.asScala, elements, equality)
+        foundSet.size == 1
+      }
+      def containsNoneOf(map: JMAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
+        val found = checkNoneOf[java.util.Map.Entry[K, V]](map.entrySet.asScala, elements, equality)
+        !found.isDefined
+      }
+    }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Containing</code> nature of <code>java.util.Map</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam JMAP any subtype of <code>java.util.Map</code>
+  //DOTTY-ONLY   * @return <code>Containing</code> of type <code>JMAP[K, V]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [K, V, JMAP[k, v] <: java.util.Map[k, v]] (using equality: Equality[java.util.Map.Entry[K, V]]): Containing[JMAP[K, V]] = convertEqualityToJavaMapContaining(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
+  //DOTTY-ONLY   * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
+  //DOTTY-ONLY   * into <code>Containing</code> of type <code>JMAP[K, V]</code>, where <code>JMAP</code> is a subtype of <code>java.util.Map</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * val javaMap = new java.util.HashMap[Int, String]()
+  //DOTTY-ONLY   * javaMap.put(1, "one")
+  //DOTTY-ONLY   * // lowerCased needs to be implemented as Normalization[java.util.Map.Entry[K, V]]
+  //DOTTY-ONLY   * (javaMap should contain (Entry(1, "ONE"))) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>java.util.Map.Entry[Int, String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Containing[java.util.HashMap[Int, String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam JMAP any subtype of <code>java.util.Map</code>
+  //DOTTY-ONLY   * @return <code>Containing</code> of type <code>JMAP[K, V]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityJavaMapContaining[K, V, JMAP[k, v] <: java.util.Map[k, v]]: Conversion[Equality[java.util.Map.Entry[K, V]], Containing[JMAP[K, V]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[java.util.Map.Entry[K, V]]): Containing[JMAP[K, V]] = convertEqualityToJavaMapContaining(equality)
+  //DOTTY-ONLY }
 
 }
 
 trait ContainingStandardImplicits extends JavaContainingImplicits {
 
   import scala.language.higherKinds
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
+    // SKIP-DOTTY-START
     * Implicit to support <code>Containing</code> nature of <code>Iterable</code>.
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY   * To support <code>Containing</code> nature of <code>Iterable</code>.
     *
     * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>Iterable</code>
     * @tparam E the type of the element in the <code>Iterable</code>
     * @tparam ITR any subtype of <code>Iterable</code>
     * @return <code>Containing[TRAV[E]]</code> that supports <code>Iterable</code> in relevant <code>contain</code> syntax
     */
+  // SKIP-DOTTY-START
   implicit def containingNatureOfIterable[E, ITR[e] <: Iterable[e]](implicit equality: Equality[E]): Containing[ITR[E]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def containingNatureOfIterable[E, ITR[e] <: Iterable[e]](implicit equality: Equality[E]): Containing[ITR[E]] =
+    convertEqualityToIterableContaining(equality)
+
+  /**
+    // SKIP-DOTTY-START
+    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+    * into <code>Containing</code> of type <code>TRAV[E]</code>, where <code>TRAV</code> is a subtype of <code>Iterable</code>.
+    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+    *
+    * <pre class="stHighlight">
+    * (List("hi") should contain oneOf ("HI")) (after being lowerCased)
+    * </pre>
+    *
+    * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+    * and this implicit conversion will convert it into <code>Containing[List[String]]</code>.
+    *
+    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+    * @tparam E type of elements in the <code>Iterable</code>
+    * @tparam ITR subtype of <code>Iterable</code>
+    * @return <code>Containing</code> of type <code>ITR[E]</code>
+    */
+  // SKIP-DOTTY-START
+  implicit def convertEqualityToIterableContaining[E, ITR[e] <: Iterable[e]](equality: Equality[E]): Containing[ITR[E]] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToIterableContaining[E, ITR[e] <: Iterable[e]](equality: Equality[E]): Containing[ITR[E]] = 
     new Containing[ITR[E]] {
       def contains(itr: ITR[E], ele: Any): Boolean = {
         equality match {
@@ -301,52 +429,60 @@ trait ContainingStandardImplicits extends JavaContainingImplicits {
       }
     }
 
-  /**
-    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
-    * into <code>Containing</code> of type <code>TRAV[E]</code>, where <code>TRAV</code> is a subtype of <code>Iterable</code>.
-    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
-    *
-    * <pre class="stHighlight">
-    * (List("hi") should contain oneOf ("HI")) (after being lowerCased)
-    * </pre>
-    *
-    * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
-    * and this implicit conversion will convert it into <code>Containing[List[String]]</code>.
-    *
-    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
-    * @tparam E type of elements in the <code>Iterable</code>
-    * @tparam ITR subtype of <code>Iterable</code>
-    * @return <code>Containing</code> of type <code>ITR[E]</code>
-    */
-  implicit def convertEqualityToIterableContaining[E, ITR[e] <: Iterable[e]](equality: Equality[E]): Containing[ITR[E]] =
-    containingNatureOfIterable(equality)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Containing</code> nature of <code>Iterable</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>Iterable</code>
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>Iterable</code>
+  //DOTTY-ONLY   * @tparam ITR any subtype of <code>Iterable</code>
+  //DOTTY-ONLY   * @return <code>Containing[ITR[E]]</code> that supports <code>Iterable</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E, ITR[e] <: Iterable[e]] (using equality: Equality[E]): Containing[ITR[E]] = convertEqualityToIterableContaining(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * into <code>Containing</code> of type <code>TRAV[E]</code>, where <code>TRAV</code> is a subtype of <code>Iterable</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * (List("hi") should contain oneOf ("HI")) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Containing[List[String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * @tparam E type of elements in the <code>Iterable</code>
+  //DOTTY-ONLY   * @tparam ITR subtype of <code>Iterable</code>
+  //DOTTY-ONLY   * @return <code>Containing</code> of type <code>ITR[E]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityIterableContaining[E, ITR[e] <: Iterable[e]]: Conversion[Equality[E], Containing[ITR[E]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[E]): Containing[ITR[E]] = convertEqualityToIterableContaining(equality)
+  //DOTTY-ONLY }
 
   // OPT so that it will work with Some also, but it doesn't work with None
   /**
+    // SKIP-DOTTY-START
     * Implicit to support <code>Containing</code> nature of <code>scala.Option</code>.
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY * To support <code>Containing</code> nature of <code>scala.Option</code>.
     *
     * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>Option</code>
     * @tparam E the type of the element in the <code>scala.Option</code>
     * @tparam OPT any subtype of <code>scala.Option</code>
     * @return <code>Containing[OPT[E]]</code> that supports <code>scala.Option</code> in relevant <code>contain</code> syntax
     */
+  // SKIP-DOTTY-START
   implicit def containingNatureOfOption[E, OPT[e] <: Option[e]](implicit equality: Equality[E]): Containing[OPT[E]] =
-    new Containing[OPT[E]] {
-      def contains(opt: OPT[E], ele: Any): Boolean = {
-        opt.exists((e: E) => equality.areEqual(e, ele))
-      }
-      def containsOneOf(opt: OPT[E], elements: scala.collection.Seq[Any]): Boolean = {
-        val foundSet = checkOneOf[E](opt, elements, equality)
-        foundSet.size == 1
-      }
-      def containsNoneOf(opt: OPT[E], elements: scala.collection.Seq[Any]): Boolean = {
-        val found = checkNoneOf[E](opt, elements, equality)
-        !found.isDefined
-      }
-    }
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def containingNatureOfOption[E, OPT[e] <: Option[e]](implicit equality: Equality[E]): Containing[OPT[E]] =
+    convertEqualityToOptionContaining(equality)
 
   /**
+    // SKIP-DOTTY-START
     * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
     * into <code>Containing</code> of type <code>OPT[E]</code>, where <code>OPT</code> is a subtype of <code>scala.Option</code>.
     * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
     *
@@ -362,32 +498,76 @@ trait ContainingStandardImplicits extends JavaContainingImplicits {
     * @tparam OPT subtype of <code>scala.Option</code>
     * @return <code>Containing</code> of type <code>OPT[E]</code>
     */
+  // SKIP-DOTTY-START
   implicit def convertEqualityToOptionContaining[E, OPT[e] <: Option[e]](equality: Equality[E]): Containing[OPT[E]] =
-    containingNatureOfOption(equality)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToOptionContaining[E, OPT[e] <: Option[e]](equality: Equality[E]): Containing[OPT[E]] =
+    new Containing[OPT[E]] {
+      def contains(opt: OPT[E], ele: Any): Boolean = {
+        opt.exists((e: E) => equality.areEqual(e, ele))
+      }
+      def containsOneOf(opt: OPT[E], elements: scala.collection.Seq[Any]): Boolean = {
+        val foundSet = checkOneOf[E](opt, elements, equality)
+        foundSet.size == 1
+      }
+      def containsNoneOf(opt: OPT[E], elements: scala.collection.Seq[Any]): Boolean = {
+        val found = checkNoneOf[E](opt, elements, equality)
+        !found.isDefined
+      }
+    }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Containing</code> nature of <code>scala.Option</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>scala.Option</code>
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>scala.Option</code>
+  //DOTTY-ONLY   * @tparam OPT any subtype of <code>scala.Option</code>
+  //DOTTY-ONLY   * @return <code>Containing[OPT[E]]</code> that supports <code>scala.Option</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E, OPT[e] <: Option[e]] (using equality: Equality[E]): Containing[OPT[E]] = convertEqualityToOptionContaining(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * into <code>Containing</code> of type <code>OPT[E]</code>, where <code>OPT</code> is a subtype of <code>scala.Option</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * (Some("hi") should contain oneOf ("HI")) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Containing[Some[String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * @tparam E type of elements in the <code>scala.Option</code>
+  //DOTTY-ONLY   * @tparam OPT subtype of <code>scala.Option</code>
+  //DOTTY-ONLY   * @return <code>Containing</code> of type <code>OPT[E]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityOptionContaining[E, OPT[e] <: Option[e]]: Conversion[Equality[E], Containing[OPT[E]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[E]): Containing[OPT[E]] = convertEqualityToOptionContaining(equality)
+  //DOTTY-ONLY }
 
   /**
+    // SKIP-DOTTY-START
     * Implicit to support <code>Containing</code> nature of <code>Array</code>.
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY * To support <code>Containing</code> nature of <code>Array</code>.
     *
     * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>Array</code>
     * @tparam E the type of the element in the <code>Array</code>
     * @return <code>Containing[Array[E]]</code> that supports <code>Array</code> in relevant <code>contain</code> syntax
     */
+  // SKIP-DOTTY-START
   implicit def containingNatureOfArray[E](implicit equality: Equality[E]): Containing[Array[E]] =
-    new Containing[Array[E]] {
-      def contains(arr: Array[E], ele: Any): Boolean =
-        arr.exists((e: E) => equality.areEqual(e, ele))
-      def containsOneOf(arr: Array[E], elements: scala.collection.Seq[Any]): Boolean = {
-        val foundSet = checkOneOf[E](arr, elements, equality)
-        foundSet.size == 1
-      }
-      def containsNoneOf(arr: Array[E], elements: scala.collection.Seq[Any]): Boolean = {
-        val found = checkNoneOf[E](arr, elements, equality)
-        !found.isDefined
-      }
-    }
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def containingNatureOfArray[E](implicit equality: Equality[E]): Containing[Array[E]] =
+    convertEqualityToArrayContaining(equality)
 
   /**
+    // SKIP-DOTTY-START
     * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
     * into <code>Containing</code> of type <code>Array[E]</code>.
     * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
     *
@@ -402,31 +582,72 @@ trait ContainingStandardImplicits extends JavaContainingImplicits {
     * @tparam E type of elements in the <code>Array</code>
     * @return <code>Containing</code> of type <code>Array[E]</code>
     */
+  // SKIP-DOTTY-START
   implicit def convertEqualityToArrayContaining[E](equality: Equality[E]): Containing[Array[E]] =
-    containingNatureOfArray(equality)
-
-  /**
-    * Implicit to support <code>Containing</code> nature of <code>String</code>.
-    *
-    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of <code>Char</code> in the <code>String</code>
-    * @return <code>Containing[String]</code> that supports <code>String</code> in relevant <code>contain</code> syntax
-    */
-  implicit def containingNatureOfString(implicit equality: Equality[Char]): Containing[String] =
-    new Containing[String] {
-      def contains(str: String, ele: Any): Boolean =
-        str.exists((e: Char) => equality.areEqual(e, ele))
-      def containsOneOf(str: String, elements: scala.collection.Seq[Any]): Boolean = {
-        val foundSet = checkOneOf[Char](str, elements, equality)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToArrayContaining[E](equality: Equality[E]): Containing[Array[E]] =
+    new Containing[Array[E]] {
+      def contains(arr: Array[E], ele: Any): Boolean =
+        arr.exists((e: E) => equality.areEqual(e, ele))
+      def containsOneOf(arr: Array[E], elements: scala.collection.Seq[Any]): Boolean = {
+        val foundSet = checkOneOf[E](arr, elements, equality)
         foundSet.size == 1
       }
-      def containsNoneOf(str: String, elements: scala.collection.Seq[Any]): Boolean = {
-        val found = checkNoneOf[Char](str, elements, equality)
+      def containsNoneOf(arr: Array[E], elements: scala.collection.Seq[Any]): Boolean = {
+        val found = checkNoneOf[E](arr, elements, equality)
         !found.isDefined
       }
     }
 
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Containing</code> nature of <code>Array</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * @tparam E type of elements in the <code>Array</code>
+  //DOTTY-ONLY   * @return <code>Containing</code> of type <code>Array[E]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E] (using equality: Equality[E]): Containing[Array[E]] = convertEqualityToArrayContaining(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * into <code>Containing</code> of type <code>Array[E]</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * (Array("hi") should contain oneOf ("HI")) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Containing[Array[String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * @tparam E type of elements in the <code>Array</code>
+  //DOTTY-ONLY   * @return <code>Containing</code> of type <code>Array[E]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityArrayContaining[E]: Conversion[Equality[E], Containing[Array[E]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[E]): Containing[Array[E]] = convertEqualityToArrayContaining(equality)
+  //DOTTY-ONLY }
+
   /**
+    // SKIP-DOTTY-START
+    * Implicit to support <code>Containing</code> nature of <code>String</code>.
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY * To support <code>Containing</code> nature of <code>String</code>.
+    *
+    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of <code>Char</code> in the <code>String</code>
+    * @return <code>Containing[String]</code> that supports <code>String</code> in relevant <code>contain</code> syntax
+    */
+  // SKIP-DOTTY-START
+  implicit def containingNatureOfString(implicit equality: Equality[Char]): Containing[String] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def containingNatureOfString(implicit equality: Equality[Char]): Containing[String] =
+    convertEqualityToStringContaining(equality)
+
+  /**
+    // SKIP-DOTTY-START
     * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Char</code>
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Char</code>
     * into <code>Containing</code> of type <code>String</code>.
     * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
     *
@@ -441,17 +662,90 @@ trait ContainingStandardImplicits extends JavaContainingImplicits {
     * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Char</code>
     * @return <code>Containing</code> of type <code>String</code>
     */
+  // SKIP-DOTTY-START
   implicit def convertEqualityToStringContaining(equality: Equality[Char]): Containing[String] =
-    containingNatureOfString(equality)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToStringContaining(equality: Equality[Char]): Containing[String] =
+    new Containing[String] {
+      def contains(str: String, ele: Any): Boolean =
+        str.exists((e: Char) => equality.areEqual(e, ele))
+      def containsOneOf(str: String, elements: scala.collection.Seq[Any]): Boolean = {
+        val foundSet = checkOneOf[Char](str, elements, equality)
+        foundSet.size == 1
+      }
+      def containsNoneOf(str: String, elements: scala.collection.Seq[Any]): Boolean = {
+        val found = checkNoneOf[Char](str, elements, equality)
+        !found.isDefined
+      }
+    }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given to support <code>Containing</code> nature of <code>String</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of <code>Char</code> in the <code>String</code>
+  //DOTTY-ONLY   * @return <code>Containing[String]</code> that supports <code>String</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given (using equality: Equality[Char]): Containing[String] = convertEqualityToStringContaining(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Char</code>
+  //DOTTY-ONLY   * into <code>Containing</code> of type <code>String</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * // lowerCased needs to be implemented as Normalization[Char]
+  //DOTTY-ONLY   * ("hi hello" should contain oneOf ('E')) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[Char]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Containing[String]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Char</code>
+  //DOTTY-ONLY   * @return <code>Containing</code> of type <code>String</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityStringContaining: Conversion[Equality[Char], Containing[String]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[Char]): Containing[String] = convertEqualityToStringContaining(equality)
+  //DOTTY-ONLY }  
 
   /**
+    // SKIP-DOTTY-START
     * Implicit to support <code>Containing</code> nature of <code>Every</code>.
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY * To support <code>Containing</code> nature of <code>Every</code>.
     *
     * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>Every</code>
     * @tparam E the type of the element in the <code>Every</code>
     * @return <code>Containing[Every[E]]</code> that supports <code>Every</code> in relevant <code>contain</code> syntax
     */
+  // SKIP-DOTTY-START
   implicit def containingNatureOfEvery[E](implicit equality: Equality[E]): Containing[Every[E]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def containingNatureOfEvery[E](implicit equality: Equality[E]): Containing[Every[E]] =
+    convertEqualityToEveryContaining(equality)
+
+  /**
+    // SKIP-DOTTY-START
+    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+    * into <code>Containing</code> of type <code>Every[E]</code>.
+    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+    *
+    * <pre class="stHighlight">
+    * (Every("hi", "he", "ho") should contain oneOf ("HI")) (after being lowerCased)
+    * </pre>
+    *
+    * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+    * and this implicit conversion will convert it into <code>Containing[Every[String]]</code>.
+    *
+    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+    * @tparam E type of elements in the <code>Every</code>
+    * @return <code>Containing</code> of type <code>Every[E]</code>
+    */
+  // SKIP-DOTTY-START
+  implicit def convertEqualityToEveryContaining[E](equality: Equality[E]): Containing[Every[E]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToEveryContaining[E](equality: Equality[E]): Containing[Every[E]] =
     new Containing[Every[E]] {
       def contains(every: Every[E], ele: Any): Boolean =
         equality match {
@@ -470,30 +764,43 @@ trait ContainingStandardImplicits extends JavaContainingImplicits {
       }
     }
 
-  /**
-    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
-    * into <code>Containing</code> of type <code>Every[E]</code>.
-    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
-    *
-    * <pre class="stHighlight">
-    * (Every("hi", "he", "ho") should contain oneOf ("HI")) (after being lowerCased)
-    * </pre>
-    *
-    * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
-    * and this implicit conversion will convert it into <code>Containing[Every[String]]</code>.
-    *
-    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
-    * @tparam E type of elements in the <code>Every</code>
-    * @return <code>Containing</code> of type <code>Every[E]</code>
-    */
-  implicit def convertEqualityToEveryContaining[E](equality: Equality[E]): Containing[Every[E]] =
-    containingNatureOfEvery(equality)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Containing</code> nature of <code>Every</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>Every</code>
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>Every</code>
+  //DOTTY-ONLY   * @return <code>Containing[Every[E]]</code> that supports <code>Every</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E] (using equality: Equality[E]): Containing[Every[E]] = convertEqualityToEveryContaining(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * into <code>Containing</code> of type <code>Every[E]</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * (Every("hi", "he", "ho") should contain oneOf ("HI")) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Containing[Every[String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * @tparam E type of elements in the <code>Every</code>
+  //DOTTY-ONLY   * @return <code>Containing</code> of type <code>Every[E]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityEveryContaining[E]: Conversion[Equality[E], Containing[Every[E]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[E]): Containing[Every[E]] = convertEqualityToEveryContaining(equality)
+  //DOTTY-ONLY }  
 }
 
 trait ContainingHighPriorityImplicits extends ContainingStandardImplicits {
 
   /**
+    // SKIP-DOTTY-START
     * Implicit to support <code>Containing</code> nature of <code>scala.collection.GenMap</code>.
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY * To support <code>Containing</code> nature of <code>scala.collection.GenMap</code>.
     *
     * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of entry in the <code>scala.collection.GenMap</code>
     * @tparam K the type of the key in the <code>scala.collection.GenMap</code>
@@ -501,23 +808,17 @@ trait ContainingHighPriorityImplicits extends ContainingStandardImplicits {
     * @tparam MAP any subtype of <code>scala.collection.GenMap</code>
     * @return <code>Containing[MAP[K, V]]</code> that supports <code>scala.collection.GenMap</code> in relevant <code>contain</code> syntax
     */
+  // SKIP-DOTTY-START
   implicit def containingNatureOfMap[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](implicit equality: Equality[(K, V)]): Containing[MAP[K, V]] =
-    new Containing[MAP[K, V]] {
-      def contains(map: MAP[K, V], ele: Any): Boolean = {
-        map.exists((e: (K, V)) => equality.areEqual(e, ele))
-      }
-      def containsOneOf(map: MAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
-        val foundSet = checkOneOf[(K, V)](map, elements, equality)
-        foundSet.size == 1
-      }
-      def containsNoneOf(map: MAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
-        val found = checkNoneOf[(K, V)](map, elements, equality)
-        !found.isDefined
-      }
-    }
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def containingNatureOfMap[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](implicit equality: Equality[(K, V)]): Containing[MAP[K, V]] =
+    convertEqualityToMapContaining(equality)
 
   /**
+    // SKIP-DOTTY-START
     * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Tuple2[K, V]</code>
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Tuple2[K, V]</code>
     * into <code>Containing</code> of type <code>MAP[K, V]</code>, where <code>MAP</code> is a subtype of <code>scala.collection.GenMap</code>.
     * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
     *
@@ -536,8 +837,58 @@ trait ContainingHighPriorityImplicits extends ContainingStandardImplicits {
     * @tparam MAP any subtype of <code>scala.collection.GenMap</code>
     * @return <code>Containing</code> of type <code>MAP[K, V]</code>
     */
+  // SKIP-DOTTY-START
   implicit def convertEqualityToMapContaining[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](equality: Equality[(K, V)]): Containing[MAP[K, V]] =
-    containingNatureOfMap(equality)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToMapContaining[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](equality: Equality[(K, V)]): Containing[MAP[K, V]] =
+    new Containing[MAP[K, V]] {
+      def contains(map: MAP[K, V], ele: Any): Boolean = {
+        map.exists((e: (K, V)) => equality.areEqual(e, ele))
+      }
+      def containsOneOf(map: MAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
+        val foundSet = checkOneOf[(K, V)](map, elements, equality)
+        foundSet.size == 1
+      }
+      def containsNoneOf(map: MAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
+        val found = checkNoneOf[(K, V)](map, elements, equality)
+        !found.isDefined
+      }
+    }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Containing</code> nature of <code>scala.collection.GenMap</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of entry in the <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY   * @tparam MAP any subtype of <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY   * @return <code>Containing[MAP[K, V]]</code> that supports <code>scala.collection.GenMap</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [K, V, MAP[k, v] <: scala.collection.GenMap[k, v]] (using equality: Equality[(K, V)]): Containing[MAP[K, V]] = convertEqualityToMapContaining(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Tuple2[K, V]</code>
+  //DOTTY-ONLY   * into <code>Containing</code> of type <code>MAP[K, V]</code>, where <code>MAP</code> is a subtype of <code>scala.collection.GenMap</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * val map = Map(1 -> "one")
+  //DOTTY-ONLY   * // lowerCased needs to be implemented as Normalization[Tuple2[K, V]]
+  //DOTTY-ONLY   * (map should contain ((1, "ONE"))) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Tuple2[Int, String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Containing[scala.collection.GenMap[Int, String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Tuple2[K, V]</code>
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY   * @tparam MAP any subtype of <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY   * @return <code>Containing</code> of type <code>MAP[K, V]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityMapContaining[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]]: Conversion[Equality[(K, V)], Containing[MAP[K, V]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[(K, V)]): Containing[MAP[K, V]] = convertEqualityToMapContaining(equality)
+  //DOTTY-ONLY }
 
 }
 

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Definition.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Definition.scala
@@ -62,10 +62,22 @@ object Definition {
    * @tparam OPT any subtype of <code>Option</code>
    * @return <code>Definition[OPT[E]]</code> that supports <code>Option</code> in <code>be defined</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def definitionOfOption[E, OPT[e] <: scala.Option[e]]: Definition[OPT[E]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def definitionOfOption[E, OPT[e] <: scala.Option[e]]: Definition[OPT[E]] =
     new Definition[OPT[E]] {
       def isDefined(option: OPT[E]): Boolean = option.isDefined
     }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Definition</code> implementation for <code>scala.Option</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>Option</code>
+  //DOTTY-ONLY   * @tparam OPT any subtype of <code>Option</code>
+  //DOTTY-ONLY   * @return <code>Definition[OPT[E]]</code> that supports <code>Option</code> in <code>be defined</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E, OPT[e] <: scala.Option[e]]: Definition[OPT[E]] = definitionOfOption
 
   import scala.language.reflectiveCalls
   
@@ -75,10 +87,20 @@ object Definition {
    * @tparam T any type that has a <code>isDefined()</code> method that returns <code>Boolean</code>
    * @return <code>Definition[T]</code> that supports <code>T</code> in <code>be defined</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def definitionOfAnyRefWithIsDefinedMethod[T <: AnyRef { def isDefined(): Boolean}]: Definition[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def definitionOfAnyRefWithIsDefinedMethod[T <: AnyRef { def isDefined(): Boolean}]: Definition[T] = 
     new Definition[T] {
       def isDefined(obj: T): Boolean = obj.isDefined()
     }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Definition</code> implementation for any arbitrary object with a <code>isDefined()</code> method that returns <code>Boolean</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @return <code>Definition[T]</code> that supports <code>T</code> in <code>be defined</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given Definition[AnyRef { def isDefined(): Boolean}] = definitionOfAnyRefWithIsDefinedMethod
 
   /**
    * Provides <code>Definition</code> implementation for any arbitrary object with a <code>isDefined</code> method that returns <code>Boolean</code>
@@ -86,9 +108,20 @@ object Definition {
    * @tparam T any type that has a parameterless <code>isDefined</code> method that returns <code>Boolean</code>
    * @return <code>Definition[T]</code> that supports <code>T</code> in <code>be defined</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def definitionOfAnyRefWithParameterlessIsDefinedMethod[T <: AnyRef { def isDefined: Boolean}]: Definition[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def definitionOfAnyRefWithParameterlessIsDefinedMethod[T <: AnyRef { def isDefined: Boolean}]: Definition[T] = 
     new Definition[T] {
       def isDefined(obj: T): Boolean = obj.isDefined
     }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Definition</code> implementation for any arbitrary object with a <code>isDefined</code> method that returns <code>Boolean</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @tparam T any type that has a parameterless <code>isDefined</code> method that returns <code>Boolean</code>
+  //DOTTY-ONLY   * @return <code>Definition[T]</code> that supports <code>T</code> in <code>be defined</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [T <: AnyRef { def isDefined: Boolean}]: Definition[T] = definitionOfAnyRefWithParameterlessIsDefinedMethod
 }
 

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Emptiness.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Emptiness.scala
@@ -74,10 +74,22 @@ object Emptiness {
    * @tparam ITR any subtype of <code>org.scalactic.ColCompatHelper.Iterable</code>
    * @return <code>Emptiness[ITR[E]]</code> that supports <code>org.scalactic.ColCompatHelper.Iterable</code> in <code>be empty</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def emptinessOfIterable[E, ITR[e] <: Iterable[e]]: Emptiness[ITR[E]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def emptinessOfIterable[E, ITR[e] <: Iterable[e]]: Emptiness[ITR[E]] =
     new Emptiness[ITR[E]] {
       def isEmpty(itr: ITR[E]): Boolean = itr.isEmpty
     }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Emptiness</code> implementation for <code>org.scalactic.ColCompatHelper.Iterable</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>org.scalactic.ColCompatHelper.Iterable</code>
+  //DOTTY-ONLY   * @tparam ITR any subtype of <code>org.scalactic.ColCompatHelper.Iterable</code>
+  //DOTTY-ONLY   * @return <code>Emptiness[ITR[E]]</code> that supports <code>org.scalactic.ColCompatHelper.Iterable</code> in <code>be empty</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E, ITR[e] <: Iterable[e]]: Emptiness[ITR[E]] = emptinessOfIterable
   
   /**
    * Enable <code>Emptiness</code> implementation for <code>Array</code>
@@ -85,20 +97,41 @@ object Emptiness {
    * @tparam E the type of the element in the <code>Array</code>
    * @return <code>Emptiness[Array[E]]</code> that supports <code>Array</code> in <code>be empty</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def emptinessOfArray[E]: Emptiness[Array[E]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def emptinessOfArray[E]: Emptiness[Array[E]] =
     new Emptiness[Array[E]] {
       def isEmpty(arr: Array[E]): Boolean = arr.length == 0
     }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Emptiness</code> implementation for <code>Array</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>Array</code>
+  //DOTTY-ONLY   * @return <code>Emptiness[Array[E]]</code> that supports <code>Array</code> in <code>be empty</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E]: Emptiness[Array[E]] = emptinessOfArray
   
   /**
    * Enable <code>Emptiness</code> implementation for <code>String</code>
    *
    * @return <code>Emptiness[String]</code> that supports <code>String</code> in <code>be empty</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def emptinessOfString: Emptiness[String] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def emptinessOfString: Emptiness[String] = 
     new Emptiness[String] {
       def isEmpty(str: String): Boolean = str.isEmpty
     }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Emptiness</code> implementation for <code>String</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @return <code>Emptiness[String]</code> that supports <code>String</code> in <code>be empty</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given Emptiness[String] = emptinessOfString
   
   /**
    * Enable <code>Emptiness</code> implementation for <code>scala.Option</code>
@@ -107,10 +140,22 @@ object Emptiness {
    * @tparam OPT any subtype of <code>scala.Option</code>
    * @return <code>Emptiness[OPT[E]]</code> that supports <code>scala.Option</code> in <code>be empty</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def emptinessOfOption[E, OPT[e] <: Option[e]]: Emptiness[OPT[E]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def emptinessOfOption[E, OPT[e] <: Option[e]]: Emptiness[OPT[E]] =
     new Emptiness[OPT[E]] {
       def isEmpty(opt: OPT[E]): Boolean = opt.isEmpty
     }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Emptiness</code> implementation for <code>scala.Option</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>scala.Option</code>
+  //DOTTY-ONLY   * @tparam OPT any subtype of <code>scala.Option</code>
+  //DOTTY-ONLY   * @return <code>Emptiness[OPT[E]]</code> that supports <code>scala.Option</code> in <code>be empty</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E, OPT[e] <: Option[e]]: Emptiness[OPT[E]] = emptinessOfOption
   
   /**
    * Enable <code>Emptiness</code> implementation for <code>java.util.Collection</code>
@@ -119,10 +164,22 @@ object Emptiness {
    * @tparam JCOL any subtype of <code>java.util.Collection</code>
    * @return <code>Emptiness[JCOL[E]]</code> that supports <code>java.util.Collection</code> in <code>be empty</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def emptinessOfJavaCollection[E, JCOL[e] <: java.util.Collection[e]]: Emptiness[JCOL[E]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def emptinessOfJavaCollection[E, JCOL[e] <: java.util.Collection[e]]: Emptiness[JCOL[E]] =
     new Emptiness[JCOL[E]] {
       def isEmpty(jcol: JCOL[E]): Boolean = jcol.isEmpty
     }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Emptiness</code> implementation for <code>java.util.Collection</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>java.util.Collection</code>
+  //DOTTY-ONLY   * @tparam JCOL any subtype of <code>java.util.Collection</code>
+  //DOTTY-ONLY   * @return <code>Emptiness[JCOL[E]]</code> that supports <code>java.util.Collection</code> in <code>be empty</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E, JCOL[e] <: java.util.Collection[e]]: Emptiness[JCOL[E]] = emptinessOfJavaCollection
 
   /**
    * Enable <code>Emptiness</code> implementation for <code>java.util.Map</code>
@@ -132,10 +189,23 @@ object Emptiness {
    * @tparam JMAP any subtype of <code>java.util.Map</code>
    * @return <code>Emptiness[JMAP[K, V]]</code> that supports <code>java.util.Map</code> in <code>be empty</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def emptinessOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]]: Emptiness[JMAP[K, V]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def emptinessOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]]: Emptiness[JMAP[K, V]] =
     new Emptiness[JMAP[K, V]] {
       def isEmpty(jmap: JMAP[K, V]): Boolean = jmap.isEmpty
     }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Emptiness</code> implementation for <code>java.util.Map</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam JMAP any subtype of <code>java.util.Map</code>
+  //DOTTY-ONLY   * @return <code>Emptiness[JMAP[K, V]]</code> that supports <code>java.util.Map</code> in <code>be empty</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [K, V, JMAP[k, v] <: java.util.Map[k, v]]: Emptiness[JMAP[K, V]] = emptinessOfJavaMap
 
   import scala.language.reflectiveCalls
   
@@ -145,10 +215,21 @@ object Emptiness {
    * @tparam T any type that has a <code>isEmpty()</code> method that returns <code>Boolean</code>
    * @return <code>Emptiness[T]</code> that supports <code>T</code> in <code>be empty</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def emptinessOfAnyRefWithIsEmptyMethod[T <: AnyRef { def isEmpty(): Boolean}]: Emptiness[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def emptinessOfAnyRefWithIsEmptyMethod[T <: AnyRef { def isEmpty(): Boolean}]: Emptiness[T] = 
     new Emptiness[T] {
       def isEmpty(obj: T): Boolean = obj.isEmpty()
     }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Emptiness</code> implementation for any arbitrary object with a <code>isEmpty()</code> method that returns <code>Boolean</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @tparam T any type that has a <code>isEmpty()</code> method that returns <code>Boolean</code>
+  //DOTTY-ONLY   * @return <code>Emptiness[T]</code> that supports <code>T</code> in <code>be empty</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given Emptiness[AnyRef { def isEmpty(): Boolean}] = emptinessOfAnyRefWithIsEmptyMethod  
   
   /**
    * Enable <code>Emptiness</code> implementation for any arbitrary object with a <code>isEmpty</code> method that returns <code>Boolean</code>
@@ -156,9 +237,20 @@ object Emptiness {
    * @tparam T any type that has a parameterless <code>isEmpty</code> method that returns <code>Boolean</code>
    * @return <code>Emptiness[T]</code> that supports <code>T</code> in <code>be empty</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def emptinessOfAnyRefWithParameterlessIsEmptyMethod[T <: AnyRef { def isEmpty: Boolean}]: Emptiness[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def emptinessOfAnyRefWithParameterlessIsEmptyMethod[T <: AnyRef { def isEmpty: Boolean}]: Emptiness[T] = 
     new Emptiness[T] {
       def isEmpty(obj: T): Boolean = obj.isEmpty
     }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Emptiness</code> implementation for any arbitrary object with a <code>isEmpty</code> method that returns <code>Boolean</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @tparam T any type that has a <code>isEmpty()</code> method that returns <code>Boolean</code>
+  //DOTTY-ONLY   * @return <code>Emptiness[T]</code> that supports <code>T</code> in <code>be empty</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [T <: AnyRef { def isEmpty: Boolean}]: Emptiness[T] = emptinessOfAnyRefWithParameterlessIsEmptyMethod
 }
 

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Existence.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Existence.scala
@@ -52,9 +52,20 @@ object Existence {
    * @tparam FILE any subtype of <code>java.io.File</code>
    * @return <code>Existence[FILE]</code> that supports <code>java.io.File</code> in <code>exist</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def existenceOfFile[FILE <: java.io.File]: Existence[FILE] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def existenceOfFile[FILE <: java.io.File]: Existence[FILE] =
     new Existence[FILE] {
       def exists(file: FILE): Boolean = file.exists
     }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Emptiness</code> implementation for <code>java.io.File</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @tparam FILE any subtype of <code>java.io.File</code>
+  //DOTTY-ONLY   * @return <code>Existence[FILE]</code> that supports <code>java.io.File</code> in <code>exist</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [FILE <: java.io.File]: Existence[FILE] = existenceOfFile
   
 }

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Futuristic.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Futuristic.scala
@@ -57,26 +57,46 @@ object Futuristic {
 
   /**
    * Provides a <code>Futuristic</code> value for <code>FutureOutcome</code> that performs cleanup using the
+   // SKIP-DOTTY-START
    * implicitly provided execution context.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY provided execution context.
    *
    * @param executionContext an execution context that provides a strategy for executing the cleanup function
    * @return a <code>Futuristic</code> instance for <code>FutureOutcome</code>
    */
+  // SKIP-DOTTY-START
   implicit def futuristicNatureOfFutureOutcome(implicit executionContext: ExecutionContext): Futuristic[FutureOutcome] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def futuristicNatureOfFutureOutcome(using executionContext: ExecutionContext): Futuristic[FutureOutcome] =
     new Futuristic[FutureOutcome] {
       def withCleanup(futuristic: FutureOutcome)(cleanup: => Unit): FutureOutcome = {
         futuristic onCompletedThen { _ => cleanup }
       }
     }
 
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given <code>Futuristic</code> value for <code>FutureOutcome</code> that performs cleanup using the
+  //DOTTY-ONLY   * provided execution context.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param executionContext an execution context that provides a strategy for executing the cleanup function
+  //DOTTY-ONLY   * @return a <code>Futuristic</code> instance for <code>FutureOutcome</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given (using executionContext: ExecutionContext): Futuristic[FutureOutcome] = futuristicNatureOfFutureOutcome(using executionContext)
+
   /**
    * Provides a <code>Futuristic</code> value for <code>Future[V]</code> for any type <code>V</code> that performs cleanup using the
-   * implicitly provided execution context.
+   // SKIP-DOTTY-START
+   * provided execution context.
+   // SKIP-DOTTY-END
    *
    * @param executionContext an execution context that provides a strategy for executing the cleanup function
    * @return a <code>Futuristic</code> instance for <code>Future[V]</code>
    */
+  // SKIP-DOTTY-START
   implicit def futuristicNatureOfFutureOf[V](implicit executionContext: ExecutionContext): Futuristic[Future[V]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def futuristicNatureOfFutureOf[V](using executionContext: ExecutionContext): Futuristic[Future[V]] =
     new Futuristic[Future[V]] {
       def withCleanup(futuristic: Future[V])(cleanup: => Unit): Future[V] = {
         // First deal with Failure, and mimic finally semantics
@@ -100,5 +120,14 @@ object Futuristic {
         }
       }
     }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given <code>Futuristic</code> value for <code>Future[V]</code> for any type <code>V</code> that performs cleanup using the
+  //DOTTY-ONLY   * provided execution context.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param executionContext an execution context that provides a strategy for executing the cleanup function
+  //DOTTY-ONLY   * @return a <code>Futuristic</code> instance for <code>Future[V]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [V] (using executionContext: ExecutionContext): Futuristic[Future[V]] = futuristicNatureOfFutureOf(using executionContext)  
 }
 

--- a/jvm/core/src/main/scala/org/scalatest/enablers/InspectorAsserting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/InspectorAsserting.scala
@@ -80,10 +80,16 @@ trait InspectorAsserting[T] {
 abstract class UnitInspectorAsserting {
 
   /**
+   // SKIP-DOTTY-START
    * Provides an implicit <code>InspectorAsserting</code> instance for any type that did not match a
+   // SKIP-DOTTY-END
+   /DOTTY-ONLY * Provides <code>InspectorAsserting</code> instance for any type that did not match a
    * higher priority implicit provider, enabling inspector syntax that has result type <code>Unit</code>.
    */
+  // SKIP-DOTTY-START
   implicit def assertingNatureOfT[T]: InspectorAsserting[T] { type Result = Unit } =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def assertingNatureOfT[T]: InspectorAsserting[T] { type Result = Unit } =
     new InspectorAsserting.InspectorAssertingImpl[T] {
       type Result = Unit
       def indicateSuccess(message: => String): Unit = ()
@@ -106,6 +112,12 @@ abstract class UnitInspectorAsserting {
         )
       }
     }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given <code>InspectorAsserting</code> instance for any type that did not match a
+  //DOTTY-ONLY   * higher priority implicit provider, enabling inspector syntax that has result type <code>Unit</code>.
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [T]: InspectorAsserting[T] { type Result = Unit } = assertingNatureOfT[T]  
 }
 
 /**
@@ -114,7 +126,17 @@ abstract class UnitInspectorAsserting {
  */
 abstract class ExpectationInspectorAsserting extends UnitInspectorAsserting {
 
-  private[scalatest] implicit def assertingNatureOfExpectation(implicit prettifier: Prettifier): InspectorAsserting[Expectation] { type Result = Expectation } = {
+  /**
+   // SKIP-DOTTY-START
+   * Provides an implicit <code>InspectorAsserting</code> instance for type <code>Expectation</code>,
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * Provides <code>InspectorAsserting</code> instance for type <code>Expectation</code>,
+   * enabling inspector syntax that has result type <code>Expectation</code>.
+   */
+  // SKIP-DOTTY-START
+  implicit def assertingNatureOfExpectation(implicit prettifier: Prettifier): InspectorAsserting[Expectation] { type Result = Expectation } = {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def assertingNatureOfExpectation(using prettifier: Prettifier): InspectorAsserting[Expectation] { type Result = Expectation } = {
     new InspectorAsserting.InspectorAssertingImpl[Expectation] {
       type Result = Expectation
       def indicateSuccess(message: => String): Expectation = Fact.Yes(message, prettifier)
@@ -122,6 +144,12 @@ abstract class ExpectationInspectorAsserting extends UnitInspectorAsserting {
       def indicateFailure(message: => String, optionalCause: Option[Throwable], pos: source.Position, analysis: scala.collection.immutable.IndexedSeq[String]): Expectation = Fact.No(message, prettifier)
     }
   }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given <code>InspectorAsserting</code> instance for type <code>Expectation</code>,
+  //DOTTY-ONLY   * enabling inspector syntax that has result type <code>Expectation</code>.
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given (using prettifier: Prettifier): InspectorAsserting[Expectation] = assertingNatureOfExpectation
 }
 
 /**
@@ -360,10 +388,16 @@ object InspectorAsserting extends ExpectationInspectorAsserting {
   }
 
   /**
+   // SKIP-DOTTY-START
    * Provides an implicit <code>InspectorAsserting</code> instance for type <code>Assertion</code>,
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * Provides <code>InspectorAsserting</code> instance for type <code>Assertion</code>,
    * enabling inspector syntax that has result type <code>Assertion</code>.
    */
+  // SKIP-DOTTY-START
   implicit def assertingNatureOfAssertion: InspectorAsserting[Assertion] { type Result = Assertion } =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def assertingNatureOfAssertion: InspectorAsserting[Assertion] { type Result = Assertion } =
     new InspectorAssertingImpl[Assertion] {
       type Result = Assertion
       def indicateSuccess(message: => String): Assertion = Succeeded
@@ -387,6 +421,12 @@ object InspectorAsserting extends ExpectationInspectorAsserting {
       }
     }
 
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given <code>InspectorAsserting</code> instance for type <code>Assertion</code>, 
+  //DOTTY-ONLY   * enabling inspector syntax that has result type <code>Assertion</code>.
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given InspectorAsserting[Assertion] = assertingNatureOfAssertion
+
   /**
     * Abstract subclass of <code>InspectorAsserting</code> that provides the bulk of the implementations of <code>InspectorAsserting</code>
     * methods.
@@ -395,7 +435,10 @@ object InspectorAsserting extends ExpectationInspectorAsserting {
 
     type Result = Future[T]
 
+    // SKIP-DOTTY-START
     implicit def executionContext: ExecutionContext
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY given executionContext: ExecutionContext
 
     // Inherit Scaladoc for now. See later if can just make this implementation class private[scalatest].
     def forAll[E](xs: Iterable[E], original: Any, shorthand: Boolean, prettifier: Prettifier, pos: source.Position)(fun: E => Future[T]): Result = {
@@ -622,7 +665,17 @@ object InspectorAsserting extends ExpectationInspectorAsserting {
     private[scalatest] def indicateFailureFuture(message: => String, optionalCause: Option[Throwable], pos: source.Position): T
   }
 
+  /**
+   // SKIP-DOTTY-START
+   * Provides an implicit <code>InspectorAsserting</code> instance for type <code>Future[Assertion]</code>,
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * Provides <code>InspectorAsserting</code> instance for type <code>Future[Assertion]</code>,
+   * enabling inspector syntax that has result type <code>Future[Assertion]</code>.
+   */
+  // SKIP-DOTTY-START
   implicit def assertingNatureOfFutureAssertion(implicit execCtx: ExecutionContext): InspectorAsserting[Future[Assertion]] { type Result = Future[Assertion] } =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def assertingNatureOfFutureAssertion(using execCtx: ExecutionContext): InspectorAsserting[Future[Assertion]] { type Result = Future[Assertion] } =
     new FutureInspectorAssertingImpl[Assertion] {
       val executionContext = execCtx
       def indicateSuccessFuture(message: => String): Assertion = Succeeded
@@ -645,6 +698,12 @@ object InspectorAsserting extends ExpectationInspectorAsserting {
         }
       }
     }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given <code>InspectorAsserting</code> instance for type <code>Future[Assertion]</code>,
+  //DOTTY-ONLY   * enabling inspector syntax that has result type <code>Assertion</code>.
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given (using execCtx: ExecutionContext): InspectorAsserting[Future[Assertion]] = assertingNatureOfFutureAssertion
 
   private[scalatest] final def indentErrorMessages(messages: IndexedSeq[String]) = indentLines(1, messages)
 

--- a/jvm/core/src/main/scala/org/scalatest/enablers/InspectorAsserting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/InspectorAsserting.scala
@@ -80,12 +80,61 @@ trait InspectorAsserting[T] {
 abstract class UnitInspectorAsserting {
 
   /**
+   * Provides an implicit <code>InspectorAsserting</code> instance for any type that did not match a
+   * higher priority implicit provider, enabling inspector syntax that has result type <code>Unit</code>.
+   */
+  implicit def assertingNatureOfT[T]: InspectorAsserting[T] { type Result = Unit } =
+    new InspectorAsserting.InspectorAssertingImpl[T] {
+      type Result = Unit
+      def indicateSuccess(message: => String): Unit = ()
+      def indicateFailure(message: => String, optionalCause: Option[Throwable], pos: source.Position): Unit = {
+        val msg: String = message
+        throw new TestFailedException(
+          (_: StackDepthException) => Some(msg),
+          optionalCause,
+          pos
+        )
+      }
+      def indicateFailure(message: => String, optionalCause: Option[Throwable], pos: source.Position, analysis: scala.collection.immutable.IndexedSeq[String]): Unit = {
+        val msg: String = message
+        throw new TestFailedException(
+          (_: StackDepthException) => Some(msg),
+          optionalCause,
+          Left(pos),
+          None,
+          analysis
+        )
+      }
+    }
+}
+
+/**
+ * Abstract class that in the future will hold an intermediate priority <code>InspectorAsserting</code> implicit, which will enable inspector expressions
+ * that have result type <code>Expectation</code>, a more composable form of assertion that returns a result instead of throwing an exception when it fails.
+ */
+abstract class ExpectationInspectorAsserting extends UnitInspectorAsserting {
+
+  private[scalatest] implicit def assertingNatureOfExpectation(implicit prettifier: Prettifier): InspectorAsserting[Expectation] { type Result = Expectation } = {
+    new InspectorAsserting.InspectorAssertingImpl[Expectation] {
+      type Result = Expectation
+      def indicateSuccess(message: => String): Expectation = Fact.Yes(message, prettifier)
+      def indicateFailure(message: => String, optionalCause: Option[Throwable], pos: org.scalactic.source.Position): Expectation = Fact.No(message, prettifier)
+      def indicateFailure(message: => String, optionalCause: Option[Throwable], pos: source.Position, analysis: scala.collection.immutable.IndexedSeq[String]): Expectation = Fact.No(message, prettifier)
+    }
+  }
+}
+
+/**
+ * Companion object to <code>InspectorAsserting</code> that provides two implicit providers, a higher priority one for passed functions that have result
+ * type <code>Assertion</code>, which also yields result type <code>Assertion</code>, and one for any other type, which yields result type <code>Unit</code>.
+ */
+object InspectorAsserting extends ExpectationInspectorAsserting {
+
+  /**
    * Abstract subclass of <code>InspectorAsserting</code> that provides the bulk of the implementations of <code>InspectorAsserting</code>
    * methods.
    */
   abstract class InspectorAssertingImpl[T] extends InspectorAsserting[T] {
-
-    import InspectorAsserting._
 
     // Inherit Scaladoc for now. See later if can just make this implementation class private[scalatest].
     def forAll[E](xs: Iterable[E], original: Any, shorthand: Boolean, prettifier: Prettifier, pos: source.Position)(fun: E => T): Result = {
@@ -309,57 +358,6 @@ abstract class UnitInspectorAsserting {
 
     private[scalatest] def indicateFailure(message: => String, optionalCause: Option[Throwable], pos: source.Position, analysis: scala.collection.immutable.IndexedSeq[String]): Result
   }
-
-  /**
-   * Provides an implicit <code>InspectorAsserting</code> instance for any type that did not match a
-   * higher priority implicit provider, enabling inspector syntax that has result type <code>Unit</code>.
-   */
-  implicit def assertingNatureOfT[T]: InspectorAsserting[T] { type Result = Unit } =
-    new InspectorAssertingImpl[T] {
-      type Result = Unit
-      def indicateSuccess(message: => String): Unit = ()
-      def indicateFailure(message: => String, optionalCause: Option[Throwable], pos: source.Position): Unit = {
-        val msg: String = message
-        throw new TestFailedException(
-          (_: StackDepthException) => Some(msg),
-          optionalCause,
-          pos
-        )
-      }
-      def indicateFailure(message: => String, optionalCause: Option[Throwable], pos: source.Position, analysis: scala.collection.immutable.IndexedSeq[String]): Unit = {
-        val msg: String = message
-        throw new TestFailedException(
-          (_: StackDepthException) => Some(msg),
-          optionalCause,
-          Left(pos),
-          None,
-          analysis
-        )
-      }
-    }
-}
-
-/**
- * Abstract class that in the future will hold an intermediate priority <code>InspectorAsserting</code> implicit, which will enable inspector expressions
- * that have result type <code>Expectation</code>, a more composable form of assertion that returns a result instead of throwing an exception when it fails.
- */
-abstract class ExpectationInspectorAsserting extends UnitInspectorAsserting {
-
-  private[scalatest] implicit def assertingNatureOfExpectation(implicit prettifier: Prettifier): InspectorAsserting[Expectation] { type Result = Expectation } = {
-    new InspectorAssertingImpl[Expectation] {
-      type Result = Expectation
-      def indicateSuccess(message: => String): Expectation = Fact.Yes(message, prettifier)
-      def indicateFailure(message: => String, optionalCause: Option[Throwable], pos: org.scalactic.source.Position): Expectation = Fact.No(message, prettifier)
-      def indicateFailure(message: => String, optionalCause: Option[Throwable], pos: source.Position, analysis: scala.collection.immutable.IndexedSeq[String]): Expectation = Fact.No(message, prettifier)
-    }
-  }
-}
-
-/**
- * Companion object to <code>InspectorAsserting</code> that provides two implicit providers, a higher priority one for passed functions that have result
- * type <code>Assertion</code>, which also yields result type <code>Assertion</code>, and one for any other type, which yields result type <code>Unit</code>.
- */
-object InspectorAsserting extends ExpectationInspectorAsserting {
 
   /**
    * Provides an implicit <code>InspectorAsserting</code> instance for type <code>Assertion</code>,

--- a/jvm/core/src/main/scala/org/scalatest/enablers/KeyMapping.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/KeyMapping.scala
@@ -65,18 +65,21 @@ object KeyMapping {
    * @tparam MAP any subtype of <code>scala.collection.GenMap</code>
    * @return <code>KeyMapping[MAP[K, V]]</code> that supports <code>scala.collection.GenMap</code> in <code>contain key</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def keyMappingNatureOfGenMap[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](implicit equality: Equality[K]): KeyMapping[MAP[K, V]] = 
-    new KeyMapping[MAP[K, V]] {
-      def containsKey(map: MAP[K, V], key: Any): Boolean = {
-        requireNonNull(map)
-        map.keySet.exists((k: K) => equality.areEqual(k, key))
-      }
-    }
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def keyMappingNatureOfGenMap[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](using equality: Equality[K]): KeyMapping[MAP[K, V]] = 
+    convertEqualityToGenMapKeyMapping(equality)  
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
+   // SKIP-DOTTY-START
    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>K</code>
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>K</code>
    * into <code>KeyMapping</code> of type <code>MAP[K, V]</code>, where <code>MAP</code> is a subtype of <code>scala.collection.GenMap</code>.
    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
    *
@@ -93,8 +96,48 @@ object KeyMapping {
    * @tparam MAP any subtype of <code>scala.collection.GenMap</code>
    * @return <code>KeyMapping</code> of type <code>MAP[K, V]</code>
    */
+  // SKIP-DOTTY-START
   implicit def convertEqualityToGenMapKeyMapping[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](equality: Equality[K]): KeyMapping[MAP[K, V]] = 
-    keyMappingNatureOfGenMap(equality)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToGenMapKeyMapping[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](equality: Equality[K]): KeyMapping[MAP[K, V]] = 
+    new KeyMapping[MAP[K, V]] {
+      def containsKey(map: MAP[K, V], key: Any): Boolean = {
+        requireNonNull(map)
+        map.keySet.exists((k: K) => equality.areEqual(k, key))
+      }
+    }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given <code>KeyMapping</code> implementation for <code>scala.collection.GenMap</code>.
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of key in the <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY   * @tparam MAP any subtype of <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY   * @return <code>KeyMapping[MAP[K, V]]</code> that supports <code>scala.collection.GenMap</code> in <code>contain key</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [K, V, MAP[k, v] <: scala.collection.GenMap[k, v]] (using equality: Equality[K]): KeyMapping[MAP[K, V]] = convertEqualityToGenMapKeyMapping(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Given conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>K</code>
+  //DOTTY-ONLY  * into <code>KeyMapping</code> of type <code>MAP[K, V]</code>, where <code>MAP</code> is a subtype of <code>scala.collection.GenMap</code>.
+  //DOTTY-ONLY  * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <pre class="stHighlight">
+  //DOTTY-ONLY  * (Map("one" -> 1) should contain key "ONE") (after being lowerCased)
+  //DOTTY-ONLY  * </pre>
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY  * and this implicit conversion will convert it into <code>KeyMapping[Map[String, Int]]</code>.
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>K</code>
+  //DOTTY-ONLY  * @tparam K the type of the key in the <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY  * @tparam V the type of the value in the <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY  * @tparam MAP any subtype of <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY  * @return <code>KeyMapping</code> of type <code>MAP[K, V]</code>
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY given equalityGenMapKeyMapping[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]]: Conversion[Equality[K], KeyMapping[MAP[K, V]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[K]): KeyMapping[MAP[K, V]] = convertEqualityToGenMapKeyMapping(equality)
+  //DOTTY-ONLY }  
 
   /**
    * Enable <code>KeyMapping</code> implementation for <code>java.util.Map</code>.
@@ -105,12 +148,11 @@ object KeyMapping {
    * @tparam JMAP any subtype of <code>java.util.Map</code>
    * @return <code>KeyMapping[JMAP[K, V]]</code> that supports <code>java.util.Map</code> in <code>contain</code> <code>key</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def keyMappingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]](implicit equality: Equality[K]): KeyMapping[JMAP[K, V]] = 
-    new KeyMapping[JMAP[K, V]] {
-      def containsKey(jMap: JMAP[K, V], key: Any): Boolean = {
-        jMap.asScala.keySet.exists((k: K) => equality.areEqual(k, key))
-      }
-    }
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def keyMappingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]](implicit equality: Equality[K]): KeyMapping[JMAP[K, V]] = 
+    convertEqualityToJavaMapKeyMapping(equality)
 
   /**
    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>K</code>
@@ -132,6 +174,48 @@ object KeyMapping {
    * @tparam JMAP any subtype of <code>java.util.Map</code>
    * @return <code>KeyMapping</code> of type <code>JMAP[K, V]</code>
    */
+  // SKIP-DOTTY-START
   implicit def convertEqualityToJavaMapKeyMapping[K, V, JMAP[k, v] <: java.util.Map[k, v]](equality: Equality[K]): KeyMapping[JMAP[K, V]] = 
-    keyMappingNatureOfJavaMap(equality)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToJavaMapKeyMapping[K, V, JMAP[k, v] <: java.util.Map[k, v]](equality: Equality[K]): KeyMapping[JMAP[K, V]] = 
+    new KeyMapping[JMAP[K, V]] {
+      def containsKey(jMap: JMAP[K, V], key: Any): Boolean = {
+        jMap.asScala.keySet.exists((k: K) => equality.areEqual(k, key))
+      }
+    }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given <code>KeyMapping</code> implementation for <code>java.util.Map</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of key in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam JMAP any subtype of <code>java.util.Map</code>
+  //DOTTY-ONLY   * @return <code>KeyMapping[JMAP[K, V]]</code> that supports <code>java.util.Map</code> in <code>contain</code> <code>key</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [K, V, JMAP[k, v] <: java.util.Map[k, v]] (using equality: Equality[K]): KeyMapping[JMAP[K, V]] = convertEqualityToJavaMapKeyMapping(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Given conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>K</code>
+  //DOTTY-ONLY  * into <code>KeyMapping</code> of type <code>JMAP[K, V]</code>, where <code>JMAP</code> is a subtype of <code>java.util.Map</code>.
+  //DOTTY-ONLY  * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <pre class="stHighlight">
+  //DOTTY-ONLY  * val javaMap = new java.util.HashMap[String, Int]()
+  //DOTTY-ONLY  * javaMap.put("one", 1)
+  //DOTTY-ONLY  * (javaMap should contain key "ONE") (after being lowerCased)
+  //DOTTY-ONLY  * </pre>
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY  * and this implicit conversion will convert it into <code>KeyMapping[java.util.HashMap[String, Int]]</code>.
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>K</code>
+  //DOTTY-ONLY  * @tparam K the type of the key in the <code>java.util.Map</code>
+  //DOTTY-ONLY  * @tparam V the type of the value in the <code>java.util.Map</code>
+  //DOTTY-ONLY  * @tparam JMAP any subtype of <code>java.util.Map</code>
+  //DOTTY-ONLY  * @return <code>KeyMapping</code> of type <code>JMAP[K, V]</code>
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY given equalityJavaMapKeyMapping[K, V, JMAP[k, v] <: java.util.Map[k, v]]: Conversion[Equality[K], KeyMapping[JMAP[K, V]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[K]): KeyMapping[JMAP[K, V]] = convertEqualityToJavaMapKeyMapping(equality)
+  //DOTTY-ONLY }  
 }

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Length.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Length.scala
@@ -126,10 +126,14 @@ object Length {
    * @tparam JLIST any subtype of <code>java.util.List</code>
    * @return <code>Length[JLIST]</code> that supports <code>java.util.List</code> in <code>have length</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def lengthOfJavaList[JLIST <: java.util.List[_]]: Length[JLIST] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def lengthOfJavaList[JLIST <: java.util.List[_]]: Length[JLIST] = 
     new Length[JLIST] {
       def lengthOf(javaList: JLIST): Long = javaList.size
     }
+  //DOTTY-ONLY given [JLIST <: java.util.List[_]]: Length[JLIST] = lengthOfJavaList
 
   /**
    * Enable <code>Length</code> implementation for <code>scala.collection.GenSeq</code>
@@ -137,10 +141,14 @@ object Length {
    * @tparam SEQ any subtype of <code>scala.collection.GenSeq</code>
    * @return <code>Length[SEQ]</code> that supports <code>scala.collection.GenSeq</code> in <code>have length</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def lengthOfGenSeq[SEQ <: scala.collection.GenSeq[_]]: Length[SEQ] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def lengthOfGenSeq[SEQ <: scala.collection.GenSeq[_]]: Length[SEQ] = 
     new Length[SEQ] {
       def lengthOf(seq: SEQ): Long = seq.length
     }
+  //DOTTY-ONLY given [SEQ <: scala.collection.GenSeq[_]]: Length[SEQ] = lengthOfGenSeq
 
   /**
    * Enable <code>Length</code> implementation for <code>Array</code>
@@ -148,20 +156,28 @@ object Length {
    * @tparam E the type of the element in the <code>Array</code>
    * @return <code>Length[Array[E]]</code> that supports <code>Array</code> in <code>have length</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def lengthOfArray[E]: Length[Array[E]] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def lengthOfArray[E]: Length[Array[E]] = 
     new Length[Array[E]] {
       def lengthOf(arr: Array[E]): Long = arr.length
     }
+  //DOTTY-ONLY given [E]: Length[Array[E]] = lengthOfArray
 
   /**
    * Enable <code>Length</code> implementation for <code>String</code>
    *
    * @return <code>Length[String]</code> that supports <code>String</code> in <code>have length</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit val lengthOfString: Length[String] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def lengthOfString: Length[String] = 
     new Length[String] {
       def lengthOf(str: String): Long = str.length
     }
+  //DOTTY-ONLY given Length[String] = lengthOfString
 
   import scala.language.reflectiveCalls
 
@@ -171,10 +187,14 @@ object Length {
    * @tparam T any type with <code>length()</code> method that returns <code>Int</code>
    * @return <code>Length[T]</code> that supports <code>T</code> in <code>have length</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def lengthOfAnyRefWithLengthMethodForInt[T <: AnyRef { def length(): Int}]: Length[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def lengthOfAnyRefWithLengthMethodForInt[T <: AnyRef { def length(): Int}]: Length[T] = 
     new Length[T] {
       def lengthOf(obj: T): Long = obj.length()
     }
+  //DOTTY-ONLY given given_lengthOfAnyRefWithLengthMethodForInt [T <: AnyRef { def length(): Int}]: Length[T] = lengthOfAnyRefWithLengthMethodForInt  
 
   /**
    * Enable <code>Length</code> implementation for arbitary object with parameterless <code>length</code> method that returns <code>Int</code>.
@@ -182,10 +202,14 @@ object Length {
    * @tparam T any type with parameterless <code>length</code> method that returns <code>Int</code>
    * @return <code>Length[T]</code> that supports <code>T</code> in <code>have length</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def lengthOfAnyRefWithParameterlessLengthMethodForInt[T <: AnyRef { def length: Int}]: Length[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def lengthOfAnyRefWithParameterlessLengthMethodForInt[T <: AnyRef { def length: Int}]: Length[T] = 
     new Length[T] {
       def lengthOf(obj: T): Long = obj.length
     }
+  //DOTTY-ONLY given given_lengthOfAnyRefWithParameterlessLengthMethodForInt[T <: AnyRef { def length: Int}]: Length[T] = lengthOfAnyRefWithParameterlessLengthMethodForInt  
 
   /**
    * Enable <code>Length</code> implementation for arbitary object with <code>getLength()</code> method that returns <code>Int</code>.
@@ -193,10 +217,14 @@ object Length {
    * @tparam T any type with <code>getLength()</code> method that returns <code>Int</code>
    * @return <code>Length[T]</code> that supports <code>T</code> in <code>have length</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def lengthOfAnyRefWithGetLengthMethodForInt[T <: AnyRef { def getLength(): Int}]: Length[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def lengthOfAnyRefWithGetLengthMethodForInt[T <: AnyRef { def getLength(): Int}]: Length[T] = 
     new Length[T] {
       def lengthOf(obj: T): Long = obj.getLength()
     }
+  //DOTTY-ONLY given given_lengthOfAnyRefWithGetLengthMethodForInt[T <: AnyRef { def getLength(): Int}]: Length[T] = lengthOfAnyRefWithGetLengthMethodForInt
 
   /**
    * Enable <code>Length</code> implementation for arbitary object with parameterless <code>getLength</code> method that returns <code>Int</code>.
@@ -204,10 +232,14 @@ object Length {
    * @tparam T any type with parameterless <code>getLength</code> method that returns <code>Int</code>
    * @return <code>Length[T]</code> that supports <code>T</code> in <code>have length</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def lengthOfAnyRefWithParameterlessGetLengthMethodForInt[T <: AnyRef { def getLength: Int}]: Length[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def lengthOfAnyRefWithParameterlessGetLengthMethodForInt[T <: AnyRef { def getLength: Int}]: Length[T] = 
     new Length[T] {
       def lengthOf(obj: T): Long = obj.getLength
     }
+  //DOTTY-ONLY given given_lengthOfAnyRefWithParameterlessGetLengthMethodForInt[T <: AnyRef { def getLength: Int}]: Length[T] = lengthOfAnyRefWithParameterlessGetLengthMethodForInt  
 
   /**
    * Enable <code>Length</code> implementation for arbitary object with <code>length()</code> method that returns <code>Long</code>.
@@ -215,10 +247,14 @@ object Length {
    * @tparam T any type with <code>length()</code> method that returns <code>Long</code>
    * @return <code>Length[T]</code> that supports <code>T</code> in <code>have length</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def lengthOfAnyRefWithLengthMethodForLong[T <: AnyRef { def length(): Long}]: Length[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def lengthOfAnyRefWithLengthMethodForLong[T <: AnyRef { def length(): Long}]: Length[T] = 
     new Length[T] {
       def lengthOf(obj: T): Long = obj.length()
     }
+  //DOTTY-ONLY given given_lengthOfAnyRefWithLengthMethodForLong[T <: AnyRef { def length(): Long}]: Length[T] = lengthOfAnyRefWithLengthMethodForLong  
 
   /**
    * Enable <code>Length</code> implementation for arbitary object with parameterless <code>length</code> method that returns <code>Long</code>.
@@ -226,10 +262,14 @@ object Length {
    * @tparam T any type with parameterless <code>length</code> method that returns <code>Long</code>
    * @return <code>Length[T]</code> that supports <code>T</code> in <code>have length</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def lengthOfAnyRefWithParameterlessLengthMethodForLong[T <: AnyRef { def length: Long}]: Length[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def lengthOfAnyRefWithParameterlessLengthMethodForLong[T <: AnyRef { def length: Long}]: Length[T] = 
     new Length[T] {
       def lengthOf(obj: T): Long = obj.length
     }
+  //DOTTY-ONLY given given_lengthOfAnyRefWithParameterlessLengthMethodForLong[T <: AnyRef { def length: Long}]: Length[T] = lengthOfAnyRefWithParameterlessLengthMethodForLong  
 
   /**
    * Enable <code>Length</code> implementation for arbitary object with <code>getLength()</code> method that returns <code>Long</code>.
@@ -237,10 +277,14 @@ object Length {
    * @tparam T any type with <code>getLength()</code> method that returns <code>Long</code>
    * @return <code>Length[T]</code> that supports <code>T</code> in <code>have length</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def lengthOfAnyRefWithGetLengthMethodForLong[T <: AnyRef { def getLength(): Long}]: Length[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def lengthOfAnyRefWithGetLengthMethodForLong[T <: AnyRef { def getLength(): Long}]: Length[T] = 
     new Length[T] {
       def lengthOf(obj: T): Long = obj.getLength()
     }
+  //DOTTY-ONLY given given_lengthOfAnyRefWithGetLengthMethodForLong[T <: AnyRef { def getLength(): Long}]: Length[T] = lengthOfAnyRefWithGetLengthMethodForLong
 
   /**
    * Enable <code>Length</code> implementation for arbitary object with parameterless <code>getLength</code> method that returns <code>Long</code>.
@@ -248,9 +292,13 @@ object Length {
    * @tparam T any type with parameterless <code>getLength</code> method that returns <code>Long</code>
    * @return <code>Length[T]</code> that supports <code>T</code> in <code>have length</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def lengthOfAnyRefWithParameterlessGetLengthMethodForLong[T <: AnyRef { def getLength: Long}]: Length[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def lengthOfAnyRefWithParameterlessGetLengthMethodForLong[T <: AnyRef { def getLength: Long}]: Length[T] = 
     new Length[T] {
       def lengthOf(obj: T): Long = obj.getLength
     }
+  //DOTTY-ONLY given given_lengthOfAnyRefWithParameterlessGetLengthMethodForLong[T <: AnyRef { def getLength: Long}]: Length[T] = lengthOfAnyRefWithParameterlessGetLengthMethodForLong  
 }
 

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Messaging.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Messaging.scala
@@ -59,8 +59,6 @@ trait Messaging[T] {
  */
 object Messaging {
 
-  //DOTTY-ONLY import scala.reflect.Selectable.reflectiveSelectable
-
   // SKIP-DOTTY-START
   /**
    * Enable <code>Messaging</code> implementation for <code>java.lang.Throwable</code>
@@ -72,9 +70,9 @@ object Messaging {
     new Messaging[EX] {
       def messageOf(exception: EX): String = exception.getMessage()
     }
+  // SKIP-DOTTY-END
 
   import scala.language.reflectiveCalls
-  // SKIP-DOTTY-END
 
   /**
    * Provides <code>Messaging</code> implementation for any arbitrary object with a <code>message()</code> method that returns <code>String</code>
@@ -82,10 +80,14 @@ object Messaging {
    * @tparam T any type that has a <code>message()</code> method that returns <code>String</code>
    * @return <code>Messaging[T]</code> that supports <code>T</code> in <code>have message</code> syntax
    */ 
+  // SKIP-DOTTY-START
   implicit def messagingNatureOfAnyRefWithMessageMethod[T <: AnyRef { def message(): String}]: Messaging[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def messagingNatureOfAnyRefWithMessageMethod[T <: AnyRef { def message(): String}]: Messaging[T] = 
     new Messaging[T] {
       def messageOf(obj: T): String = obj.message()
     }
+  //DOTTY-ONLY given given_messagingNatureOfAnyRefWithMessageMethod[T <: AnyRef { def message(): String}]: Messaging[T] = messagingNatureOfAnyRefWithMessageMethod
 
   /**
    * Provides <code>Messaging</code> implementation for any arbitrary object with a parameterless <code>message</code> method that returns <code>String</code>
@@ -93,10 +95,14 @@ object Messaging {
    * @tparam T any type that has a parameterless <code>message</code> method that returns <code>String</code>
    * @return <code>Messaging[T]</code> that supports <code>T</code> in <code>have message</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def messagingNatureOfAnyRefWithParameterlessMessageMethod[T <: AnyRef { def message: String}]: Messaging[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def messagingNatureOfAnyRefWithParameterlessMessageMethod[T <: AnyRef { def message: String}]: Messaging[T] = 
     new Messaging[T] {
       def messageOf(obj: T): String = obj.message
     }
+  //DOTTY-ONLY given given_messagingNatureOfAnyRefWithParameterlessMessageMethod[T <: AnyRef { def message: String}]: Messaging[T] = messagingNatureOfAnyRefWithParameterlessMessageMethod
 
   /**
    * Provides <code>Messaging</code> implementation for any arbitrary object with a <code>getMessage()</code> method that returns <code>String</code>
@@ -104,10 +110,14 @@ object Messaging {
    * @tparam T any type that has a <code>getMessage()</code> method that returns <code>String</code>
    * @return <code>Messaging[T]</code> that supports <code>T</code> in <code>have message</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def messagingNatureOfAnyRefWithGetMessageMethod[T <: AnyRef { def getMessage(): String}]: Messaging[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def messagingNatureOfAnyRefWithGetMessageMethod[T <: AnyRef { def getMessage(): String}]: Messaging[T] = 
     new Messaging[T] {
       def messageOf(obj: T): String = obj.getMessage()
     }
+  //DOTTY-ONLY given given_messagingNatureOfAnyRefWithGetMessageMethod[T <: AnyRef { def getMessage(): String}]: Messaging[T] = messagingNatureOfAnyRefWithGetMessageMethod  
 
   /**
    * Provides <code>Messaging</code> implementation for any arbitrary object with a parameterless <code>getMessage</code> method that returns <code>String</code>
@@ -115,10 +125,14 @@ object Messaging {
    * @tparam T any type that has a parameterless <code>getMessage</code> method that returns <code>String</code>
    * @return <code>Messaging[T]</code> that supports <code>T</code> in <code>have message</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def messagingNatureOfAnyRefWithParameterlessGetMessageMethod[T <: AnyRef { def getMessage: String}]: Messaging[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def messagingNatureOfAnyRefWithParameterlessGetMessageMethod[T <: AnyRef { def getMessage: String}]: Messaging[T] = 
     new Messaging[T] {
       def messageOf(obj: T): String = obj.getMessage
     }
+  //DOTTY-ONLY given given_messagingNatureOfAnyRefWithParameterlessGetMessageMethod[T <: AnyRef { def getMessage: String}]: Messaging[T] = messagingNatureOfAnyRefWithParameterlessGetMessageMethod  
 }
 
 

--- a/jvm/core/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
@@ -130,7 +130,10 @@ abstract class ExpectationPropCheckerAsserting {
 
   import PropCheckerAsserting.PropCheckerAssertingImpl
 
+  // SKIP-DOTTY-START
   implicit def assertingNatureOfExpectation(implicit prettifier: Prettifier): PropCheckerAsserting[Expectation] { type Result = Expectation } = {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def assertingNatureOfExpectation(using prettifier: Prettifier): PropCheckerAsserting[Expectation] { type Result = Expectation } = {
     new PropCheckerAssertingImpl[Expectation] {
       type Result = Expectation
       def discard(result: Expectation): Boolean = result.isVacuousYes
@@ -153,6 +156,7 @@ abstract class ExpectationPropCheckerAsserting {
       }
     }
   }
+  //DOTTY-ONLY given given_assertingNatureOfExpectation(using prettifier: Prettifier): PropCheckerAsserting[Expectation] { type Result = Expectation } = assertingNatureOfExpectation(using prettifier)
 }
 
 object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
@@ -2192,7 +2196,10 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
 
   }
 
+  // SKIP-DOTTY-START
   implicit def assertingNatureOfAssertion: PropCheckerAsserting[Assertion] { type Result = Assertion } = {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def assertingNatureOfAssertion: PropCheckerAsserting[Assertion] { type Result = Assertion } = { 
     new PropCheckerAssertingImpl[Assertion] {
       type Result = Assertion
       def discard(result: Assertion): Boolean = false
@@ -2212,8 +2219,12 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
       }
     }
   }
+  //DOTTY-ONLY given given_assertingNatureOfAssertion: PropCheckerAsserting[Assertion] { type Result = Assertion } = assertingNatureOfAssertion
 
+  // SKIP-DOTTY-START
   implicit def assertingNatureOfFutureAssertion(implicit exeCtx: scala.concurrent.ExecutionContext): PropCheckerAsserting[Future[Assertion]] { type Result = Future[Assertion] } = {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def assertingNatureOfFutureAssertion(using exeCtx: scala.concurrent.ExecutionContext): PropCheckerAsserting[Future[Assertion]] { type Result = Future[Assertion] } = {
     new FuturePropCheckerAssertingImpl[Assertion] {
       implicit val executionContext = exeCtx
       def discard(result: Assertion): Boolean = false
@@ -2233,6 +2244,7 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
       }
     }
   }
+  //DOTTY-ONLY given given_assertingNatureOfFutureAssertion(using exeCtx: scala.concurrent.ExecutionContext): PropCheckerAsserting[Future[Assertion]] { type Result = Future[Assertion] } = assertingNatureOfFutureAssertion(using exeCtx)
 
   private[enablers] def argsAndLabels(result: PropertyCheckResult): (List[PropertyArgument], List[String]) = {
 

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Readability.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Readability.scala
@@ -58,18 +58,20 @@ trait Readability[-T] {
  */
 object Readability {
 
-  //DOTTY-ONLY import scala.reflect.Selectable.reflectiveSelectable
-
   /**
    * Enable <code>Readability</code> implementation for <code>java.io.File</code>.
    *
    * @tparam FILE any subtype of <code>java.io.File</code>
    * @return <code>Readability[FILE]</code> that supports <code>java.io.File</code> in <code>be readable</code> syntax
-   */
+   */ 
+  // SKIP-DOTTY-START
   implicit def readabilityOfFile[FILE <: java.io.File]: Readability[FILE] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def readabilityOfFile[FILE <: java.io.File]: Readability[FILE] =
     new Readability[FILE] {
       def isReadable(file: FILE): Boolean = file.canRead
     }
+  //DOTTY-ONLY given given_readabilityOfFile[FILE <: java.io.File]: Readability[FILE] = readabilityOfFile  
 
   import scala.language.reflectiveCalls
 
@@ -79,10 +81,14 @@ object Readability {
    * @tparam T any type that has a <code>isReadable()</code> method that returns <code>Boolean</code>
    * @return <code>Readability[T]</code> that supports <code>T</code> in <code>be readable</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def readabilityOfAnyRefWithIsReadableMethod[T <: AnyRef { def isReadable(): Boolean}]: Readability[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def readabilityOfAnyRefWithIsReadableMethod[T <: AnyRef { def isReadable(): Boolean}]: Readability[T] = 
     new Readability[T] {
       def isReadable(obj: T): Boolean = obj.isReadable()
     }
+  //DOTTY-ONLY given given_readabilityOfAnyRefWithIsReadableMethod[T <: AnyRef { def isReadable(): Boolean}]: Readability[T] = readabilityOfAnyRefWithIsReadableMethod
 
   /**
    * Enable <code>Readability</code> implementation for any arbitrary object with a parameterless <code>isReadable</code> method that returns <code>Boolean</code>
@@ -90,9 +96,13 @@ object Readability {
    * @tparam T any type that has a parameterless <code>isReadable</code> method that returns <code>Boolean</code>
    * @return <code>Readability[T]</code> that supports <code>T</code> in <code>be readable</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def readabilityOfAnyRefWithParameterlessIsReadableMethod[T <: AnyRef { def isReadable: Boolean}]: Readability[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def readabilityOfAnyRefWithParameterlessIsReadableMethod[T <: AnyRef { def isReadable: Boolean}]: Readability[T] = 
     new Readability[T] {
       def isReadable(obj: T): Boolean = obj.isReadable
     }
+  //DOTTY-ONLY given given_readabilityOfAnyRefWithParameterlessIsReadableMethod[T <: AnyRef { def isReadable: Boolean}]: Readability[T] = readabilityOfAnyRefWithParameterlessIsReadableMethod
 }
 

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Retrying.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Retrying.scala
@@ -73,7 +73,10 @@ object Retrying {
   /**
     * Provides implicit <code>Retrying</code> implementation for <code>Future[T]</code>.
     */
+  // SKIP-DOTTY-START
   implicit def retryingNatureOfFutureT[T](implicit execCtx: ExecutionContext): Retrying[Future[T]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def retryingNatureOfFutureT[T](using execCtx: ExecutionContext): Retrying[Future[T]] =
     new Retrying[Future[T]] {
       def retry(timeout: Span, interval: Span, pos: source.Position)(fun: => Future[T]): Future[T] = {
         val startNanos = System.nanoTime
@@ -171,11 +174,15 @@ object Retrying {
         tryTryAgain(1)
       }
     }
+  //DOTTY-ONLY given given_retryingNatureOfFutureT[T](using execCtx: ExecutionContext): Retrying[Future[T]] = retryingNatureOfFutureT(using execCtx)
 
   /**
     * Provides implicit <code>Retrying</code> implementation for <code>T</code>.
     */
+  // SKIP-DOTTY-START
   implicit def retryingNatureOfT[T]: Retrying[T] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def retryingNatureOfT[T]: Retrying[T] =
     new Retrying[T] {
       def retry(timeout: Span, interval: Span, pos: source.Position)(fun: => T): T = {
         val startNanos = System.nanoTime
@@ -226,5 +233,6 @@ object Retrying {
         tryTryAgain(1)
       }
     }
+  //DOTTY-ONLY given given_retryingNatureOfT[T]: Retrying[T] = retryingNatureOfT  
 
 }

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Sequencing.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Sequencing.scala
@@ -923,7 +923,10 @@ object Sequencing {
   //DOTTY-ONLY }
 
   /**
+   // SKIP-DOTTY-START
    * Implicit to support <code>Sequencing</code> nature of <code>Every</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * To support <code>Sequencing</code> nature of <code>Every</code>.
    *
    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>Every</code>
    * @tparam E the type of the element in the <code>Every</code>
@@ -936,7 +939,10 @@ object Sequencing {
     convertEqualityToEverySequencing(equality)
 
   /**
+   // SKIP-DOTTY-START
    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
    * into <code>Sequencing</code> of type <code>Every[E]</code>.
    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
    *

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Sequencing.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Sequencing.scala
@@ -214,14 +214,50 @@ object Sequencing {
   import scala.language.higherKinds
 
   /**
+   // SKIP-DOTTY-START
    * Implicit to support <code>Sequencing</code> nature of <code>scala.collection.GenSeq</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY  * To support <code>Sequencing</code> nature of <code>scala.collection.GenSeq</code>.
    *
    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>scala.collection.GenSeq</code>
    * @tparam E the type of the element in the <code>scala.collection.GenSeq</code>
    * @tparam SEQ any subtype of <code>scala.collection.GenSeq</code>
    * @return <code>Sequencing[SEQ[E]]</code> that supports <code>scala.collection.GenSeq</code> in relevant <code>contain</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sequencingNatureOfGenSeq[E, SEQ[e] <: scala.collection.GenSeq[e]](implicit equality: Equality[E]): Sequencing[SEQ[E]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sequencingNatureOfGenSeq[E, SEQ[e] <: scala.collection.GenSeq[e]](using equality: Equality[E]): Sequencing[SEQ[E]] =
+    convertEqualityToGenSeqSequencing(equality)
+
+  // SKIP-DOTTY-START
+  import scala.language.implicitConversions
+  // SKIP-DOTTY-END
+
+  /**
+   // SKIP-DOTTY-START
+   * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY  * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+   * into <code>Sequencing</code> of type <code>SEQ[E]</code>, where <code>SEQ</code> is a subtype of <code>scala.collection.GenSeq</code>.
+   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+   *
+   * <pre class="stHighlight">
+   * (List("hi", "he") should contain inOrderOnly ("HI", "HE")) (after being lowerCased)
+   * </pre>
+   *
+   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+   * and this implicit conversion will convert it into <code>Sequencing[List[String]]</code>.
+   *
+   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+   * @tparam E type of elements in the <code>scala.collection.GenSeq</code>
+   * @tparam SEQ subtype of <code>scala.collection.GenSeq</code>
+   * @return <code>Sequencing</code> of type <code>SEQ[E]</code>
+   */
+  // SKIP-DOTTY-START
+  implicit def convertEqualityToGenSeqSequencing[E, SEQ[e] <: scala.collection.GenSeq[e]](equality: Equality[E]): Sequencing[SEQ[E]] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToGenSeqSequencing[E, SEQ[e] <: scala.collection.GenSeq[e]](equality: Equality[E]): Sequencing[SEQ[E]] = 
     new Sequencing[SEQ[E]] {
 
       def containsInOrder(seq: SEQ[E], elements: scala.collection.Seq[Any]): Boolean = {
@@ -238,54 +274,59 @@ object Sequencing {
       }
     }
 
-  import scala.language.implicitConversions
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Sequencing</code> nature of <code>scala.collection.GenSeq</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>scala.collection.GenSeq</code>
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>scala.collection.GenSeq</code>
+  //DOTTY-ONLY   * @tparam SEQ any subtype of <code>scala.collection.GenSeq</code>
+  //DOTTY-ONLY   * @return <code>Sequencing[SEQ[E]]</code> that supports <code>scala.collection.GenSeq</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E, SEQ[e] <: scala.collection.GenSeq[e]] (using equality: Equality[E]): Sequencing[SEQ[E]] = convertEqualityToGenSeqSequencing(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * into <code>Sequencing</code> of type <code>SEQ[E]</code>, where <code>SEQ</code> is a subtype of <code>scala.collection.GenSeq</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * (List("hi", "he") should contain inOrderOnly ("HI", "HE")) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Sequencing[List[String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * @tparam E type of elements in the <code>scala.collection.GenSeq</code>
+  //DOTTY-ONLY   * @tparam SEQ subtype of <code>scala.collection.GenSeq</code>
+  //DOTTY-ONLY   * @return <code>Sequencing</code> of type <code>SEQ[E]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityGenSeqSequencing[E, SEQ[e] <: scala.collection.GenSeq[e]]: Conversion[Equality[E], Sequencing[SEQ[E]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[E]): Sequencing[SEQ[E]] = convertEqualityToGenSeqSequencing(equality)
+  //DOTTY-ONLY }
 
   /**
-   * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
-   * into <code>Sequencing</code> of type <code>SEQ[E]</code>, where <code>SEQ</code> is a subtype of <code>scala.collection.GenSeq</code>.
-   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
-   *
-   * <pre class="stHighlight">
-   * (List("hi", "he") should contain inOrderOnly ("HI", "HE")) (after being lowerCased)
-   * </pre>
-   *
-   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
-   * and this implicit conversion will convert it into <code>Sequencing[List[String]]</code>.
-   *
-   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
-   * @tparam E type of elements in the <code>scala.collection.GenSeq</code>
-   * @tparam SEQ subtype of <code>scala.collection.GenSeq</code>
-   * @return <code>Sequencing</code> of type <code>SEQ[E]</code>
-   */
-  implicit def convertEqualityToGenSeqSequencing[E, SEQ[e] <: scala.collection.GenSeq[e]](equality: Equality[E]): Sequencing[SEQ[E]] = 
-    sequencingNatureOfGenSeq(equality)
-
-  /**
+   // SKIP-DOTTY-START
    * Implicit to support <code>Sequencing</code> nature of <code>scala.collection.SortedSet</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY  * To support <code>Sequencing</code> nature of <code>scala.collection.SortedSet</code>.
    *
    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>scala.collection.SortedSet</code>
    * @tparam E the type of the element in the <code>scala.collection.SortedSet</code>
    * @tparam SET any subtype of <code>scala.collection.SortedSet</code>
    * @return <code>Sequencing[SET[E]]</code> that supports <code>scala.collection.SortedSet</code> in relevant <code>contain</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sequencingNatureOfSortedSet[E, SET[e] <: scala.collection.SortedSet[e]](implicit equality: Equality[E]): Sequencing[SET[E]] =
-    new Sequencing[SET[E]] {
-
-      def containsInOrder(set: SET[E], elements: scala.collection.Seq[Any]): Boolean = {
-        checkInOrder(set, elements, equality)
-      }
-
-      def containsInOrderOnly(set: SET[E], elements: scala.collection.Seq[Any]): Boolean = {
-        checkInOrderOnly[E](set, elements, equality)
-      }
-
-      def containsTheSameElementsInOrderAs(set: SET[E], elements: Iterable[Any]): Boolean = {
-        checkTheSameElementsInOrderAs[E](set, elements, equality)
-      }
-    }
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sequencingNatureOfSortedSet[E, SET[e] <: scala.collection.SortedSet[e]](implicit equality: Equality[E]): Sequencing[SET[E]] =
+    convertEqualityToSortedSetSequencing(equality)
 
   /**
+   // SKIP-DOTTY-START
    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
    * into <code>Sequencing</code> of type <code>SET[E]</code>, where <code>SET</code> is a subtype of <code>scala.collection.SortedSet</code>.
    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
    *
@@ -301,8 +342,55 @@ object Sequencing {
    * @tparam SET subtype of <code>scala.collection.SortedSet</code>
    * @return <code>Sequencing</code> of type <code>SET[E]</code>
    */
+  // SKIP-DOTTY-START
   implicit def convertEqualityToSortedSetSequencing[E, SET[e] <: scala.collection.SortedSet[e]](equality: Equality[E]): Sequencing[SET[E]] = 
-    sequencingNatureOfSortedSet(equality)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToSortedSetSequencing[E, SET[e] <: scala.collection.SortedSet[e]](equality: Equality[E]): Sequencing[SET[E]] = 
+    new Sequencing[SET[E]] {
+
+      def containsInOrder(set: SET[E], elements: scala.collection.Seq[Any]): Boolean = {
+        checkInOrder(set, elements, equality)
+      }
+
+      def containsInOrderOnly(set: SET[E], elements: scala.collection.Seq[Any]): Boolean = {
+        checkInOrderOnly[E](set, elements, equality)
+      }
+
+      def containsTheSameElementsInOrderAs(set: SET[E], elements: Iterable[Any]): Boolean = {
+        checkTheSameElementsInOrderAs[E](set, elements, equality)
+      }
+    }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given support <code>Sequencing</code> nature of <code>scala.collection.SortedSet</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>scala.collection.SortedSet</code>
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>scala.collection.SortedSet</code>
+  //DOTTY-ONLY   * @tparam SET any subtype of <code>scala.collection.SortedSet</code>
+  //DOTTY-ONLY   * @return <code>Sequencing[SET[E]]</code> that supports <code>scala.collection.SortedSet</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E, SET[e] <: scala.collection.SortedSet[e]] (using equality: Equality[E]): Sequencing[SET[E]] = convertEqualityToSortedSetSequencing(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * into <code>Sequencing</code> of type <code>SET[E]</code>, where <code>SET</code> is a subtype of <code>scala.collection.SortedSet</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * (SortedSet("hi", "he") should contain inOrderOnly ("HI", "HE")) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Sequencing[SortedSet[String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * @tparam E type of elements in the <code>scala.collection.SortedSet</code>
+  //DOTTY-ONLY   * @tparam SET subtype of <code>scala.collection.SortedSet</code>
+  //DOTTY-ONLY   * @return <code>Sequencing</code> of type <code>SET[E]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalitySortedSetSequencing[E, SET[e] <: scala.collection.SortedSet[e]]: Conversion[Equality[E], Sequencing[SET[E]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[E]): Sequencing[SET[E]] = convertEqualityToSortedSetSequencing(equality)
+  //DOTTY-ONLY }
 
   /**
    * Implicit to support <code>Sequencing</code> nature of <code>scala.collection.SortedMap</code>.
@@ -313,24 +401,17 @@ object Sequencing {
    * @tparam MAP any subtype of <code>scala.collection.SortedMap</code>
    * @return <code>Sequencing[MAP[K, V]]</code> that supports <code>scala.collection.SortedMap</code> in relevant <code>contain</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sequencingNatureOfSortedMap[K, V, MAP[k, v] <: scala.collection.SortedMap[k, v]](implicit equality: Equality[(K, V)]): Sequencing[MAP[K, V]] =
-    new Sequencing[MAP[K, V]] {
-
-      def containsInOrder(map: MAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
-        checkInOrder(map, elements, equality)
-      }
-
-      def containsInOrderOnly(map: MAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
-        checkInOrderOnly(map, elements, equality)
-      }
-
-      def containsTheSameElementsInOrderAs(map: MAP[K, V], elements: Iterable[Any]): Boolean = {
-        checkTheSameElementsInOrderAs(map, elements, equality)
-      }
-    }
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sequencingNatureOfSortedMap[K, V, MAP[k, v] <: scala.collection.SortedMap[k, v]](using equality: Equality[(K, V)]): Sequencing[MAP[K, V]] =
+    convertEqualityToSortedMapSequencing(equality)
 
   /**
+   // SKIP-DOTTY-START 
    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>(K, V)</code>
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>(K, V)</code>
    * into <code>Sequencing</code> of type <code>MAP[K, V]</code>, where <code>MAP</code> is a subtype of <code>scala.collection.SortedMap</code>.
    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
    *
@@ -348,8 +429,58 @@ object Sequencing {
    * @tparam MAP subtype of <code>scala.collection.SortedMap</code>
    * @return <code>Sequencing</code> of type <code>MAP[K, V]</code>
    */
+  // SKIP-DOTTY-START
   implicit def convertEqualityToSortedMapSequencing[K, V, MAP[k, v] <: scala.collection.SortedMap[k, v]](equality: Equality[(K, V)]): Sequencing[MAP[K, V]] = 
-    sequencingNatureOfSortedMap(equality)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToSortedMapSequencing[K, V, MAP[k, v] <: scala.collection.SortedMap[k, v]](equality: Equality[(K, V)]): Sequencing[MAP[K, V]] = 
+    new Sequencing[MAP[K, V]] {
+
+      def containsInOrder(map: MAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
+        checkInOrder(map, elements, equality)
+      }
+
+      def containsInOrderOnly(map: MAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
+        checkInOrderOnly(map, elements, equality)
+      }
+
+      def containsTheSameElementsInOrderAs(map: MAP[K, V], elements: Iterable[Any]): Boolean = {
+        checkTheSameElementsInOrderAs(map, elements, equality)
+      }
+    }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given <code>Sequencing</code> nature of <code>scala.collection.SortedMap</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>scala.collection.SortedMap</code>
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>scala.collection.SortedMap</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>scala.collection.SortedMap</code>
+  //DOTTY-ONLY   * @tparam MAP any subtype of <code>scala.collection.SortedMap</code>
+  //DOTTY-ONLY   * @return <code>Sequencing[MAP[K, V]]</code> that supports <code>scala.collection.SortedMap</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [K, V, MAP[k, v] <: scala.collection.SortedMap[k, v]] (using equality: Equality[(K, V)]): Sequencing[MAP[K, V]] = convertEqualityToSortedMapSequencing(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>(K, V)</code>
+  //DOTTY-ONLY   * into <code>Sequencing</code> of type <code>MAP[K, V]</code>, where <code>MAP</code> is a subtype of <code>scala.collection.SortedMap</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * // lowerCased needs to be implemented as Normalization[(K, V)]
+  //DOTTY-ONLY   * (SortedMap("hi" -> "hi", "he" -> "he") should contain inOrderOnly ("HI" -> "HI", "HE" -> "HE")) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Sequencing[SortedMap[String, String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>(K, V)</code>
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>scala.collection.SortedMap</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>scala.collection.SortedMap</code>
+  //DOTTY-ONLY   * @tparam MAP subtype of <code>scala.collection.SortedMap</code>
+  //DOTTY-ONLY   * @return <code>Sequencing</code> of type <code>MAP[K, V]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalitySortedMapSequencing[K, V, MAP[k, v] <: scala.collection.SortedMap[k, v]]: Conversion[Equality[(K, V)], Sequencing[MAP[K, V]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[(K, V)]): Sequencing[MAP[K, V]] = convertEqualityToSortedMapSequencing(equality)
+  //DOTTY-ONLY }
 
   /**
    * Implicit to support <code>Sequencing</code> nature of <code>Array</code>.
@@ -358,7 +489,35 @@ object Sequencing {
    * @tparam E the type of the element in the <code>Array</code>
    * @return <code>Sequencing[Array[E]]</code> that supports <code>Array</code> in relevant <code>contain</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sequencingNatureOfArray[E](implicit equality: Equality[E]): Sequencing[Array[E]] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sequencingNatureOfArray[E](implicit equality: Equality[E]): Sequencing[Array[E]] = 
+    sequencingNatureOfArray(equality)
+
+  /**
+   // SKIP-DOTTY-START
+   * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+   * into <code>Sequencing</code> of type <code>Array[E]</code>.
+   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+   *
+   * <pre class="stHighlight">
+   * (Array("hi", "he") should contain inOrderOnly ("HI", "HE")) (after being lowerCased)
+   * </pre>
+   *
+   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+   * and this implicit conversion will convert it into <code>Sequencing[Array[String]]</code>.
+   *
+   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+   * @tparam E type of elements in the <code>Array</code>
+   * @return <code>Sequencing</code> of type <code>Array[E]</code>
+   */
+  // SKIP-DOTTY-START
+  implicit def convertEqualityToArraySequencing[E](equality: Equality[E]): Sequencing[Array[E]] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToArraySequencing[E](equality: Equality[E]): Sequencing[Array[E]] = 
     new Sequencing[Array[E]] {
 
       def containsInOrder(array: Array[E], elements: scala.collection.Seq[Any]): Boolean = {
@@ -374,51 +533,57 @@ object Sequencing {
       }
     }
 
-  /**
-   * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
-   * into <code>Sequencing</code> of type <code>Array[E]</code>.
-   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
-   *
-   * <pre class="stHighlight">
-   * (Array("hi", "he") should contain inOrderOnly ("HI", "HE")) (after being lowerCased)
-   * </pre>
-   *
-   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
-   * and this implicit conversion will convert it into <code>Sequencing[Array[String]]</code>.
-   *
-   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
-   * @tparam E type of elements in the <code>Array</code>
-   * @return <code>Sequencing</code> of type <code>Array[E]</code>
-   */
-  implicit def convertEqualityToArraySequencing[E](equality: Equality[E]): Sequencing[Array[E]] = 
-    sequencingNatureOfArray(equality)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given <code>Sequencing</code> nature of <code>Array</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>Array</code>
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>Array</code>
+  //DOTTY-ONLY   * @return <code>Sequencing[Array[E]]</code> that supports <code>Array</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E] (using equality: Equality[E]): Sequencing[Array[E]] = convertEqualityToArraySequencing(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * into <code>Sequencing</code> of type <code>Array[E]</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * (Array("hi", "he") should contain inOrderOnly ("HI", "HE")) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Sequencing[Array[String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * @tparam E type of elements in the <code>Array</code>
+  //DOTTY-ONLY   * @return <code>Sequencing</code> of type <code>Array[E]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityArraySequencing[E]: Conversion[Equality[E], Sequencing[Array[E]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[E]): Sequencing[Array[E]] = convertEqualityToArraySequencing(equality)
+  //DOTTY-ONLY }  
 
   /**
+   // SKIP-DOTTY-START
    * Implicit to support <code>Sequencing</code> nature of <code>java.util.List</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * To support <code>Sequencing</code> nature of <code>java.util.List</code>.
    *
    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>java.util.List</code>
    * @tparam E the type of the element in the <code>java.util.List</code>
    * @tparam JLIST any subtype of <code>java.util.List</code>
    * @return <code>Sequencing[JLIST[E]]</code> that supports <code>java.util.List</code> in relevant <code>contain</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sequencingNatureOfJavaList[E, JLIST[e] <: java.util.List[e]](implicit equality: Equality[E]): Sequencing[JLIST[E]] = 
-    new Sequencing[JLIST[E]] {
-
-      def containsInOrder(col: JLIST[E], elements: scala.collection.Seq[Any]): Boolean = {
-        checkInOrder(col.asScala, elements, equality)
-      }
-
-      def containsInOrderOnly(col: JLIST[E], elements: scala.collection.Seq[Any]): Boolean = {
-        checkInOrderOnly(col.asScala, elements, equality)
-      }
-
-      def containsTheSameElementsInOrderAs(col: JLIST[E], elements: Iterable[Any]): Boolean = {
-        checkTheSameElementsInOrderAs(col.asScala, elements, equality)
-      }
-    }
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sequencingNatureOfJavaList[E, JLIST[e] <: java.util.List[e]](implicit equality: Equality[E]): Sequencing[JLIST[E]] = 
+    convertEqualityToJavaListSequencing(equality)
 
   /**
+   // SKIP-DOTTY-START
    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
    * into <code>Sequencing</code> of type <code>JLIST[E]</code>, where <code>JLIST</code> is a subtype of <code>java.util.List</code>.
    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
    *
@@ -436,35 +601,80 @@ object Sequencing {
    * @tparam JLIST subtype of <code>java.util.List</code>
    * @return <code>Sequencing</code> of type <code>JLIST[E]</code>
    */
+  // SKIP-DOTTY-START
   implicit def convertEqualityToJavaListSequencing[E, JLIST[e] <: java.util.List[e]](equality: Equality[E]): Sequencing[JLIST[E]] = 
-    sequencingNatureOfJavaList(equality)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToJavaListSequencing[E, JLIST[e] <: java.util.List[e]](equality: Equality[E]): Sequencing[JLIST[E]] = 
+    new Sequencing[JLIST[E]] {
+
+      def containsInOrder(col: JLIST[E], elements: scala.collection.Seq[Any]): Boolean = {
+        checkInOrder(col.asScala, elements, equality)
+      }
+
+      def containsInOrderOnly(col: JLIST[E], elements: scala.collection.Seq[Any]): Boolean = {
+        checkInOrderOnly(col.asScala, elements, equality)
+      }
+
+      def containsTheSameElementsInOrderAs(col: JLIST[E], elements: Iterable[Any]): Boolean = {
+        checkTheSameElementsInOrderAs(col.asScala, elements, equality)
+      }
+    }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given <code>Sequencing</code> nature of <code>java.util.List</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>java.util.List</code>
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>java.util.List</code>
+  //DOTTY-ONLY   * @tparam JLIST any subtype of <code>java.util.List</code>
+  //DOTTY-ONLY   * @return <code>Sequencing[JLIST[E]]</code> that supports <code>java.util.List</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E, JLIST[e] <: java.util.List[e]] (using equality: Equality[E]): Sequencing[JLIST[E]] = convertEqualityToJavaListSequencing(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * into <code>Sequencing</code> of type <code>JLIST[E]</code>, where <code>JLIST</code> is a subtype of <code>java.util.List</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * val javaList = new java.util.ArrayList[String]()
+  //DOTTY-ONLY   * javaList.add("hi", "he")
+  //DOTTY-ONLY   * (javaList should contain ("HI", "HE")) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Sequencing[java.util.ArrayList[String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * @tparam E type of elements in the <code>java.util.List</code>
+  //DOTTY-ONLY   * @tparam JLIST subtype of <code>java.util.List</code>
+  //DOTTY-ONLY   * @return <code>Sequencing</code> of type <code>JLIST[E]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityJavaListSequencing[E, JLIST[e] <: java.util.List[e]]: Conversion[Equality[E], Sequencing[JLIST[E]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[E]): Sequencing[JLIST[E]] = convertEqualityToJavaListSequencing(equality)
+  //DOTTY-ONLY }  
 
   /**
+   // SKIP-DOTTY-START
    * Implicit to support <code>Sequencing</code> nature of <code>java.util.SortedSet</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * To support <code>Sequencing</code> nature of <code>java.util.SortedSet</code>.
    *
    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>java.util.SortedSet</code>
    * @tparam E the type of the element in the <code>java.util.SortedSet</code>
    * @tparam JSET any subtype of <code>java.util.SortedSet</code>
    * @return <code>Sequencing[JSET[E]]</code> that supports <code>java.util.SortedSet</code> in relevant <code>contain</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sequencingNatureOfJavaSortedSet[E, JSET[e] <: java.util.SortedSet[e]](implicit equality: Equality[E]): Sequencing[JSET[E]] =
-    new Sequencing[JSET[E]] {
-
-      def containsInOrder(set: JSET[E], elements: scala.collection.Seq[Any]): Boolean = {
-        checkInOrder(set.iterator.asScala.toVector, elements, equality)
-      }
-
-      def containsInOrderOnly(set: JSET[E], elements: scala.collection.Seq[Any]): Boolean = {
-        checkInOrderOnly[E](set.iterator.asScala.toVector, elements, equality)
-      }
-
-      def containsTheSameElementsInOrderAs(set: JSET[E], elements: Iterable[Any]): Boolean = {
-        checkTheSameElementsInOrderAs[E](set.iterator.asScala.toVector, elements, equality)
-      }
-    }
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sequencingNatureOfJavaSortedSet[E, JSET[e] <: java.util.SortedSet[e]](using equality: Equality[E]): Sequencing[JSET[E]] =
+    convertEqualityToJavaSortedSetSequencing(equality)
 
   /**
+   // SKIP-DOTTY-START
    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
    * into <code>Sequencing</code> of type <code>JSET[E]</code>, where <code>JSET</code> is a subtype of <code>java.util.SortedSet</code>.
    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
    *
@@ -482,11 +692,63 @@ object Sequencing {
    * @tparam JSET subtype of <code>java.util.List</code>
    * @return <code>Sequencing</code> of type <code>JLIST[E]</code>
    */
+  // SKIP-DOTTY-START
   implicit def convertEqualityToJavaSortedSetSequencing[E, JSET[e] <: java.util.SortedSet[e]](equality: Equality[E]): Sequencing[JSET[E]] = 
-    sequencingNatureOfJavaSortedSet(equality)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToJavaSortedSetSequencing[E, JSET[e] <: java.util.SortedSet[e]](equality: Equality[E]): Sequencing[JSET[E]] = 
+    new Sequencing[JSET[E]] {
+
+      def containsInOrder(set: JSET[E], elements: scala.collection.Seq[Any]): Boolean = {
+        checkInOrder(set.iterator.asScala.toVector, elements, equality)
+      }
+
+      def containsInOrderOnly(set: JSET[E], elements: scala.collection.Seq[Any]): Boolean = {
+        checkInOrderOnly[E](set.iterator.asScala.toVector, elements, equality)
+      }
+
+      def containsTheSameElementsInOrderAs(set: JSET[E], elements: Iterable[Any]): Boolean = {
+        checkTheSameElementsInOrderAs[E](set.iterator.asScala.toVector, elements, equality)
+      }
+    }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given <code>Sequencing</code> nature of <code>java.util.SortedSet</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>java.util.SortedSet</code>
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>java.util.SortedSet</code>
+  //DOTTY-ONLY   * @tparam JSET any subtype of <code>java.util.SortedSet</code>
+  //DOTTY-ONLY   * @return <code>Sequencing[JSET[E]]</code> that supports <code>java.util.SortedSet</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E, JSET[e] <: java.util.SortedSet[e]] (using equality: Equality[E]): Sequencing[JSET[E]] = convertEqualityToJavaSortedSetSequencing(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * into <code>Sequencing</code> of type <code>JSET[E]</code>, where <code>JSET</code> is a subtype of <code>java.util.SortedSet</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * val javaSet = new java.util.TreeSet[String]()
+  //DOTTY-ONLY   * javaSet.add("hi", "he")
+  //DOTTY-ONLY   * (javaSet should contain inOrderOnly ("HI", "HE")) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Sequencing[java.util.TreeSet[String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * @tparam E type of elements in the <code>java.util.List</code>
+  //DOTTY-ONLY   * @tparam JSET subtype of <code>java.util.List</code>
+  //DOTTY-ONLY   * @return <code>Sequencing</code> of type <code>JLIST[E]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityJavaSortedSetSequencing[E, JSET[e] <: java.util.SortedSet[e]]: Conversion[Equality[E], Sequencing[JSET[E]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[E]): Sequencing[JSET[E]] = convertEqualityToJavaSortedSetSequencing(equality)
+  //DOTTY-ONLY }  
 
   /**
+   // SKIP-DOTTY-START
    * Implicit to support <code>Sequencing</code> nature of <code>java.util.SortedMap</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * To support <code>Sequencing</code> nature of <code>java.util.SortedMap</code>.
    *
    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of entry in the <code>java.util.SortedMap</code>
    * @tparam K the type of the key in the <code>java.util.SortedMap</code>
@@ -494,24 +756,17 @@ object Sequencing {
    * @tparam JMAP any subtype of <code>java.util.SortedMap</code>
    * @return <code>Sequencing[JMAP[K, V]]</code> that supports <code>java.util.SortedMap</code> in relevant <code>contain</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sequencingNatureOfJavaSortedMap[K, V, JMAP[k, v] <: java.util.SortedMap[k, v]](implicit equality: Equality[java.util.Map.Entry[K, V]]): Sequencing[JMAP[K, V]] =
-    new Sequencing[JMAP[K, V]] {
-
-      def containsInOrder(map: JMAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
-        checkInOrder(map.entrySet.iterator.asScala.toVector, elements, equality)
-      }
-
-      def containsInOrderOnly(map: JMAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
-        checkInOrderOnly(map.entrySet.iterator.asScala.toVector, elements, equality)
-      }
-
-      def containsTheSameElementsInOrderAs(map: JMAP[K, V], elements: Iterable[Any]): Boolean = {
-        checkTheSameElementsInOrderAs(map.entrySet.iterator.asScala.toVector, elements, equality)
-      }
-    }
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sequencingNatureOfJavaSortedMap[K, V, JMAP[k, v] <: java.util.SortedMap[k, v]](using equality: Equality[java.util.Map.Entry[K, V]]): Sequencing[JMAP[K, V]] =
+    convertEqualityToJavaSortedMapSequencing(equality)
 
   /**
+   // SKIP-DOTTY-START
    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
    * into <code>Sequencing</code> of type <code>JMAP[K, V]</code>, where <code>JMAP</code> is a subtype of <code>java.util.SortedMap</code>.
    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
    *
@@ -531,16 +786,99 @@ object Sequencing {
    * @tparam JMAP subtype of <code>java.util.SortedMap</code>
    * @return <code>Sequencing</code> of type <code>JMAP[K, V]</code>
    */
+  // SKIP-DOTTY-START
   implicit def convertEqualityToJavaSortedMapSequencing[K, V, JMAP[k, v] <: java.util.SortedMap[k, v]](equality: Equality[java.util.Map.Entry[K, V]]): Sequencing[JMAP[K, V]] = 
-    sequencingNatureOfJavaSortedMap(equality)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToJavaSortedMapSequencing[K, V, JMAP[k, v] <: java.util.SortedMap[k, v]](equality: Equality[java.util.Map.Entry[K, V]]): Sequencing[JMAP[K, V]] = 
+    new Sequencing[JMAP[K, V]] {
+
+      def containsInOrder(map: JMAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
+        checkInOrder(map.entrySet.iterator.asScala.toVector, elements, equality)
+      }
+
+      def containsInOrderOnly(map: JMAP[K, V], elements: scala.collection.Seq[Any]): Boolean = {
+        checkInOrderOnly(map.entrySet.iterator.asScala.toVector, elements, equality)
+      }
+
+      def containsTheSameElementsInOrderAs(map: JMAP[K, V], elements: Iterable[Any]): Boolean = {
+        checkTheSameElementsInOrderAs(map.entrySet.iterator.asScala.toVector, elements, equality)
+      }
+    }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given to support <code>Sequencing</code> nature of <code>java.util.SortedMap</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of entry in the <code>java.util.SortedMap</code>
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>java.util.SortedMap</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>java.util.SortedMap</code>
+  //DOTTY-ONLY   * @tparam JMAP any subtype of <code>java.util.SortedMap</code>
+  //DOTTY-ONLY   * @return <code>Sequencing[JMAP[K, V]]</code> that supports <code>java.util.SortedMap</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [K, V, JMAP[k, v] <: java.util.SortedMap[k, v]] (using equality: Equality[java.util.Map.Entry[K, V]]): Sequencing[JMAP[K, V]] = convertEqualityToJavaSortedMapSequencing(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
+  //DOTTY-ONLY   * into <code>Sequencing</code> of type <code>JMAP[K, V]</code>, where <code>JMAP</code> is a subtype of <code>java.util.SortedMap</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * val javaMap = new java.util.TreeMap[Int, String]()
+  //DOTTY-ONLY   * javaMap.put(1, "one")
+  //DOTTY-ONLY   * // lowerCased needs to be implemented as Normalization[java.util.Map.Entry[K, V]]
+  //DOTTY-ONLY   * (javaMap should contain inOrderOnly (Entry(1, "ONE"))) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>java.util.Map.Entry[Int, String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Aggregating[java.util.TreeMap[Int, String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>java.util.Map.Entry[K, V]</code>
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>java.util.SortedMap</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>java.util.SortedMap</code>
+  //DOTTY-ONLY   * @tparam JMAP subtype of <code>java.util.SortedMap</code>
+  //DOTTY-ONLY   * @return <code>Sequencing</code> of type <code>JMAP[K, V]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityJavaSortedMapSequencing[K, V, JMAP[k, v] <: java.util.SortedMap[k, v]]: Conversion[Equality[java.util.Map.Entry[K, V]], Sequencing[JMAP[K, V]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[java.util.Map.Entry[K, V]]): Sequencing[JMAP[K, V]] = convertEqualityToJavaSortedMapSequencing(equality)
+  //DOTTY-ONLY }  
 
   /**
+   // SKIP-DOTTY-START
    * Implicit to support <code>Sequencing</code> nature of <code>String</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * To support <code>Sequencing</code> nature of <code>String</code>.
    *
    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of <code>Char</code> in the <code>String</code>
    * @return <code>Sequencing[String]</code> that supports <code>String</code> in relevant <code>contain</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sequencingNatureOfString(implicit equality: Equality[Char]): Sequencing[String] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sequencingNatureOfString(implicit equality: Equality[Char]): Sequencing[String] = 
+    convertEqualityToStringSequencing(equality)
+
+  /**
+   // SKIP-DOTTY-START
+   * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Char</code>
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Char</code>
+   * into <code>Sequencing</code> of type <code>String</code>.
+   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+   *
+   * <pre class="stHighlight">
+   * // lowerCased needs to be implemented as Normalization[Char]
+   * ("hi hello" should contain inOrderOnly ('E')) (after being lowerCased)
+   * </pre>
+   *
+   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[Char]</code></a>
+   * and this implicit conversion will convert it into <code>Sequencing[String]</code>.
+   *
+   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Char</code>
+   * @return <code>Sequencing</code> of type <code>String</code>
+   */
+  // SKIP-DOTTY-START
+  implicit def convertEqualityToStringSequencing(equality: Equality[Char]): Sequencing[String] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToStringSequencing(equality: Equality[Char]): Sequencing[String] = 
     new Sequencing[String] {
 
       def containsInOrder(s: String, elements: scala.collection.Seq[Any]): Boolean = {
@@ -556,24 +894,33 @@ object Sequencing {
       }
     }
 
-  /**
-   * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Char</code>
-   * into <code>Sequencing</code> of type <code>String</code>.
-   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
-   *
-   * <pre class="stHighlight">
-   * // lowerCased needs to be implemented as Normalization[Char]
-   * ("hi hello" should contain inOrderOnly ('E')) (after being lowerCased)
-   * </pre>
-   *
-   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[Char]</code></a>
-   * and this implicit conversion will convert it into <code>Sequencing[String]</code>.
-   *
-   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Char</code>
-   * @return <code>Sequencing</code> of type <code>String</code>
-   */
-  implicit def convertEqualityToStringSequencing(equality: Equality[Char]): Sequencing[String] = 
-    sequencingNatureOfString(equality)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given to support <code>Sequencing</code> nature of <code>String</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of <code>Char</code> in the <code>String</code>
+  //DOTTY-ONLY   * @return <code>Sequencing[String]</code> that supports <code>String</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given (using equality: Equality[Char]): Sequencing[String] = convertEqualityToStringSequencing(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Char</code>
+  //DOTTY-ONLY   * into <code>Sequencing</code> of type <code>String</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * // lowerCased needs to be implemented as Normalization[Char]
+  //DOTTY-ONLY   * ("hi hello" should contain inOrderOnly ('E')) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[Char]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Sequencing[String]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>Char</code>
+  //DOTTY-ONLY   * @return <code>Sequencing</code> of type <code>String</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityStringSequencing: Conversion[Equality[Char], Sequencing[String]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[Char]): Sequencing[String] = convertEqualityToStringSequencing(equality)
+  //DOTTY-ONLY }
 
   /**
    * Implicit to support <code>Sequencing</code> nature of <code>Every</code>.
@@ -582,18 +929,11 @@ object Sequencing {
    * @tparam E the type of the element in the <code>Every</code>
    * @return <code>Sequencing[Every[E]]</code> that supports <code>Every</code> in relevant <code>contain</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sequencingNatureOfEvery[E](implicit equality: Equality[E]): Sequencing[Every[E]] =
-    new Sequencing[Every[E]] {
-
-      def containsInOrder(every: Every[E], elements: scala.collection.Seq[Any]): Boolean =
-        checkInOrder(every, elements, equality)
-
-      def containsInOrderOnly(every: Every[E], elements: scala.collection.Seq[Any]): Boolean =
-        checkInOrderOnly(every, elements, equality)
-
-      def containsTheSameElementsInOrderAs(every: Every[E], elements: Iterable[Any]): Boolean =
-        checkTheSameElementsInOrderAs[E](every, elements, equality)
-    }
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sequencingNatureOfEvery[E](using equality: Equality[E]): Sequencing[Every[E]] =
+    convertEqualityToEverySequencing(equality)
 
   /**
    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
@@ -611,7 +951,49 @@ object Sequencing {
    * @tparam E type of elements in the <code>Every</code>
    * @return <code>Sequencing</code> of type <code>Every[E]</code>
    */
+  // SKIP-DOTTY-START
   implicit def convertEqualityToEverySequencing[E](equality: Equality[E]): Sequencing[Every[E]] =
-    sequencingNatureOfEvery(equality)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToEverySequencing[E](equality: Equality[E]): Sequencing[Every[E]] =
+    new Sequencing[Every[E]] {
+
+      def containsInOrder(every: Every[E], elements: scala.collection.Seq[Any]): Boolean =
+        checkInOrder(every, elements, equality)
+
+      def containsInOrderOnly(every: Every[E], elements: scala.collection.Seq[Any]): Boolean =
+        checkInOrderOnly(every, elements, equality)
+
+      def containsTheSameElementsInOrderAs(every: Every[E], elements: Iterable[Any]): Boolean =
+        checkTheSameElementsInOrderAs[E](every, elements, equality)
+    }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given <code>Sequencing</code> nature of <code>Every</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of element in the <code>Every</code>
+  //DOTTY-ONLY   * @tparam E the type of the element in the <code>Every</code>
+  //DOTTY-ONLY   * @return <code>Sequencing[Every[E]]</code> that supports <code>Every</code> in relevant <code>contain</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [E] (using equality: Equality[E]): Sequencing[Every[E]] = convertEqualityToEverySequencing(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * into <code>Sequencing</code> of type <code>Every[E]</code>.
+  //DOTTY-ONLY   * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <pre class="stHighlight">
+  //DOTTY-ONLY   * (Every("hi", "he") should contain inOrderOnly ("HI", "HE")) (after being lowerCased)
+  //DOTTY-ONLY   * </pre>
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY   * and this implicit conversion will convert it into <code>Sequencing[Every[String]]</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>E</code>
+  //DOTTY-ONLY   * @tparam E type of elements in the <code>Every</code>
+  //DOTTY-ONLY   * @return <code>Sequencing</code> of type <code>Every[E]</code>
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given equalityEverySequencing[E]: Conversion[Equality[E], Sequencing[Every[E]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[E]): Sequencing[Every[E]] = convertEqualityToEverySequencing(equality)
+  //DOTTY-ONLY }  
     
 }

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Sequencing.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Sequencing.scala
@@ -493,7 +493,7 @@ object Sequencing {
   implicit def sequencingNatureOfArray[E](implicit equality: Equality[E]): Sequencing[Array[E]] = 
   // SKIP-DOTTY-END
   //DOTTY-ONLY def sequencingNatureOfArray[E](implicit equality: Equality[E]): Sequencing[Array[E]] = 
-    sequencingNatureOfArray(equality)
+    convertEqualityToArraySequencing(equality)
 
   /**
    // SKIP-DOTTY-START

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Size.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Size.scala
@@ -119,18 +119,20 @@ trait Size[T] {
  */
 object Size {
 
-  //DOTTY-ONLY import scala.reflect.Selectable.reflectiveSelectable
-
   /**
    * Enable <code>Size</code> implementation for <code>java.util.Collection</code>
    *
    * @tparam JCOL any subtype of <code>java.util.Collection</code>
    * @return <code>Size[JCOL]</code> that supports <code>java.util.Collection</code> in <code>have size</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sizeOfJavaCollection[JCOL <: java.util.Collection[_]]: Size[JCOL] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sizeOfJavaCollection[JCOL <: java.util.Collection[_]]: Size[JCOL] = 
     new Size[JCOL] {
       def sizeOf(javaColl: JCOL): Long = javaColl.size
     }
+  //DOTTY-ONLY given [JCOL <: java.util.Collection[_]]: Size[JCOL] = sizeOfJavaCollection
 
   /**
    * Enable <code>Size</code> implementation for <code>java.util.Map</code>
@@ -138,10 +140,14 @@ object Size {
    * @tparam JMAP any subtype of <code>java.util.Map</code>
    * @return <code>Size[JMAP]</code> that supports <code>java.util.Map</code> in <code>have size</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sizeOfJavaMap[JMAP <: java.util.Map[_, _]]: Size[JMAP] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sizeOfJavaMap[JMAP <: java.util.Map[_, _]]: Size[JMAP] = 
     new Size[JMAP] {
       def sizeOf(javaMap: JMAP): Long = javaMap.size
     }
+  //DOTTY-ONLY given [JMAP <: java.util.Map[_, _]]: Size[JMAP] = sizeOfJavaMap
 
   /**
    * Enable <code>Size</code> implementation for <code>org.scalactic.ColCompatHelper.Iterable</code>
@@ -149,10 +155,14 @@ object Size {
    * @tparam ITR any subtype of <code>org.scalactic.ColCompatHelper.Iterable</code>
    * @return <code>Size[ITR]</code> that supports <code>org.scalactic.ColCompatHelper.Iterable</code> in <code>have size</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sizeOfIterable[ITR <: Iterable[_]]: Size[ITR] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sizeOfIterable[ITR <: Iterable[_]]: Size[ITR] = 
     new Size[ITR] {
       def sizeOf(itr: ITR): Long = itr.size
     }
+  //DOTTY-ONLY given [ITR <: Iterable[_]]: Size[ITR] = sizeOfIterable
 
   /**
    * Enable <code>Size</code> implementation for <code>Array</code>
@@ -160,20 +170,28 @@ object Size {
    * @tparam E the type of the element in the <code>Array</code>
    * @return <code>Size[Array[E]]</code> that supports <code>Array</code> in <code>have size</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sizeOfArray[E]: Size[Array[E]] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sizeOfArray[E]: Size[Array[E]] = 
     new Size[Array[E]] {
       def sizeOf(arr: Array[E]): Long = arr.length
     }
+  //DOTTY-ONLY given [E]: Size[Array[E]] = sizeOfArray
 
   /**
    * Enable <code>Size</code> implementation for <code>String</code>
    *
    * @return <code>Size[String]</code> that supports <code>String</code> in <code>have size</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit val sizeOfString: Size[String] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY val sizeOfString: Size[String] = 
     new Size[String] {
       def sizeOf(str: String): Long = str.length
     }
+  //DOTTY-ONLY given Size[String] = sizeOfString
 
   import scala.language.reflectiveCalls
 
@@ -183,10 +201,14 @@ object Size {
    * @tparam T any type with <code>size()</code> method that returns <code>Int</code>
    * @return <code>Size[T]</code> that supports <code>T</code> in <code>have size</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sizeOfAnyRefWithSizeMethodForInt[T <: AnyRef { def size(): Int}]: Size[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sizeOfAnyRefWithSizeMethodForInt[T <: AnyRef { def size(): Int}]: Size[T] = 
     new Size[T] {
       def sizeOf(obj: T): Long = obj.size()
     }
+  //DOTTY-ONLY given given_sizeOfAnyRefWithSizeMethodForInt[T <: AnyRef { def size(): Int}]: Size[T] = sizeOfAnyRefWithSizeMethodForInt
 
   /**
    * Enable <code>Size</code> implementation for arbitary object with parameterless <code>size</code> method that returns <code>Int</code>.
@@ -194,10 +216,14 @@ object Size {
    * @tparam T any type with parameterless <code>size</code> method that returns <code>Int</code>
    * @return <code>Size[T]</code> that supports <code>T</code> in <code>have size</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sizeOfAnyRefWithParameterlessSizeMethodForInt[T <: AnyRef { def size: Int}]: Size[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sizeOfAnyRefWithParameterlessSizeMethodForInt[T <: AnyRef { def size: Int}]: Size[T] = 
     new Size[T] {
       def sizeOf(obj: T): Long = obj.size
     }
+  //DOTTY-ONLY given given_sizeOfAnyRefWithParameterlessSizeMethodForInt[T <: AnyRef { def size: Int}]: Size[T] = sizeOfAnyRefWithParameterlessSizeMethodForInt  
 
   /**
    * Enable <code>Size</code> implementation for arbitary object with <code>getSize()</code> method that returns <code>Int</code>.
@@ -205,10 +231,14 @@ object Size {
    * @tparam T any type with <code>getSize()</code> method that returns <code>Int</code>
    * @return <code>Size[T]</code> that supports <code>T</code> in <code>have size</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sizeOfAnyRefWithGetSizeMethodForInt[T <: AnyRef { def getSize(): Int}]: Size[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sizeOfAnyRefWithGetSizeMethodForInt[T <: AnyRef { def getSize(): Int}]: Size[T] = 
     new Size[T] {
       def sizeOf(obj: T): Long = obj.getSize()
     }
+  //DOTTY-ONLY given given_sizeOfAnyRefWithGetSizeMethodForInt[T <: AnyRef { def getSize(): Int}]: Size[T] = sizeOfAnyRefWithGetSizeMethodForInt  
 
   /**
    * Enable <code>Size</code> implementation for arbitary object with parameterless <code>getSize</code> method that returns <code>Int</code>.
@@ -216,10 +246,14 @@ object Size {
    * @tparam T any type with parameterless <code>getSize</code> method that returns <code>Int</code>
    * @return <code>Size[T]</code> that supports <code>T</code> in <code>have size</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sizeOfAnyRefWithParameterlessGetSizeMethodForInt[T <: AnyRef { def getSize: Int}]: Size[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sizeOfAnyRefWithParameterlessGetSizeMethodForInt[T <: AnyRef { def getSize: Int}]: Size[T] = 
     new Size[T] {
       def sizeOf(obj: T): Long = obj.getSize
     }
+  //DOTTY-ONLY given given_sizeOfAnyRefWithParameterlessGetSizeMethodForInt[T <: AnyRef { def getSize: Int}]: Size[T] = sizeOfAnyRefWithParameterlessGetSizeMethodForInt  
 
   /**
    * Enable <code>Size</code> implementation for arbitary object with <code>size()</code> method that returns <code>Long</code>.
@@ -227,10 +261,14 @@ object Size {
    * @tparam T any type with <code>size()</code> method that returns <code>Long</code>
    * @return <code>Size[T]</code> that supports <code>T</code> in <code>have size</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sizeOfAnyRefWithSizeMethodForLong[T <: AnyRef { def size(): Long}]: Size[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sizeOfAnyRefWithSizeMethodForLong[T <: AnyRef { def size(): Long}]: Size[T] = 
     new Size[T] {
       def sizeOf(obj: T): Long = obj.size()
     }
+  //DOTTY-ONLY given given_sizeOfAnyRefWithSizeMethodForLong[T <: AnyRef { def size(): Long}]: Size[T] = sizeOfAnyRefWithSizeMethodForLong   
 
   /**
    * Enable <code>Size</code> implementation for arbitary object with parameterless <code>size</code> method that returns <code>Long</code>.
@@ -238,10 +276,14 @@ object Size {
    * @tparam T any type with parameterless <code>size</code> method that returns <code>Long</code>
    * @return <code>Size[T]</code> that supports <code>T</code> in <code>have size</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sizeOfAnyRefWithParameterlessSizeMethodForLong[T <: AnyRef { def size: Long}]: Size[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sizeOfAnyRefWithParameterlessSizeMethodForLong[T <: AnyRef { def size: Long}]: Size[T] = 
     new Size[T] {
       def sizeOf(obj: T): Long = obj.size
     }
+  //DOTTY-ONLY given given_sizeOfAnyRefWithParameterlessSizeMethodForLong[T <: AnyRef { def size: Long}]: Size[T] = sizeOfAnyRefWithParameterlessSizeMethodForLong   
 
   /**
    * Enable <code>Size</code> implementation for arbitary object with <code>getSize()</code> method that returns <code>Long</code>.
@@ -249,10 +291,14 @@ object Size {
    * @tparam T any type with <code>getSize()</code> method that returns <code>Long</code>
    * @return <code>Size[T]</code> that supports <code>T</code> in <code>have size</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sizeOfAnyRefWithGetSizeMethodForLong[T <: AnyRef { def getSize(): Long}]: Size[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sizeOfAnyRefWithGetSizeMethodForLong[T <: AnyRef { def getSize(): Long}]: Size[T] = 
     new Size[T] {
       def sizeOf(obj: T): Long = obj.getSize()
     }
+  //DOTTY-ONLY given given_sizeOfAnyRefWithGetSizeMethodForLong[T <: AnyRef { def getSize(): Long}]: Size[T] = sizeOfAnyRefWithGetSizeMethodForLong  
 
   /**
    * Enable <code>Size</code> implementation for arbitary object with <code>getSize</code> method that returns <code>Long</code>.
@@ -260,8 +306,12 @@ object Size {
    * @tparam T any type with <code>getSize</code> method that returns <code>Long</code>
    * @return <code>Size[T]</code> that supports <code>T</code> in <code>have size</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sizeOfAnyRefWithParameterlessGetSizeMethodForLong[T <: AnyRef { def getSize: Long}]: Size[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sizeOfAnyRefWithParameterlessGetSizeMethodForLong[T <: AnyRef { def getSize: Long}]: Size[T] = 
     new Size[T] {
       def sizeOf(obj: T): Long = obj.getSize
     }
+  //DOTTY-ONLY given given_sizeOfAnyRefWithParameterlessGetSizeMethodForLong[T <: AnyRef { def getSize: Long}]: Size[T] = sizeOfAnyRefWithParameterlessGetSizeMethodForLong  
 }

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Slicing.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Slicing.scala
@@ -105,16 +105,23 @@ private[scalatest] trait Slicing[-A] {
 private[scalatest] object Slicing {
 
   /**
+   // SKIP-DOTTY-START
    * Implicit to support <code>Aggregating</code> nature of <code>String</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * To support <code>Aggregating</code> nature of <code>String</code>.
    *
    * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of <code>Char</code> in the <code>String</code>
    * @return <code>Aggregating[String]</code> that supports <code>String</code> in relevant <code>contain</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def slicingNatureOfString: Slicing[String] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def slicingNatureOfString: Slicing[String] = 
     new Slicing[String] {
       def includes(string: String, subString: String): Boolean = string.indexOf(subString) >= 0
       def startsWith(string: String, prefix: String): Boolean = string.startsWith(prefix)
       def endsWith(string: String, suffix: String): Boolean = string.endsWith(suffix)
     }
+  //DOTTY-ONLY given Slicing[String] = slicingNatureOfString
 }
 

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Sortable.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Sortable.scala
@@ -77,7 +77,10 @@ object Sortable {
    * @tparam SEQ any subtype of <code>scala.collection.GenSeq</code>
    * @return <code>Sortable[SEQ[E]]</code> that supports <code>scala.collection.GenSeq</code> in <code>be</code> <code>sortable</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sortableNatureOfSeq[E, SEQ[e] <: scala.collection.GenSeq[e]](implicit ordering: Ordering[E]): Sortable[SEQ[E]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sortableNatureOfSeq[E, SEQ[e] <: scala.collection.GenSeq[e]](using ordering: Ordering[E]): Sortable[SEQ[E]] =
     new Sortable[SEQ[E]] {
       def isSorted(o: SEQ[E]): Boolean =
         if (o.size > 1)
@@ -85,6 +88,7 @@ object Sortable {
         else
           true
     }
+  //DOTTY-ONLY given given_sortableNatureOfSeq[E, SEQ[e] <: scala.collection.GenSeq[e]](using ordering: Ordering[E]): Sortable[SEQ[E]] = sortableNatureOfSeq(using ordering)  
 
   /**
    * Enable <code>Sortable</code> implementation for <code>Array</code>
@@ -93,7 +97,10 @@ object Sortable {
    * @tparam E type of elements in the <code>Array</code>
    * @return <code>Sortable[Array[E]]</code> that supports <code>Array</code> in <code>be</code> <code>sortable</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sortableNatureOfArray[E](implicit ordering: Ordering[E]): Sortable[Array[E]] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sortableNatureOfArray[E](using ordering: Ordering[E]): Sortable[Array[E]] = 
     new Sortable[Array[E]] {
       def isSorted(o: Array[E]): Boolean =
         if (o.length > 1)
@@ -101,6 +108,7 @@ object Sortable {
         else
           true
     }
+  //DOTTY-ONLY given given_sortableNatureOfArray[E](using ordering: Ordering[E]): Sortable[Array[E]] = sortableNatureOfArray(using ordering)  
 
   /**
    * Enable <code>Sortable</code> implementation for <code>String</code>
@@ -108,7 +116,10 @@ object Sortable {
    * @param ordering <code>scala.math.Ordering</code></a> of type <code>Char</code>
    * @return <code>Sortable[String]</code> that supports <code>String</code> in <code>be</code> <code>sortable</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sortableNatureOfString(implicit ordering: Ordering[Char]): Sortable[String] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sortableNatureOfString(using ordering: Ordering[Char]): Sortable[String] = 
     new Sortable[String] {
       def isSorted(o: String): Boolean =
         if (o.length > 1)
@@ -116,6 +127,7 @@ object Sortable {
         else
           true
     }
+  //DOTTY-ONLY given given_sortableNatureOfString(using ordering: Ordering[Char]): Sortable[String] = sortableNatureOfString(using ordering)  
 
   /**
    * Enable <code>Sortable</code> implementation for <code>java.util.List</code>
@@ -125,7 +137,10 @@ object Sortable {
    * @tparam JLIST any subtype of <code>java.util.List</code>
    * @return <code>Sortable[JLIST[E]]</code> that supports <code>java.util.List</code> in <code>be</code> <code>sortable</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def sortableNatureOfJavaList[E, JLIST[e] <: java.util.List[e]](implicit ordering: Ordering[E]): Sortable[JLIST[E]] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sortableNatureOfJavaList[E, JLIST[e] <: java.util.List[e]](using ordering: Ordering[E]): Sortable[JLIST[E]] = 
     new Sortable[JLIST[E]] {
       def isSorted(o: JLIST[E]): Boolean =
         if (o.size > 1)
@@ -133,5 +148,6 @@ object Sortable {
         else
           true
     }
+  //DOTTY-ONLY given given_sortableNatureOfJavaList[E, JLIST[e] <: java.util.List[e]](using ordering: Ordering[E]): Sortable[JLIST[E]] = sortableNatureOfJavaList(using ordering)  
 }
 

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Timed.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Timed.scala
@@ -86,7 +86,10 @@ below:
 */
 
   /**
+   // SKIP-DOTTY-START
    * Implicit method that provides <code>Timed</code> implementation for any <code>T</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * Method that provides <code>Timed</code> implementation for any <code>T</code>.
    *
    * <p>
    * If the function completes <em>before</em> the timeout expires:
@@ -110,7 +113,10 @@ below:
    * This implementation will start a timer that when the time limit is exceeded while the passed in function <code>f</code> is still running, it will attempt to call the passed in <code>Signaler</code> to signal/interrupt the running function <code>f</code>.
    * </p>
    */
+  // SKIP-DOTTY-START
   implicit def timed[T]: Timed[T] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def timed[T]: Timed[T] =
     new Timed[T] {
       def timeoutAfter(
         timeout: Span,
@@ -155,8 +161,13 @@ below:
       }
     }
 
+  //DOTTY-ONLY given given_timed[T]: Timed[T] = timed
+
   /**
+   // SKIP-DOTTY-START
    * Implicit method that provides <code>Timed</code> implementation for any <code>Future[T]</code>.
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY * Method that provides <code>Timed</code> implementation for any <code>Future[T]</code>.
    *
    * <p>
     * If the asynchronous function completes <em>before</em> the timeout expires:
@@ -180,7 +191,10 @@ below:
    * This implementation will start a timer that when the time limit is exceeded while the passed in asynchronous function <code>f</code> is still running, it will attempt to call the passed in <code>Signaler</code> to signal/interrupt the running function <code>f</code>.
    * </p>
    */
+  // SKIP-DOTTY-START
   implicit def timedFutureOf[T](implicit executionContext: ExecutionContext): Timed[Future[T]] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def timedFutureOf[T](using executionContext: ExecutionContext): Timed[Future[T]] =
     new Timed[Future[T]] {
       def timeoutAfter(
                         timeout: Span,
@@ -249,6 +263,8 @@ below:
       }
     }
 
+  //DOTTY-ONLY given given_timedFutureOf[T](using executionContext: ExecutionContext): Timed[Future[T]] = timedFutureOf(using executionContext)
+
   /*
   Chee Seng: This one should catch TestCanceledException and change it into
   a Canceled. It should catch TestPendingException and change it into
@@ -284,7 +300,10 @@ below:
     * This implementation will start a timer that when the time limit is exceeded while the passed in asynchronous function <code>f</code> is still running, it will attempt to call the passed in <code>Signaler</code> to signal/interrupt the running function <code>f</code>.
     * </p>
     */
+  // SKIP-DOTTY-START
   implicit def timedFutureOutcome(implicit executionContext: ExecutionContext): Timed[FutureOutcome] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def timedFutureOutcome(using executionContext: ExecutionContext): Timed[FutureOutcome] =
     new Timed[FutureOutcome] {
       def timeoutAfter(
                         timeout: Span,
@@ -340,4 +359,6 @@ below:
         futureOutcome
       }
     }
+
+  //DOTTY-ONLY given given_timedFutureOutcome(using executionContext: ExecutionContext): Timed[FutureOutcome] = timedFutureOutcome(using executionContext)
 }

--- a/jvm/core/src/main/scala/org/scalatest/enablers/ValueMapping.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/ValueMapping.scala
@@ -72,18 +72,21 @@ object ValueMapping {
    * @tparam MAP any subtype of <code>scala.collection.GenMap</code>
    * @return <code>ValueMapping[MAP[K, V]]</code> that supports <code>scala.collection.GenMap</code> in <code>contain value</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def valueMappingNatureOfGenMap[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](implicit equality: Equality[V]): ValueMapping[MAP[K, V]] = 
-    new ValueMapping[MAP[K, V]] {
-      def containsValue(map: MAP[K, V], value: Any): Boolean = {
-        // map.values.exists((v: V) => equality.areEqual(v, value)) go back to this once I'm off 2.9
-        map.iterator.map(_._2).exists((v: V) => equality.areEqual(v, value))
-      }
-    }
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def valueMappingNatureOfGenMap[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](using equality: Equality[V]): ValueMapping[MAP[K, V]] = 
+    convertEqualityToGenMapValueMapping(equality)
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
+  // SKIP-DOTTY-START
    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>V</code>
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY  * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>V</code>
    * into <code>ValueMapping</code> of type <code>MAP[K, V]</code>, where <code>MAP</code> is a subtype of <code>scala.collection.GenMap</code>.
    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
    *
@@ -100,8 +103,49 @@ object ValueMapping {
    * @tparam MAP any subtype of <code>scala.collection.GenMap</code>
    * @return <code>ValueMapping</code> of type <code>MAP[K, V]</code>
    */
+  // SKIP-DOTTY-START
   implicit def convertEqualityToGenMapValueMapping[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](equality: Equality[V]): ValueMapping[MAP[K, V]] = 
-    valueMappingNatureOfGenMap(equality)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToGenMapValueMapping[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](equality: Equality[V]): ValueMapping[MAP[K, V]] = 
+    new ValueMapping[MAP[K, V]] {
+      def containsValue(map: MAP[K, V], value: Any): Boolean = {
+        // map.values.exists((v: V) => equality.areEqual(v, value)) go back to this once I'm off 2.9
+        map.iterator.map(_._2).exists((v: V) => equality.areEqual(v, value))
+      }
+    }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given <code>ValueMapping</code> implementation for <code>scala.collection.GenMap</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of value in the <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY   * @tparam MAP any subtype of <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY   * @return <code>ValueMapping[MAP[K, V]]</code> that supports <code>scala.collection.GenMap</code> in <code>contain value</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](using equality: Equality[V]): ValueMapping[MAP[K, V]] =  convertEqualityToGenMapValueMapping(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Given conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>V</code>
+  //DOTTY-ONLY  * into <code>ValueMapping</code> of type <code>MAP[K, V]</code>, where <code>MAP</code> is a subtype of <code>scala.collection.GenMap</code>.
+  //DOTTY-ONLY  * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <pre class="stHighlight">
+  //DOTTY-ONLY  * (Map(1 -> "one") should contain value "ONE") (after being lowerCased)
+  //DOTTY-ONLY  * </pre>
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY  * and this implicit conversion will convert it into <code>ValueMapping[Map[Int, String]]</code>.
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>V</code>
+  //DOTTY-ONLY  * @tparam K the type of the key in the <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY  * @tparam V the type of the value in the <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY  * @tparam MAP any subtype of <code>scala.collection.GenMap</code>
+  //DOTTY-ONLY  * @return <code>ValueMapping</code> of type <code>MAP[K, V]</code>
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY given equalityGenMapValueMapping[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]]: Conversion[Equality[V], ValueMapping[MAP[K, V]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[V]): ValueMapping[MAP[K, V]] = convertEqualityToGenMapValueMapping(equality)
+  //DOTTY-ONLY }  
 
   /**
    * Enable <code>ValueMapping</code> implementation for <code>java.util.Map</code>.
@@ -112,15 +156,17 @@ object ValueMapping {
    * @tparam JMAP any subtype of <code>java.util.Map</code>
    * @return <code>ValueMapping[JMAP[K, V]]</code> that supports <code>java.util.Map</code> in <code>contain</code> <code>value</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def valueMappingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]](implicit equality: Equality[V]): ValueMapping[JMAP[K, V]] = 
-    new ValueMapping[JMAP[K, V]] {
-      def containsValue(jMap: JMAP[K, V], value: Any): Boolean = {
-        jMap.asScala.values.exists((v: V) => equality.areEqual(v, value))
-      }
-    }
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def valueMappingNatureOfJavaMap[K, V, JMAP[k, v] <: java.util.Map[k, v]](using equality: Equality[V]): ValueMapping[JMAP[K, V]] = 
+    convertEqualityToJavaMapValueMapping(equality)
 
   /**
+  // SKIP-DOTTY-START
    * Implicit conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>V</code>
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY * Converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>V</code>
    * into <code>ValueMapping</code> of type <code>JMAP[K, V]</code>, where <code>JMAP</code> is a subtype of <code>java.util.Map</code>.
    * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
    *
@@ -139,6 +185,48 @@ object ValueMapping {
    * @tparam JMAP any subtype of <code>java.util.Map</code>
    * @return <code>ValueMapping</code> of type <code>JMAP[K, V]</code>
    */
+  // SKIP-DOTTY-START
   implicit def convertEqualityToJavaMapValueMapping[K, V, JMAP[k, v] <: java.util.Map[k, v]](equality: Equality[V]): ValueMapping[JMAP[K, V]] = 
-    valueMappingNatureOfJavaMap(equality)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEqualityToJavaMapValueMapping[K, V, JMAP[k, v] <: java.util.Map[k, v]](equality: Equality[V]): ValueMapping[JMAP[K, V]] = 
+    new ValueMapping[JMAP[K, V]] {
+      def containsValue(jMap: JMAP[K, V], value: Any): Boolean = {
+        jMap.asScala.values.exists((v: V) => equality.areEqual(v, value))
+      }
+    }
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY   * Given <code>ValueMapping</code> implementation for <code>java.util.Map</code>.
+  //DOTTY-ONLY   *
+  //DOTTY-ONLY   * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> type class that is used to check equality of value in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam K the type of the key in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam V the type of the value in the <code>java.util.Map</code>
+  //DOTTY-ONLY   * @tparam JMAP any subtype of <code>java.util.Map</code>
+  //DOTTY-ONLY   * @return <code>ValueMapping[JMAP[K, V]]</code> that supports <code>java.util.Map</code> in <code>contain</code> <code>value</code> syntax
+  //DOTTY-ONLY   */
+  //DOTTY-ONLY given [K, V, JMAP[k, v] <: java.util.Map[k, v]](using equality: Equality[V]): ValueMapping[JMAP[K, V]] =  convertEqualityToJavaMapValueMapping(equality)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Given conversion that converts an <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>V</code>
+  //DOTTY-ONLY  * into <code>ValueMapping</code> of type <code>JMAP[K, V]</code>, where <code>JMAP</code> is a subtype of <code>java.util.Map</code>.
+  //DOTTY-ONLY  * This is required to support the explicit <a href="../../scalactic/Equality.html"><code>Equality</code></a> syntax, for example:
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <pre class="stHighlight">
+  //DOTTY-ONLY  * val javaMap = new java.util.HashMap[Int, String]()
+  //DOTTY-ONLY  * javaMap.put(1, "one")
+  //DOTTY-ONLY  * (javaMap should contain value "ONE") (after being lowerCased)
+  //DOTTY-ONLY  * </pre>
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <code>(after being lowerCased)</code> will returns an <a href="../../scalactic/Equality.html"><code>Equality[String]</code></a>
+  //DOTTY-ONLY  * and this implicit conversion will convert it into <code>ValueMapping[java.util.HashMap[Int, String]]</code>.
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * @param equality <a href="../../scalactic/Equality.html"><code>Equality</code></a> of type <code>V</code>
+  //DOTTY-ONLY  * @tparam K the type of the key in the <code>java.util.Map</code>
+  //DOTTY-ONLY  * @tparam V the type of the value in the <code>java.util.Map</code>
+  //DOTTY-ONLY  * @tparam JMAP any subtype of <code>java.util.Map</code>
+  //DOTTY-ONLY  * @return <code>ValueMapping</code> of type <code>JMAP[K, V]</code>
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY given equalityJavaMapValueMapping[K, V, JMAP[k, v] <: java.util.Map[k, v]]: Conversion[Equality[V], ValueMapping[JMAP[K, V]]] with {
+  //DOTTY-ONLY   def apply(equality: Equality[V]): ValueMapping[JMAP[K, V]] = convertEqualityToJavaMapValueMapping(equality)
+  //DOTTY-ONLY }  
 }

--- a/jvm/core/src/main/scala/org/scalatest/enablers/WheneverAsserting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/WheneverAsserting.scala
@@ -54,7 +54,10 @@ abstract class UnitWheneverAsserting {
     * but throw [[org.scalatest.exceptions.DiscardedEvaluationException DiscardedEvaluationException]]
     * when check fails.
     */
+  // SKIP-DOTTY-START
   implicit def assertingNatureOfT[T]: WheneverAsserting[T] { type Result = Unit } = {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def assertingNatureOfT[T]: WheneverAsserting[T] { type Result = Unit } = {
     new WheneverAsserting[T] {
       type Result = Unit
       def whenever(condition: Boolean)(fun: => T): Unit =
@@ -64,6 +67,7 @@ abstract class UnitWheneverAsserting {
           fun
     }
   }
+  //DOTTY-ONLY given [T]: WheneverAsserting[T] { type Result = Unit } = assertingNatureOfT
 }
 
 /**
@@ -71,7 +75,10 @@ abstract class UnitWheneverAsserting {
   * that have result type <code>Expectation</code>, a more composable form of assertion that returns a result instead of throwing an exception when it fails.
   */
 abstract class ExpectationWheneverAsserting extends UnitWheneverAsserting {
+  // SKIP-DOTTY-START
   implicit def assertingNatureOfExpectation: WheneverAsserting[Expectation] { type Result = Expectation } = {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def assertingNatureOfExpectation: WheneverAsserting[Expectation] { type Result = Expectation } = {
     new WheneverAsserting[Expectation] {
       type Result = Expectation
       def whenever(condition: Boolean)(fun: => Expectation): Expectation =
@@ -81,7 +88,11 @@ abstract class ExpectationWheneverAsserting extends UnitWheneverAsserting {
          fun
     }
   }
+  //DOTTY-ONLY given WheneverAsserting[Expectation] { type Result = Expectation } = assertingNatureOfExpectation
+  // SKIP-DOTTY-START
   implicit def assertingNatureOfFutureAssertion: WheneverAsserting[Future[Assertion]] { type Result = Future[Assertion] } = {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def assertingNatureOfFutureAssertion: WheneverAsserting[Future[Assertion]] { type Result = Future[Assertion] } = {
     new WheneverAsserting[Future[Assertion]] {
       type Result = Future[Assertion]
       def whenever(condition: Boolean)(fun: => Future[Assertion]): Future[Assertion] =
@@ -91,6 +102,7 @@ abstract class ExpectationWheneverAsserting extends UnitWheneverAsserting {
           fun
     }
   }
+  //DOTTY-ONLY given WheneverAsserting[Future[Assertion]] { type Result = Future[Assertion] } = assertingNatureOfFutureAssertion
 }
 
 /**
@@ -98,8 +110,10 @@ abstract class ExpectationWheneverAsserting extends UnitWheneverAsserting {
   * type <code>Assertion</code>, which also yields result type <code>Assertion</code>, and one for any other type, which yields result type <code>Unit</code>.
   */
 object WheneverAsserting extends ExpectationWheneverAsserting {
-
+  // SKIP-DOTTY-START
   implicit def assertingNatureOfAssertion: WheneverAsserting[Assertion] { type Result = Assertion } = {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def assertingNatureOfAssertion: WheneverAsserting[Assertion] { type Result = Assertion } = {
     new WheneverAsserting[Assertion] {
       type Result = Assertion
       def whenever(condition: Boolean)(fun: => Assertion): Assertion =
@@ -109,4 +123,5 @@ object WheneverAsserting extends ExpectationWheneverAsserting {
           fun
     }
   }
+  //DOTTY-ONLY given WheneverAsserting[Assertion] { type Result = Assertion } = assertingNatureOfAssertion
 }

--- a/jvm/core/src/main/scala/org/scalatest/enablers/Writability.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/Writability.scala
@@ -57,18 +57,20 @@ trait Writability[-T] {
  */
 object Writability {
 
-  //DOTTY-ONLY import scala.reflect.Selectable.reflectiveSelectable
-
   /**
    * Enable <code>Writability</code> implementation for <code>java.io.File</code>.
    *
    * @tparam FILE any subtype of <code>java.io.File</code>
    * @return <code>Writability[FILE]</code> that supports <code>java.io.File</code> in <code>be</code> <code>writable</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def writabilityOfFile[FILE <: java.io.File]: Writability[FILE] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def writabilityOfFile[FILE <: java.io.File]: Writability[FILE] =
     new Writability[FILE] {
       def isWritable(file: FILE): Boolean = file.canWrite
     }
+  //DOTTY-ONLY given [FILE <: java.io.File]: Writability[FILE] = writabilityOfFile  
 
   import scala.language.reflectiveCalls
 
@@ -78,10 +80,14 @@ object Writability {
    * @tparam T any type that has a <code>isWritable()</code> method that returns <code>Boolean</code>
    * @return <code>Writability[T]</code> that supports <code>T</code> in <code>be</code> <code>writable</code> syntax
    */
+  // SKIP-DOTTY-START 
   implicit def writabilityOfAnyRefWithIsWritableMethod[T <: AnyRef { def isWritable(): Boolean}]: Writability[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def writabilityOfAnyRefWithIsWritableMethod[T <: AnyRef { def isWritable(): Boolean}]: Writability[T] = 
     new Writability[T] {
       def isWritable(obj: T): Boolean = obj.isWritable()
     }
+  //DOTTY-ONLY given given_writabilityOfAnyRefWithIsWritableMethod[T <: AnyRef { def isWritable(): Boolean}]: Writability[T] = writabilityOfAnyRefWithIsWritableMethod
 
   /**
    * Enable <code>Writability</code> implementation for any arbitrary object with a parameterless <code>isWritable</code> method that returns <code>Boolean</code>
@@ -89,9 +95,13 @@ object Writability {
    * @tparam T any type that has a parameterless <code>isWritable</code> method that returns <code>Boolean</code>
    * @return <code>Writability[T]</code> that supports <code>T</code> in <code>be</code> <code>writable</code> syntax
    */
+  // SKIP-DOTTY-START
   implicit def writabilityOfAnyRefWithParameterlessIsWritableMethod[T <: AnyRef { def isWritable: Boolean}]: Writability[T] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def writabilityOfAnyRefWithParameterlessIsWritableMethod[T <: AnyRef { def isWritable: Boolean}]: Writability[T] = 
     new Writability[T] {
       def isWritable(obj: T): Boolean = obj.isWritable
     }
+  //DOTTY-ONLY given given_writabilityOfAnyRefWithParameterlessIsWritableMethod[T <: AnyRef { def isWritable: Boolean}]: Writability[T] = writabilityOfAnyRefWithParameterlessIsWritableMethod  
 }
 

--- a/jvm/core/src/main/scala/org/scalatest/time/Span.scala
+++ b/jvm/core/src/main/scala/org/scalatest/time/Span.scala
@@ -716,12 +716,28 @@ object Span {
       case _ => Span.Max // Duration.Inf and Undefined
     }
   }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Given conversion that converts a <code>scala.concurrent.duration.FiniteDuration</code> to a <code>Span</code>,
+  //DOTTY-ONLY  * so that a <code>FiniteDuration</code> can be used where a <code>Span</code> is needed.
+  //DOTTY-ONLY  */
   //DOTTY-ONLY given Conversion[Duration, Span] = convertDurationToSpan
 
   /**
+   // SKIP-DOTTY-START
    * Implicitly converts a <code>Span</code> to a <code>scala.concurrent.duration.FiniteDuration</code>,
+   // SKIP-DOTTY-END
+    //DOTTY-ONLY  * Converts a <code>Span</code> to a <code>scala.concurrent.duration.FiniteDuration</code>,
    * so that a <code>Span</code> can be used where a <code>FiniteDuration</code> is needed.
    */
-  implicit def convertSpanToDuration(span: Span): FiniteDuration = Duration.fromNanos(span.totalNanos)
+  // SKIP-DOTTY-START
+  implicit def convertSpanToDuration(span: Span): FiniteDuration = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertSpanToDuration(span: Span): FiniteDuration = 
+    Duration.fromNanos(span.totalNanos)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Given conversion that converts a <code>Span</code> to a <code>scala.concurrent.duration.FiniteDuration</code>,
+  //DOTTY-ONLY  * so that a <code>Span</code> can be used where a <code>FiniteDuration</code> is needed.
+  //DOTTY-ONLY  */  
+  //DOTTY-ONLY given Conversion[Span, FiniteDuration] = convertSpanToDuration
 }
 

--- a/jvm/expectations/src/main/scala/org/scalatest/expectations/Expectations.scala
+++ b/jvm/expectations/src/main/scala/org/scalatest/expectations/Expectations.scala
@@ -238,25 +238,47 @@ trait Expectations {
    */
   def expectTypeError(code: String)(implicit prettifier: Prettifier, pos: source.Position): Fact = macro CompileMacro.expectTypeErrorImpl
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
+   // SKIP-DOTTY-START
    * Implicitly converts a boolean expression to a [[Fact]] for assertion purposes, which makes (x &gt; 0) implies expect(x &gt; -1) syntax works
+   // SKIP-DOTTY-END
+  //DOTTY-ONLY  * Converts a boolean expression to a [[Fact]] for assertion purposes, which makes (x &gt; 0) implies expect(x &gt; -1) syntax works
    *
    * @param expression the boolean expression to be evaluated
    * @param prettifier the prettifier used to pretty-print the values
    * @param pos the source position
    * @return a [[Fact]] representing the result of the assertion
-   */  
+   */
+  // SKIP-DOTTY-START    
   implicit def booleanToFact(expression: Boolean)(implicit prettifier: Prettifier, pos: source.Position): Fact = macro ExpectationsMacro.expect
-  
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def booleanToFact(expression: Boolean)(implicit prettifier: Prettifier, pos: source.Position): Fact = macro ExpectationsMacro.expect
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Given conversion that converts a boolean expression to a [[Fact]] for assertion purposes, which makes (x &gt; 0) implies expect(x &gt; -1) syntax works
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY given Conversion[Boolean, Fact] = booleanToFact
+
   /**
+   // SKIP-DOTTY-START
    * Implicitly converts an [[Expectation]] to an [[Assertion]].
+   // SKIP-DOTTY-END
+  //DOTTY-ONLY  * Converts an [[Expectation]] to an [[Assertion]].
    *
    * @param exp the expectation to be converted
    * @return an [[Assertion]] representing the result of the expectation
    */
+  // SKIP-DOTTY-END 
   implicit def convertExpectationToAssertion(exp: Expectation): Assertion = exp.toAssertion
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertExpectationToAssertion(exp: Expectation): Assertion = exp.toAssertion
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Given conversion that converts an [[Expectation]] to an [[Assertion]].
+  //DOTTY-ONLY  */  
+  //DOTTY-ONLY given Conversion[Expectation, Assertion] = convertExpectationToAssertion
 }
 
 

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecLike.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecLike.scala
@@ -472,7 +472,9 @@ trait FixtureAnyFeatureSpecLike extends org.scalatest.FixtureTestSuite with Info
    */
   protected def ScenariosFor(unit: Unit): Unit = {}
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
    * Implicitly converts a function that takes no parameters and results in <code>PendingStatement</code> to
@@ -487,9 +489,25 @@ trait FixtureAnyFeatureSpecLike extends org.scalatest.FixtureTestSuite with Info
    * @param f a function
    * @return a function of <code>FixtureParam => Any</code>
    */
+  // SKIP-DOTTY-START    
   protected implicit def convertPendingToFixtureFunction(f: => PendingStatement): FixtureParam => Any /* Assertion */ = {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected def convertPendingToFixtureFunction(f: => PendingStatement): FixtureParam => Any /* Assertion */ = {
     fixture => { f; Succeeded }
   }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Given conversion that converts a function that takes no parameters and results in <code>PendingStatement</code> to
+  //DOTTY-ONLY  * a function from <code>FixtureParam</code> to <code>Any</code>, to enable pending tests to registered as by-name parameters
+  //DOTTY-ONLY  * by methods that require a test function that takes a <code>FixtureParam</code>.
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <p>
+  //DOTTY-ONLY  * This method makes it possible to write pending tests as simply <code>(pending)</code>, without needing
+  //DOTTY-ONLY  * to write <code>(fixture => pending)</code>.
+  //DOTTY-ONLY  * </p>
+  //DOTTY-ONLY  * @param f a function
+  //DOTTY-ONLY  * @return a function of <code>FixtureParam => Any</code>
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY given Conversion[PendingStatement, FixtureParam => Any /* Assertion */] = convertPendingToFixtureFunction
 
   // I need this implicit because the function is passed to scenario as the 2nd parameter list, and
   // I can't overload on that. I could if I took the ScenarioWord approach, but that has possibly a worse

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecLike.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAnyFeatureSpecLike.scala
@@ -477,7 +477,10 @@ trait FixtureAnyFeatureSpecLike extends org.scalatest.FixtureTestSuite with Info
   // SKIP-DOTTY-END
 
   /**
+  // SKIP-DOTTY-START
    * Implicitly converts a function that takes no parameters and results in <code>PendingStatement</code> to
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY * Converts a function that takes no parameters and results in <code>PendingStatement</code> to
    * a function from <code>FixtureParam</code> to <code>Any</code>, to enable pending tests to registered as by-name parameters
    * by methods that require a test function that takes a <code>FixtureParam</code>.
    *

--- a/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLike.scala
+++ b/jvm/featurespec/src/main/scala/org/scalatest/featurespec/FixtureAsyncFeatureSpecLike.scala
@@ -437,10 +437,15 @@ trait FixtureAsyncFeatureSpecLike extends org.scalatest.FixtureAsyncTestSuite wi
    */
   protected def ScenariosFor(unit: Unit): Unit = {}
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
+  // SKIP-DOTTY-START
    * Implicitly converts a function that takes no parameters and results in <code>PendingStatement</code> to
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY * Converts a function that takes no parameters and results in <code>PendingStatement</code> to
    * a function from <code>FixtureParam</code> to <code>Any</code>, to enable pending tests to registered as by-name parameters
    * by methods that require a test function that takes a <code>FixtureParam</code>.
    *
@@ -452,9 +457,26 @@ trait FixtureAsyncFeatureSpecLike extends org.scalatest.FixtureAsyncTestSuite wi
    * @param f a function
    * @return a function of <code>FixtureParam => Any</code>
    */
+  // SKIP-DOTTY-START
   protected implicit def convertPendingToFixtureFunction(f: => PendingStatement): FixtureParam => compatible.Assertion = {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected def convertPendingToFixtureFunction(f: => PendingStatement): FixtureParam => compatible.Assertion = {
     fixture => { f; Succeeded }
   }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Given conversion that converts a function takes no parameters and results in <code>PendingStatement</code> to
+  //DOTTY-ONLY  * a function from <code>FixtureParam</code> to <code>Any</code>, to enable pending tests to registered as by-name parameters
+  //DOTTY-ONLY  * by methods that require a test function that takes a <code>FixtureParam</code>.
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <p>
+  //DOTTY-ONLY  * This method makes it possible to write pending tests as simply <code>(pending)</code>, without needing
+  //DOTTY-ONLY  * to write <code>(fixture => pending)</code>.
+  //DOTTY-ONLY  * </p>
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * @param f a function
+  //DOTTY-ONLY  * @return a function of <code>FixtureParam => Any</code>
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY given Conversion[PendingStatement, FixtureParam => compatible.Assertion] = convertPendingToFixtureFunction
 
   // I need this implicit because the function is passed to scenario as the 2nd parameter list, and
   // I can't overload on that. I could if I took the ScenarioWord approach, but that has possibly a worse

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala
@@ -1503,7 +1503,7 @@ trait AnyFlatSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
   protected final class InAndIgnoreMethods(resultOfStringPassedToVerb: ResultOfStringPassedToVerb) {
 
     import resultOfStringPassedToVerb.rest
-import resultOfStringPassedToVerb.verb
+    import resultOfStringPassedToVerb.verb
 
     /**
      * Supports the registration of tests in shorthand form.
@@ -1527,9 +1527,8 @@ import resultOfStringPassedToVerb.verb
       registerTestToRun(verb.trim + " " + rest.trim, "in", List(), () => testFun, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: => Any /* Assertion */): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToRun(verb.trim + " " + rest.trim, "in", List(), () => testFun, pos) }) } 
-    //DOTTY-ONLY }
+    //DOTTY-ONLY def in(testFun: => Any /* Assertion */)(using pos: source.Position): Unit = 
+    //DOTTY-ONLY   registerTestToRun(verb.trim + " " + rest.trim, "in", List(), () => testFun, pos)
 
     /**
      * Supports the registration of ignored tests in shorthand form.
@@ -1593,8 +1592,10 @@ import resultOfStringPassedToVerb.verb
   //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
   //DOTTY-ONLY    * </p>
   //DOTTY-ONLY    */ 
-  //DOTTY-ONLY   inline infix def in(testFun: => Any /* Assertion */)(using pos: source.Position): Unit =
-  //DOTTY-ONLY     convertToInAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)
+  //DOTTY-ONLY   inline infix def in(testFun: => Any /* Assertion */): Unit =
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => 
+  //DOTTY-ONLY       convertToInAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY   /**
   //DOTTY-ONLY     * Supports the registration of tagged, ignored tests in shorthand form.
   //DOTTY-ONLY     *
@@ -1685,9 +1686,8 @@ import resultOfStringPassedToVerb.verb
       registerTestToRun(verb.trim + " " + rest.trim, "in", tagsList, () => testFun, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: => Any /* Assertion */): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToRun(verb.trim + " " + rest.trim, "in", tagsList, () => testFun, pos) }) } 
-    //DOTTY-ONLY }
+    //DOTTY-ONLY def in(testFun: => Any /* Assertion */)(using pos: source.Position): Unit = 
+    //DOTTY-ONLY   registerTestToRun(verb.trim + " " + rest.trim, "in", tagsList, () => testFun, pos)
 
     /**
      * Supports the registration of tagged, ignored tests in shorthand form.
@@ -1751,8 +1751,10 @@ import resultOfStringPassedToVerb.verb
   //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
   //DOTTY-ONLY    * </p>
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   inline infix def in(testFun: => Any /* Assertion */)(using pos: source.Position): Unit =
-  //DOTTY-ONLY     convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)
+  //DOTTY-ONLY   inline infix def in(testFun: => Any /* Assertion */): Unit =
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY   /**
   //DOTTY-ONLY    * Supports the registration of tagged, ignored tests in shorthand form.
   //DOTTY-ONLY    *
@@ -1776,6 +1778,7 @@ import resultOfStringPassedToVerb.verb
   //DOTTY-ONLY     convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)
   //DOTTY-ONLY }
 
+
   /**
    * Supports the shorthand form of test registration.
    *
@@ -1798,7 +1801,7 @@ import resultOfStringPassedToVerb.verb
    * the function, respectively).
    * </p>
    */
-  // SKIP-DOTTY-START 
+  // SKIP-DOTTY-START
   protected implicit val shorthandTestRegistrationFunction: StringVerbStringInvocation =
   // SKIP-DOTTY-END
   //DOTTY-ONLY  protected val shorthandTestRegistrationFunction: StringVerbStringInvocation =

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala
@@ -1524,11 +1524,10 @@ trait AnyFlatSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
      */
     // SKIP-DOTTY-START
     def in(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def in(testFun: => Any /* Assertion */)(using pos: source.Position): Unit = {
       registerTestToRun(verb.trim + " " + rest.trim, "in", List(), () => testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY def in(testFun: => Any /* Assertion */)(using pos: source.Position): Unit = 
-    //DOTTY-ONLY   registerTestToRun(verb.trim + " " + rest.trim, "in", List(), () => testFun, pos)
 
     /**
      * Supports the registration of ignored tests in shorthand form.
@@ -1549,15 +1548,15 @@ trait AnyFlatSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
      */
     // SKIP-DOTTY-START
     def ignore(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def ignore(testFun: => Any /* Assertion */)(using pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + rest.trim, List(), "ignore", () => testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(testFun: => Any /* Assertion */): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToIgnore(verb.trim + " " + rest.trim, List(), "ignore", () => testFun, pos) }) } 
-    //DOTTY-ONLY }
   }
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
   // SKIP-DOTTY-START
@@ -1615,8 +1614,10 @@ trait AnyFlatSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
   //DOTTY-ONLY     * in the main documentation for trait <code>AnyFlatSpec</code>.
   //DOTTY-ONLY     * </p>
   //DOTTY-ONLY     */
-  //DOTTY-ONLY   inline infix def ignore(testFun: => Any /* Assertion */)(using pos: source.Position): Unit =
-  //DOTTY-ONLY     convertToInAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)
+  //DOTTY-ONLY   inline infix def ignore(testFun: => Any /* Assertion */): Unit =
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => 
+  //DOTTY-ONLY       convertToInAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY }
    
   /**
@@ -1709,12 +1710,10 @@ trait AnyFlatSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
      */
     // SKIP-DOTTY-START
     def ignore(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY inline infix def ignore(testFun: => Any /* Assertion */)(using pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + rest.trim, tagsList, "ignore", () => testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(testFun: => Any /* Assertion */): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToIgnore(verb.trim + " " + rest.trim, tagsList, "ignore", () => testFun, pos) }) } 
-    //DOTTY-ONLY }
   }
 
   /**
@@ -1773,8 +1772,10 @@ trait AnyFlatSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
   //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
   //DOTTY-ONLY    * </p>
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   inline infix def ignore(testFun: => Any /* Assertion */)(using pos: source.Position): Unit =
-  //DOTTY-ONLY     convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)
+  //DOTTY-ONLY   inline infix def ignore(testFun: => Any /* Assertion */): Unit =
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY }
 
 

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala
@@ -1561,13 +1561,63 @@ import resultOfStringPassedToVerb.verb
   import scala.language.implicitConversions
 
   /**
+  // SKIP-DOTTY-START
    * Implicitly converts an object of type <code>ResultOfStringPassedToVerb</code> to an
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY  * converts an object of type <code>ResultOfStringPassedToVerb</code> to an
    * <code>InAndIgnoreMethods</code>, to enable <code>in</code> and <code>ignore</code>
    * methods to be invokable on that object.
    */
+  // SKIP-DOTTY-START
   protected implicit def convertToInAndIgnoreMethods(resultOfStringPassedToVerb: ResultOfStringPassedToVerb): InAndIgnoreMethods =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected def convertToInAndIgnoreMethods(resultOfStringPassedToVerb: ResultOfStringPassedToVerb): InAndIgnoreMethods =
     new InAndIgnoreMethods(resultOfStringPassedToVerb)
+  
 
+  //DOTTY-ONLY extension (resultOfStringPassedToVerb: ResultOfStringPassedToVerb) {
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of tagged tests in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) in { ... }
+  //DOTTY-ONLY    *                                                                           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of tagged test registration, see the <a href="AnyFlatSpec.html#taggingTests">Tagging tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */ 
+  //DOTTY-ONLY   inline infix def in(testFun: => Any /* Assertion */)(using pos: source.Position): Unit =
+  //DOTTY-ONLY     convertToInAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY     * Supports the registration of tagged, ignored tests in shorthand form.
+  //DOTTY-ONLY     *
+  //DOTTY-ONLY     * <p>
+  //DOTTY-ONLY     * This method supports syntax such as the following:
+  //DOTTY-ONLY     * </p>
+  //DOTTY-ONLY     *
+  //DOTTY-ONLY     * <pre class="stHighlight">
+  //DOTTY-ONLY     * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) ignore { ... }
+  //DOTTY-ONLY     *                                                                           ^
+  //DOTTY-ONLY     * </pre>
+  //DOTTY-ONLY     *
+  //DOTTY-ONLY     * <p>
+  //DOTTY-ONLY     * For examples of ignored test registration, see the <a href="AnyFlatSpec.html#ignoredTests">Ignored tests section</a>
+  //DOTTY-ONLY     * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY     * For examples of tagged test registration, see the <a href="AnyFlatSpec.html#taggingTests">Tagging tests section</a>
+  //DOTTY-ONLY     * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY     * </p>
+  //DOTTY-ONLY     */
+  //DOTTY-ONLY   inline infix def ignore(testFun: => Any /* Assertion */)(using pos: source.Position): Unit =
+  //DOTTY-ONLY     convertToInAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)
+  //DOTTY-ONLY }
+   
   /**
    * Class that supports tagged test registration in shorthand form.
    *
@@ -1669,12 +1719,62 @@ import resultOfStringPassedToVerb.verb
   }
 
   /**
+  // SKIP-DOTTY-START
    * Implicitly converts an object of type <code>ResultOfTaggedAsInvocation</code> to an
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY  * Converts an object of type <code>ResultOfTaggedAsInvocation</code> to an
    * <code>InAndIgnoreMethodsAfterTaggedAs</code>, to enable <code>in</code> and <code>ignore</code>
    * methods to be invokable on that object.
    */
+  // SKIP-DOTTY-START
   protected implicit def convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation: ResultOfTaggedAsInvocation): InAndIgnoreMethodsAfterTaggedAs =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected def convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation: ResultOfTaggedAsInvocation): InAndIgnoreMethodsAfterTaggedAs =
     new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation)
+  
+
+  //DOTTY-ONLY extension (resultOfTaggedAsInvocation: ResultOfTaggedAsInvocation) {
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of tagged tests in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) in { ... }
+  //DOTTY-ONLY    *                                                                           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of tagged test registration, see the <a href="AnyFlatSpec.html#taggingTests">Tagging tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def in(testFun: => Any /* Assertion */)(using pos: source.Position): Unit =
+  //DOTTY-ONLY     convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of tagged, ignored tests in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) ignore { ... }
+  //DOTTY-ONLY    *                                                                           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of ignored test registration, see the <a href="AnyFlatSpec.html#ignoredTests">Ignored tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * For examples of tagged test registration, see the <a href="AnyFlatSpec.html#taggingTests">Tagging tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def ignore(testFun: => Any /* Assertion */)(using pos: source.Position): Unit =
+  //DOTTY-ONLY     convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)
+  //DOTTY-ONLY }
 
   /**
    * Supports the shorthand form of test registration.

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala
@@ -1798,7 +1798,10 @@ import resultOfStringPassedToVerb.verb
    * the function, respectively).
    * </p>
    */
+  // SKIP-DOTTY-START 
   protected implicit val shorthandTestRegistrationFunction: StringVerbStringInvocation =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY  protected val shorthandTestRegistrationFunction: StringVerbStringInvocation =
     new StringVerbStringInvocation {
       def apply(subject: String, verb: String, rest: String, pos: source.Position): ResultOfStringPassedToVerb = {
         // SKIP-SCALATESTJS,NATIVE-START
@@ -1828,6 +1831,7 @@ import resultOfStringPassedToVerb.verb
         }
       }
     }
+  //DOTTY-ONLY given StringVerbStringInvocation = shorthandTestRegistrationFunction  
 
   /**
    * Supports the shorthand form of shared test registration.
@@ -1849,13 +1853,17 @@ import resultOfStringPassedToVerb.verb
    * subject description (the  parameter to the function) and returns a <code>BehaveWord</code>.
    * </p>
    */
+  // SKIP-DOTTY-START
   protected implicit val shorthandSharedTestRegistrationFunction: StringVerbBehaveLikeInvocation =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected val shorthandSharedTestRegistrationFunction: StringVerbBehaveLikeInvocation =
     new StringVerbBehaveLikeInvocation {
       def apply(subject: String, pos: source.Position): BehaveWord = {
         registerFlatBranch(subject, Resources.shouldCannotAppearInsideAnIn, "AnyFlatSpecLike.scala", "apply", 5, 0, Some(pos))
         new BehaveWord
       }
     }
+  //DOTTY-ONLY given StringVerbBehaveLikeInvocation = shorthandSharedTestRegistrationFunction  
 
 // TODO: I got a:
 // runsuite:

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AnyFlatSpecLike.scala
@@ -1683,11 +1683,10 @@ trait AnyFlatSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
      */
     // SKIP-DOTTY-START
     def in(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END  
+    //DOTTY-ONLY def in(testFun: => Any /* Assertion */)(using pos: source.Position): Unit = {
       registerTestToRun(verb.trim + " " + rest.trim, "in", tagsList, () => testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY def in(testFun: => Any /* Assertion */)(using pos: source.Position): Unit = 
-    //DOTTY-ONLY   registerTestToRun(verb.trim + " " + rest.trim, "in", tagsList, () => testFun, pos)
 
     /**
      * Supports the registration of tagged, ignored tests in shorthand form.

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpecLike.scala
@@ -1565,7 +1565,9 @@ import resultOfStringPassedToVerb.verb
     //DOTTY-ONLY }
   }
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
   // SKIP-DOTTY-START

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpecLike.scala
@@ -1568,12 +1568,63 @@ import resultOfStringPassedToVerb.verb
   import scala.language.implicitConversions
 
   /**
+  // SKIP-DOTTY-START
    * Implicitly converts an object of type <code>ResultOfStringPassedToVerb</code> to an
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY  * Converts an object of type <code>ResultOfStringPassedToVerb</code> to an
    * <code>InAndIgnoreMethods</code>, to enable <code>in</code> and <code>ignore</code>
    * methods to be invokable on that object.
    */
+  // SKIP-DOTTY-START 
   protected implicit def convertToInAndIgnoreMethods(resultOfStringPassedToVerb: ResultOfStringPassedToVerb): InAndIgnoreMethods =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected def convertToInAndIgnoreMethods(resultOfStringPassedToVerb: ResultOfStringPassedToVerb): InAndIgnoreMethods =
     new InAndIgnoreMethods(resultOfStringPassedToVerb)
+  
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods for `ResultOfStringPassedToVerb` providing `in` and `ignore` for Dotty.
+  //DOTTY-ONLY  * Enables syntax like `"A Stack" must "pop values" in { ... }` and `"A Stack" must "pop values" ignore { ... }`.
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY extension (resultOfStringPassedToVerb: ResultOfStringPassedToVerb) {
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of tagged tests in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) in { ... }
+  //DOTTY-ONLY    *                                                                           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of tagged test registration, see the <a href="AsyncFlatSpec.html#taggingTests">Tagging tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AsyncFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def in(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of tagged, ignored tests in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) ignore { ... }
+  //DOTTY-ONLY    *                                                                           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of ignored test registration, see the <a href="AsyncFlatSpec.html#ignoredTests">Ignored tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AsyncFlatSpec</code>.
+  //DOTTY-ONLY    * For examples of tagged test registration, see the <a href="AsyncFlatSpec.html#taggingTests">Tagging tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AsyncFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def ignore(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)
+  //DOTTY-ONLY }
 
   /**
    * Class that supports tagged test registration in shorthand form.
@@ -1676,12 +1727,63 @@ import resultOfStringPassedToVerb.verb
   }
 
   /**
+  // SKIP-DOTTY-START
    * Implicitly converts an object of type <code>ResultOfTaggedAsInvocation</code> to an
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY  * Converts an object of type <code>ResultOfTaggedAsInvocation</code> to an
    * <code>InAndIgnoreMethodsAfterTaggedAs</code>, to enable <code>in</code> and <code>ignore</code>
    * methods to be invokable on that object.
    */
+  // SKIP-DOTTY-START
   protected implicit def convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation: ResultOfTaggedAsInvocation): InAndIgnoreMethodsAfterTaggedAs =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected def convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation: ResultOfTaggedAsInvocation): InAndIgnoreMethodsAfterTaggedAs =
     new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods for `ResultOfTaggedAsInvocation` providing `in` and `ignore` for Dotty.
+  //DOTTY-ONLY  * Enables syntax like `"A Stack" must "pop values" taggedAs(SlowTest) in { ... }` and `"A Stack" must "pop values" taggedAs(SlowTest) ignore { ... }`.
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY extension (resultOfTaggedAsInvocation: ResultOfTaggedAsInvocation) {
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY    * Supports the registration of tagged tests in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) in { ... }
+  //DOTTY-ONLY    *                                                                           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of tagged test registration, see the <a href="AsyncFlatSpec.html#taggingTests">Tagging tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AsyncFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def in(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY    * Supports the registration of tagged, ignored tests in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) ignore { ... }
+  //DOTTY-ONLY    *                                                                           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of ignored test registration, see the <a href="AsyncFlatSpec.html#ignoredTests">Ignored tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AsyncFlatSpec</code>.
+  //DOTTY-ONLY    * For examples of tagged test registration, see the <a href="AsyncFlatSpec.html#taggingTests">Tagging tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AsyncFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def ignore(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)
+  //DOTTY-ONLY }
 
   /**
    * Supports the shorthand form of test registration.

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpecLike.scala
@@ -1605,7 +1605,7 @@ import resultOfStringPassedToVerb.verb
   //DOTTY-ONLY    * in the main documentation for trait <code>AsyncFlatSpec</code>.
   //DOTTY-ONLY    * </p>
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   inline infix def in(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)
+  //DOTTY-ONLY   infix def in(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)
   //DOTTY-ONLY   /**
   //DOTTY-ONLY    * Supports the registration of tagged, ignored tests in shorthand form.
   //DOTTY-ONLY    *
@@ -1625,7 +1625,7 @@ import resultOfStringPassedToVerb.verb
   //DOTTY-ONLY    * in the main documentation for trait <code>AsyncFlatSpec</code>.
   //DOTTY-ONLY    * </p>
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   inline infix def ignore(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)
+  //DOTTY-ONLY   infix def ignore(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)
   //DOTTY-ONLY }
 
   /**
@@ -1764,7 +1764,7 @@ import resultOfStringPassedToVerb.verb
   //DOTTY-ONLY    * in the main documentation for trait <code>AsyncFlatSpec</code>.
   //DOTTY-ONLY    * </p>
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   inline infix def in(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)
+  //DOTTY-ONLY   infix def in(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)
   //DOTTY-ONLY /**
   //DOTTY-ONLY    * Supports the registration of tagged, ignored tests in shorthand form.
   //DOTTY-ONLY    *
@@ -1784,7 +1784,7 @@ import resultOfStringPassedToVerb.verb
   //DOTTY-ONLY    * in the main documentation for trait <code>AsyncFlatSpec</code>.
   //DOTTY-ONLY    * </p>
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   inline infix def ignore(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)
+  //DOTTY-ONLY   infix def ignore(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)
   //DOTTY-ONLY }
 
   /**

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpecLike.scala
@@ -1809,7 +1809,10 @@ import resultOfStringPassedToVerb.verb
    * the function, respectively).
    * </p>
    */
+  // SKIP-DOTTY-START 
   protected implicit val shorthandTestRegistrationFunction: StringVerbStringInvocation =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected val shorthandTestRegistrationFunction: StringVerbStringInvocation =
     new StringVerbStringInvocation {
       def apply(subject: String, verb: String, rest: String, pos: source.Position): ResultOfStringPassedToVerb = {
         registerFlatBranch(subject, Resources.shouldCannotAppearInsideAnIn, pos)
@@ -1835,6 +1838,7 @@ import resultOfStringPassedToVerb.verb
         }
       }
     }
+  //DOTTY-ONLY given StringVerbStringInvocation = shorthandTestRegistrationFunction
 
   /**
    * Supports the shorthand form of shared test registration.
@@ -1856,13 +1860,17 @@ import resultOfStringPassedToVerb.verb
    * subject description (the  parameter to the function) and returns a <code>BehaveWord</code>.
    * </p>
    */
+  // SKIP-DOTTY-START 
   protected implicit val shorthandSharedTestRegistrationFunction: StringVerbBehaveLikeInvocation =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected val shorthandSharedTestRegistrationFunction: StringVerbBehaveLikeInvocation =
     new StringVerbBehaveLikeInvocation {
       def apply(subject: String, pos: source.Position): BehaveWord = {
         registerFlatBranch(subject, Resources.shouldCannotAppearInsideAnIn, pos)
         new BehaveWord
       }
     }
+  //DOTTY-ONLY given StringVerbBehaveLikeInvocation = shorthandSharedTestRegistrationFunction  
 
   // TODO: I got a:
   // runsuite:

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/AsyncFlatSpecLike.scala
@@ -1531,12 +1531,10 @@ import resultOfStringPassedToVerb.verb
      */
     // SKIP-DOTTY-START
     def in(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def in(testFun: => Future[compatible.Assertion])(using pos: source.Position): Unit = {
       registerTestToRun(verb.trim + " " + rest.trim, "in", List(), () => testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToRun(verb.trim + " " + rest.trim, "in", List(), () => testFun, pos) }) } 
-    //DOTTY-ONLY }
 
     /**
      * Supports the registration of ignored tests in shorthand form.
@@ -1557,12 +1555,10 @@ import resultOfStringPassedToVerb.verb
      */
     // SKIP-DOTTY-START
     def ignore(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def ignore(testFun: => Future[compatible.Assertion])(using pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + rest.trim, List(), "ignore", () => testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(testFun: => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToIgnore(verb.trim + " " + rest.trim, List(), "ignore", () => testFun, pos) }) } 
-    //DOTTY-ONLY }
   }
 
   // SKIP-DOTTY-START
@@ -1605,7 +1601,10 @@ import resultOfStringPassedToVerb.verb
   //DOTTY-ONLY    * in the main documentation for trait <code>AsyncFlatSpec</code>.
   //DOTTY-ONLY    * </p>
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   infix def in(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)
+  //DOTTY-ONLY   inline infix def in(testFun: => Future[compatible.Assertion]): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       convertToInAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY   /**
   //DOTTY-ONLY    * Supports the registration of tagged, ignored tests in shorthand form.
   //DOTTY-ONLY    *
@@ -1625,7 +1624,10 @@ import resultOfStringPassedToVerb.verb
   //DOTTY-ONLY    * in the main documentation for trait <code>AsyncFlatSpec</code>.
   //DOTTY-ONLY    * </p>
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   infix def ignore(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)
+  //DOTTY-ONLY   inline infix def ignore(testFun: => Future[compatible.Assertion]): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       convertToInAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY }
 
   /**
@@ -1692,12 +1694,10 @@ import resultOfStringPassedToVerb.verb
      */
     // SKIP-DOTTY-START
     def in(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def in(testFun: => Future[compatible.Assertion])(using pos: source.Position): Unit = {
       registerTestToRun(verb.trim + " " + rest.trim, "in", tagsList, () => testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToRun(verb.trim + " " + rest.trim, "in", tagsList, () => testFun, pos) }) } 
-    //DOTTY-ONLY }
 
     /**
      * Supports the registration of tagged, ignored tests in shorthand form.
@@ -1720,12 +1720,10 @@ import resultOfStringPassedToVerb.verb
      */
     // SKIP-DOTTY-START
     def ignore(testFun: => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def ignore(testFun: => Future[compatible.Assertion])(using pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + rest.trim, tagsList, "ignore", () => testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(testFun: => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToIgnore(verb.trim + " " + rest.trim, tagsList, "ignore", () => testFun, pos) }) } 
-    //DOTTY-ONLY }
   }
 
   /**
@@ -1764,7 +1762,10 @@ import resultOfStringPassedToVerb.verb
   //DOTTY-ONLY    * in the main documentation for trait <code>AsyncFlatSpec</code>.
   //DOTTY-ONLY    * </p>
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   infix def in(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)
+  //DOTTY-ONLY   inline infix def in(testFun: => Future[compatible.Assertion]): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY /**
   //DOTTY-ONLY    * Supports the registration of tagged, ignored tests in shorthand form.
   //DOTTY-ONLY    *
@@ -1784,7 +1785,10 @@ import resultOfStringPassedToVerb.verb
   //DOTTY-ONLY    * in the main documentation for trait <code>AsyncFlatSpec</code>.
   //DOTTY-ONLY    * </p>
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   infix def ignore(testFun: => Future[compatible.Assertion]): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)
+  //DOTTY-ONLY   inline infix def ignore(testFun: => Future[compatible.Assertion]): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY }
 
   /**

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpecLike.scala
@@ -2056,17 +2056,112 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
     //DOTTY-ONLY }
   }
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
+  // SKIP-DOTTY-START
    * Implicitly converts an object of type <code>ResultOfStringPassedToVerb</code> to an
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY  * Converts an object of type <code>ResultOfStringPassedToVerb</code> to an 
    * <code>InAndIgnoreMethods</code>, to enable <code>in</code> and <code>ignore</code>
    * methods to be invokable on that object.
    *
    * @param resultOfStringPassedToVerb an <code>ResultOfStringPassedToVerb</code> instance
    */
+  // SKIP-DOTTY-START
   protected implicit def convertToInAndIgnoreMethods(resultOfStringPassedToVerb: ResultOfStringPassedToVerb): InAndIgnoreMethods =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected def convertToInAndIgnoreMethods(resultOfStringPassedToVerb: ResultOfStringPassedToVerb): InAndIgnoreMethods =
     new InAndIgnoreMethods(resultOfStringPassedToVerb)
+  
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods for `ResultOfStringPassedToVerb` providing `in` and `ignore` for Dotty.
+  //DOTTY-ONLY  * Enables syntax like `"A Stack" must "pop values" in { () => ... }` and `"A Stack" must "pop values" ignore { () => ... }`.
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY extension (resultOfStringPassedToVerb: ResultOfStringPassedToVerb) {
+  //DOTTY-ONLY  /**
+  //DOTTY-ONLY    * Supports the registration of no-arg tests in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" in { () => ... }
+  //DOTTY-ONLY    *                                                        ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of test registration, see the <a href="FixtureAnyFlatSpec.html">main documentation</a>
+  //DOTTY-ONLY    * for trait <code>FixtureAnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def in(testFun: () => Any /* Assertion */): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY    * Supports the registration of one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" in { fixture => ... }
+  //DOTTY-ONLY    *                                                        ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of test registration, see the <a href="FixtureAnyFlatSpec.html">main documentation</a>
+  //DOTTY-ONLY    * for trait <code>FixtureAnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def in(testFun: FixtureParam => Any /* Assertion */): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY    * Supports the registration of ignored, no-arg tests in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" ignore { () => ... }
+  //DOTTY-ONLY    *                                                        ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of ignored test registration, see the <a href="AnyFlatSpec.html#IgnoredTests">Ignored tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def ignore(testFun: () => Any /* Assertion */): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY    * Supports the registration of ignored, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" ignore { fixture => ... }
+  //DOTTY-ONLY    *                                                        ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of ignored test registration, see the <a href="AnyFlatSpec.html#IgnoredTests">Ignored tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def ignore(testFun: FixtureParam => Any /* Assertion */): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)
+  //DOTTY-ONLY }
 
   /**
    * Class that supports tagged test registration in shorthand form.
@@ -2248,8 +2343,109 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
    *
    * @param resultOfTaggedAsInvocation an <code>ResultOfTaggedAsInvocation</code> instance
    */
+  /**
+  // SKIP-DOTTY-START
+   * Implicitly converts an object of type `ResultOfTaggedAsInvocation` to an
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY  * Converts an object of type `ResultOfTaggedAsInvocation` to an  
+   * `InAndIgnoreMethodsAfterTaggedAs`, to enable `in` and `ignore` methods to be invokable on that object.
+   */
+  // SKIP-DOTTY-START
   protected implicit def convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation: ResultOfTaggedAsInvocation): InAndIgnoreMethodsAfterTaggedAs =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected def convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation: ResultOfTaggedAsInvocation): InAndIgnoreMethodsAfterTaggedAs =
     new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods for `ResultOfTaggedAsInvocation` providing `in` and `ignore` for Dotty.
+  //DOTTY-ONLY  * Enables syntax like `"A Stack" must "pop values" taggedAs(SlowTest) in { ... }` and `"A Stack" must "pop values" taggedAs(SlowTest) ignore { ... }`.
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY extension (resultOfTaggedAsInvocation: ResultOfTaggedAsInvocation) {
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of tagged, no-arg tests in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) in { () => ... }
+  //DOTTY-ONLY    *                                                                           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of tagged test registration, see the <a href="AnyFlatSpec.html#TaggingTests">Tagging tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def in(testFun: () => Any /* Assertion */): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of tagged, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) in { fixture => ... }
+  //DOTTY-ONLY    *                                                                           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of tagged test registration, see the <a href="AnyFlatSpec.html#TaggingTests">Tagging tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def in(testFun: FixtureParam => Any /* Assertion */): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of tagged, ignored, no-arg tests in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) ignore { () => ... }
+  //DOTTY-ONLY    *                                                                           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of ignored test registration, see the <a href="AnyFlatSpec.html#IgnoredTests">Ignored tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * For examples of tagged test registration, see the <a href="AnyFlatSpec.html#TaggingTests">Tagging tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def ignore(testFun: () => Any /* Assertion */): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of tagged, ignored, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) ignore { fixture => ... }
+  //DOTTY-ONLY    *                                                                           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of ignored test registration, see the <a href="AnyFlatSpec.html#IgnoredTests">Ignored tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * For examples of tagged test registration, see the <a href="AnyFlatSpec.html#TaggingTests">Tagging tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def ignore(testFun: FixtureParam => Any /* Assertion */): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)
+  //DOTTY-ONLY }
 
   /**
    * Supports the shorthand form of test registration.
@@ -2273,7 +2469,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
    * the function, respectively).
    * </p>
    */
+  // SKIP-DOTTY-START 
   protected implicit val shorthandTestRegistrationFunction: StringVerbStringInvocation =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected val shorthandTestRegistrationFunction: StringVerbStringInvocation =
     new StringVerbStringInvocation {
       def apply(subject: String, verb: String, rest: String, pos: source.Position): ResultOfStringPassedToVerb = {
         // SKIP-SCALATESTJS,NATIVE-START
@@ -2300,6 +2499,7 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
         }
       }
     }
+  //DOTTY-ONLY given StringVerbStringInvocation = shorthandTestRegistrationFunction
 
   // TODO: Get rid of unusedfixture, and use NoArgTestFunction instead
 
@@ -2323,14 +2523,18 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
    * subject description (the  parameter to the function) and returns a <code>BehaveWord</code>.
    * </p>
    */
+  // SKIP-DOTTY-START 
   protected implicit val shorthandSharedTestRegistrationFunction: StringVerbBehaveLikeInvocation =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected val shorthandSharedTestRegistrationFunction: StringVerbBehaveLikeInvocation =
     new StringVerbBehaveLikeInvocation {
       def apply(subject: String, pos: source.Position): BehaveWord = {
         registerFlatBranch(subject, Resources.shouldCannotAppearInsideAnIn, sourceFileName, "apply", 5, 0, Some(pos))
         new BehaveWord
       }
     }
-
+  //DOTTY-ONLY given StringVerbBehaveLikeInvocation = shorthandSharedTestRegistrationFunction
+  
   /**
    * Register a test to ignore, which has the given spec text, optional tags, and test function value that takes no arguments.
    * This method will register the test for later ignoring via an invocation of one of the <code>execute</code>

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAnyFlatSpecLike.scala
@@ -1960,12 +1960,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
      */
     // SKIP-DOTTY-START
     def in(testFun: () => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def in(testFun: () => Any /* Assertion */)(using pos: source.Position): Unit = {
       inImpl(testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: () => Any /* Assertion */): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => inImpl(testFun, pos) }) } 
-    //DOTTY-ONLY }
 
     private final def ignoreImpl(testFun: () => Any /* Assertion */, pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + rest.trim, List(), "ignore", new NoArgTestWrapper(testFun), pos)
@@ -1992,12 +1990,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
      */
     // SKIP-DOTTY-START
     def ignore(testFun: () => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def ignore(testFun: () => Any /* Assertion */)(using pos: source.Position): Unit = {
       ignoreImpl(testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(testFun: () => Any /* Assertion */): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => ignoreImpl(testFun, pos) }) } 
-    //DOTTY-ONLY }
 
     /**
      * Supports the registration of one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
@@ -2020,12 +2016,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
      */
     // SKIP-DOTTY-START
     def in(testFun: FixtureParam => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def in(testFun: FixtureParam => Any /* Assertion */)(using pos: source.Position): Unit = {
       registerTestToRun(verb.trim + " " + rest.trim, List(), "in", testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: FixtureParam => Any /* Assertion */): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToRun(verb.trim + " " + rest.trim, List(), "in", testFun, pos) }) } 
-    //DOTTY-ONLY }
 
     /**
      * Supports the registration of ignored, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
@@ -2048,12 +2042,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
      */
     // SKIP-DOTTY-START
     def ignore(testFun: FixtureParam => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def ignore(testFun: FixtureParam => Any /* Assertion */)(using pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + rest.trim, List(), "ignore", testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(testFun: FixtureParam => Any /* Assertion */): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToIgnore(verb.trim + " " + rest.trim, List(), "ignore", testFun, pos) }) } 
-    //DOTTY-ONLY }
   }
 
   // SKIP-DOTTY-START
@@ -2100,7 +2092,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   inline infix def in(testFun: () => Any /* Assertion */): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)
+  //DOTTY-ONLY   inline infix def in(testFun: () => Any /* Assertion */): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       convertToInAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY /**
   //DOTTY-ONLY    * Supports the registration of one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
   //DOTTY-ONLY    *
@@ -2120,7 +2115,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   inline infix def in(testFun: FixtureParam => Any /* Assertion */): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)
+  //DOTTY-ONLY   inline infix def in(testFun: FixtureParam => Any /* Assertion */): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       convertToInAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY /**
   //DOTTY-ONLY    * Supports the registration of ignored, no-arg tests in shorthand form.
   //DOTTY-ONLY    *
@@ -2140,7 +2138,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   inline infix def ignore(testFun: () => Any /* Assertion */): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)
+  //DOTTY-ONLY   inline infix def ignore(testFun: () => Any /* Assertion */): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       convertToInAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY /**
   //DOTTY-ONLY    * Supports the registration of ignored, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
   //DOTTY-ONLY    *
@@ -2160,7 +2161,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   inline infix def ignore(testFun: FixtureParam => Any /* Assertion */): Unit = convertToInAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)
+  //DOTTY-ONLY   inline infix def ignore(testFun: FixtureParam => Any /* Assertion */): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       convertToInAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY }
 
   /**
@@ -2236,12 +2240,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
      */
     // SKIP-DOTTY-START
     def in(testFun: () => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def in(testFun: () => Any /* Assertion */)(using pos: source.Position): Unit = {
       inImpl(testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: () => Any /* Assertion */): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => inImpl(testFun, pos) }) } 
-    //DOTTY-ONLY }
 
     private final def ignoreImpl(testFun: () => Any /* Assertion */, pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + rest.trim, tagsList, "ignore", new NoArgTestWrapper(testFun), pos)
@@ -2270,12 +2272,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
      */
     // SKIP-DOTTY-START
     def ignore(testFun: () => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def ignore(testFun: () => Any /* Assertion */)(using pos: source.Position): Unit = {
       ignoreImpl(testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(testFun: () => Any /* Assertion */): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => ignoreImpl(testFun, pos) }) } 
-    //DOTTY-ONLY }
 
     /**
      * Supports the registration of tagged, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
@@ -2298,12 +2298,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
      */
     // SKIP-DOTTY-START
     def in(testFun: FixtureParam => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def in(testFun: FixtureParam => Any /* Assertion */)(using pos: source.Position): Unit = {
       registerTestToRun(verb.trim + " " + rest.trim, tagsList, "in", testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: FixtureParam => Any /* Assertion */): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToRun(verb.trim + " " + rest.trim, tagsList, "in", testFun, pos) }) } 
-    //DOTTY-ONLY }
 
     /**
      * Supports the registration of tagged, ignored, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
@@ -2328,12 +2326,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
      */
     // SKIP-DOTTY-START
     def ignore(testFun: FixtureParam => Any /* Assertion */)(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def ignore(testFun: FixtureParam => Any /* Assertion */)(using pos: source.Position): Unit = {
       registerTestToIgnore(verb.trim + " " + rest.trim, tagsList, "ignore", testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(testFun: FixtureParam => Any /* Assertion */): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToIgnore(verb.trim + " " + rest.trim, tagsList, "ignore", testFun, pos) }) } 
-    //DOTTY-ONLY }
   }
 
   /**
@@ -2380,7 +2376,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   inline infix def in(testFun: () => Any /* Assertion */): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)
+  //DOTTY-ONLY   inline infix def in(testFun: () => Any /* Assertion */): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY   /**
   //DOTTY-ONLY    * Supports the registration of tagged, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
   //DOTTY-ONLY    *
@@ -2400,7 +2399,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   inline infix def in(testFun: FixtureParam => Any /* Assertion */): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)
+  //DOTTY-ONLY   inline infix def in(testFun: FixtureParam => Any /* Assertion */): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY   /**
   //DOTTY-ONLY    * Supports the registration of tagged, ignored, no-arg tests in shorthand form.
   //DOTTY-ONLY    *
@@ -2422,7 +2424,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   inline infix def ignore(testFun: () => Any /* Assertion */): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)
+  //DOTTY-ONLY   inline infix def ignore(testFun: () => Any /* Assertion */): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY   /**
   //DOTTY-ONLY    * Supports the registration of tagged, ignored, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
   //DOTTY-ONLY    *
@@ -2444,7 +2449,10 @@ trait FixtureAnyFlatSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   inline infix def ignore(testFun: FixtureParam => Any /* Assertion */): Unit = convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)
+  //DOTTY-ONLY   inline infix def ignore(testFun: FixtureParam => Any /* Assertion */): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY }
 
   /**

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLike.scala
@@ -1941,11 +1941,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
      */
     // SKIP-DOTTY-START
     def in(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def in(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = {
       inImpl(testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY infix def in(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-    //DOTTY-ONLY   inImpl(testFun, pos)
 
     private final def ignoreImpl(testFun: () => Future[compatible.Assertion], pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + rest.trim, List(), new NoArgTestWrapper(testFun), pos)
@@ -1972,11 +1971,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
      */
     // SKIP-DOTTY-START
     def ignore(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def ignore(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = {
       ignoreImpl(testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY infix def ignore(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-    //DOTTY-ONLY   ignoreImpl(testFun, pos) 
 
     /**
      * Supports the registration of one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
@@ -1999,11 +1997,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
      */
     // SKIP-DOTTY-START
     def in(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def in(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = {
       registerAsyncTestToRun(verb.trim + " " + rest.trim, List(), "in", testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY infix def in(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-    //DOTTY-ONLY   registerAsyncTestToRun(verb.trim + " " + rest.trim, List(), "in", testFun, pos)
 
     /**
      * Supports the registration of ignored, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
@@ -2026,11 +2023,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
      */
     // SKIP-DOTTY-START
     def ignore(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def ignore(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + rest.trim, List(), testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY infix def ignore(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-    //DOTTY-ONLY   registerAsyncTestToIgnore(verb.trim + " " + rest.trim, List(), testFun, pos)
   }
 
   // SKIP-DOTTY-START
@@ -2077,8 +2073,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   def in(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-  //DOTTY-ONLY     new InAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)(using pos)
+  //DOTTY-ONLY   inline infix def in(testFun: () => Future[compatible.Assertion]): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       new InAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY   /**
   //DOTTY-ONLY    * Supports the registration of ignored, no-arg tests in shorthand form.
   //DOTTY-ONLY    *
@@ -2098,8 +2096,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   def ignore(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-  //DOTTY-ONLY     new InAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)(using pos)
+  //DOTTY-ONLY   inline infix def ignore(testFun: () => Future[compatible.Assertion]): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       new InAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY   /**
   //DOTTY-ONLY    * Supports the registration of one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
   //DOTTY-ONLY    *
@@ -2119,8 +2119,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   def in(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-  //DOTTY-ONLY     new InAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)(using pos)
+  //DOTTY-ONLY   inline infix def in(testFun: FixtureParam => Future[compatible.Assertion]): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       new InAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY   /**
   //DOTTY-ONLY    * Supports the registration of ignored, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
   //DOTTY-ONLY    *
@@ -2140,8 +2142,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   def ignore(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-  //DOTTY-ONLY     new InAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)(using pos)
+  //DOTTY-ONLY   inline infix def ignore(testFun: FixtureParam => Future[compatible.Assertion]): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       new InAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY }  
 
   /**
@@ -2217,11 +2221,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
      */
     // SKIP-DOTTY-START
     def in(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def in(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = {
       inImpl(testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-    //DOTTY-ONLY   inImpl(testFun, pos) 
 
     private final def ignoreImpl(testFun: () => Future[compatible.Assertion], pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + rest.trim, tagsList, new NoArgTestWrapper(testFun), pos)
@@ -2250,11 +2253,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
      */
     // SKIP-DOTTY-START
     def ignore(testFun: () => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
-      ignoreImpl(testFun, pos)
-    }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-    //DOTTY-ONLY   ignoreImpl(testFun, pos) 
+    //DOTTY-ONLY def ignore(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = {
+      ignoreImpl(testFun, pos)
+    } 
 
     /**
      * Supports the registration of tagged, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
@@ -2277,11 +2279,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
      */
     // SKIP-DOTTY-START
     def in(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def in(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = {
       registerAsyncTestToRun(verb.trim + " " + rest.trim, tagsList, "in", testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-    //DOTTY-ONLY   registerAsyncTestToRun(verb.trim + " " + rest.trim, tagsList, "in", testFun, pos)
 
     /**
      * Supports the registration of tagged, ignored, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
@@ -2306,11 +2307,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
      */
     // SKIP-DOTTY-START
     def ignore(testFun: FixtureParam => Future[compatible.Assertion])(implicit pos: source.Position): Unit = {
+    // SKIP-DOTTY-END
+    //DOTTY-ONLY def ignore(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + rest.trim, tagsList, testFun, pos)
     }
-    // SKIP-DOTTY-END
-    //DOTTY-ONLY infix def ignore(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-    //DOTTY-ONLY   registerAsyncTestToIgnore(verb.trim + " " + rest.trim, tagsList, testFun, pos)
   }
 
   /**
@@ -2353,8 +2353,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   def in(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-  //DOTTY-ONLY     new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)(using pos)
+  //DOTTY-ONLY   inline infix def in(testFun: () => Future[compatible.Assertion]): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY   /**
   //DOTTY-ONLY    * Supports the registration of tagged, ignored, no-arg tests in shorthand form.
   //DOTTY-ONLY    *
@@ -2376,8 +2378,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   def ignore(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-  //DOTTY-ONLY     new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)(using pos)
+  //DOTTY-ONLY   inline infix def ignore(testFun: () => Future[compatible.Assertion]): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY   /**
   //DOTTY-ONLY    * Supports the registration of tagged, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
   //DOTTY-ONLY    *
@@ -2397,8 +2401,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   def in(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-  //DOTTY-ONLY     new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)(using pos)
+  //DOTTY-ONLY   inline infix def in(testFun: FixtureParam => Future[compatible.Assertion]): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY   /**
   //DOTTY-ONLY    * Supports the registration of tagged, ignored, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
   //DOTTY-ONLY    *
@@ -2420,8 +2426,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
   //DOTTY-ONLY    *
   //DOTTY-ONLY    * @param testFun the test function
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   def ignore(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
-  //DOTTY-ONLY     new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)(using pos)
+  //DOTTY-ONLY   inline infix def ignore(testFun: FixtureParam => Future[compatible.Assertion]): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) =>
+  //DOTTY-ONLY       new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)(using pos)
+  //DOTTY-ONLY     }) }
   //DOTTY-ONLY }  
 
   /**

--- a/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLike.scala
+++ b/jvm/flatspec/src/main/scala/org/scalatest/flatspec/FixtureAsyncFlatSpecLike.scala
@@ -1944,9 +1944,8 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       inImpl(testFun, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: () => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => inImpl(testFun, pos) }) } 
-    //DOTTY-ONLY }
+    //DOTTY-ONLY infix def in(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+    //DOTTY-ONLY   inImpl(testFun, pos)
 
     private final def ignoreImpl(testFun: () => Future[compatible.Assertion], pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + rest.trim, List(), new NoArgTestWrapper(testFun), pos)
@@ -1976,9 +1975,8 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       ignoreImpl(testFun, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(testFun: () => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => ignoreImpl(testFun, pos) }) } 
-    //DOTTY-ONLY }
+    //DOTTY-ONLY infix def ignore(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+    //DOTTY-ONLY   ignoreImpl(testFun, pos) 
 
     /**
      * Supports the registration of one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
@@ -2004,9 +2002,8 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       registerAsyncTestToRun(verb.trim + " " + rest.trim, List(), "in", testFun, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: FixtureParam => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerAsyncTestToRun(verb.trim + " " + rest.trim, List(), "in", testFun, pos) }) } 
-    //DOTTY-ONLY }
+    //DOTTY-ONLY infix def in(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+    //DOTTY-ONLY   registerAsyncTestToRun(verb.trim + " " + rest.trim, List(), "in", testFun, pos)
 
     /**
      * Supports the registration of ignored, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
@@ -2032,22 +2029,120 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       registerAsyncTestToIgnore(verb.trim + " " + rest.trim, List(), testFun, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(testFun: FixtureParam => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerAsyncTestToIgnore(verb.trim + " " + rest.trim, List(), testFun, pos) }) } 
-    //DOTTY-ONLY }
+    //DOTTY-ONLY infix def ignore(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+    //DOTTY-ONLY   registerAsyncTestToIgnore(verb.trim + " " + rest.trim, List(), testFun, pos)
   }
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
+  // SKIP-DOTTY-START
    * Implicitly converts an object of type <code>ResultOfStringPassedToVerb</code> to an
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY   * Converts an object of type <code>ResultOfStringPassedToVerb</code> to an
    * <code>InAndIgnoreMethods</code>, to enable <code>in</code> and <code>ignore</code>
    * methods to be invokable on that object.
    *
    * @param resultOfStringPassedToVerb an <code>ResultOfStringPassedToVerb</code> instance
    */
+  // SKIP-DOTTY-START
   protected implicit def convertToInAndIgnoreMethods(resultOfStringPassedToVerb: ResultOfStringPassedToVerb): InAndIgnoreMethods =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected def convertToInAndIgnoreMethods(resultOfStringPassedToVerb: ResultOfStringPassedToVerb): InAndIgnoreMethods =
     new InAndIgnoreMethods(resultOfStringPassedToVerb)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods for `ResultOfStringPassedToVerb` providing `in` and `ignore` for Dotty.
+  //DOTTY-ONLY  * Enables syntax like `"A Stack" must "pop values" in { ... }` and `"A Stack" must "pop values" ignore { ... }`.
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY extension (resultOfStringPassedToVerb: ResultOfStringPassedToVerb) {
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of no-arg tests in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" in { () => ... }
+  //DOTTY-ONLY    *                                                        ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of test registration, see the <a href="AnyFlatSpec.html">main documentation</a>
+  //DOTTY-ONLY    * for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def in(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+  //DOTTY-ONLY     new InAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)(using pos)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of ignored, no-arg tests in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" ignore { () => ... }
+  //DOTTY-ONLY    *                                                        ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of ignored test registration, see the <a href="AnyFlatSpec.html#IgnoredTests">Ignored tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def ignore(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+  //DOTTY-ONLY     new InAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)(using pos)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" in { fixture => ... }
+  //DOTTY-ONLY    *                                                        ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of test registration, see the <a href="AnyFlatSpec.html">main documentation</a>
+  //DOTTY-ONLY    * for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def in(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+  //DOTTY-ONLY     new InAndIgnoreMethods(resultOfStringPassedToVerb).in(testFun)(using pos)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of ignored, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" ignore { fixture => ... }
+  //DOTTY-ONLY    *                                                        ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of ignored test registration, see the <a href="AnyFlatSpec.html#IgnoredTests">Ignored tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def ignore(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+  //DOTTY-ONLY     new InAndIgnoreMethods(resultOfStringPassedToVerb).ignore(testFun)(using pos)
+  //DOTTY-ONLY }  
 
   /**
    * Class that supports tagged test registration in shorthand form.
@@ -2125,9 +2220,8 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       inImpl(testFun, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: () => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => inImpl(testFun, pos) }) } 
-    //DOTTY-ONLY }
+    //DOTTY-ONLY inline infix def in(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+    //DOTTY-ONLY   inImpl(testFun, pos) 
 
     private final def ignoreImpl(testFun: () => Future[compatible.Assertion], pos: source.Position): Unit = {
       registerAsyncTestToIgnore(verb.trim + " " + rest.trim, tagsList, new NoArgTestWrapper(testFun), pos)
@@ -2159,9 +2253,8 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       ignoreImpl(testFun, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(testFun: () => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => ignoreImpl(testFun, pos) }) } 
-    //DOTTY-ONLY }
+    //DOTTY-ONLY inline infix def ignore(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+    //DOTTY-ONLY   ignoreImpl(testFun, pos) 
 
     /**
      * Supports the registration of tagged, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
@@ -2187,9 +2280,8 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       registerAsyncTestToRun(verb.trim + " " + rest.trim, tagsList, "in", testFun, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: FixtureParam => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerAsyncTestToRun(verb.trim + " " + rest.trim, tagsList, "in", testFun, pos) }) } 
-    //DOTTY-ONLY }
+    //DOTTY-ONLY inline infix def in(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+    //DOTTY-ONLY   registerAsyncTestToRun(verb.trim + " " + rest.trim, tagsList, "in", testFun, pos)
 
     /**
      * Supports the registration of tagged, ignored, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
@@ -2217,20 +2309,120 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       registerAsyncTestToIgnore(verb.trim + " " + rest.trim, tagsList, testFun, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(testFun: FixtureParam => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerAsyncTestToIgnore(verb.trim + " " + rest.trim, tagsList, testFun, pos) }) } 
-    //DOTTY-ONLY }
+    //DOTTY-ONLY infix def ignore(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+    //DOTTY-ONLY   registerAsyncTestToIgnore(verb.trim + " " + rest.trim, tagsList, testFun, pos)
   }
 
   /**
+  // SKIP-DOTTY-START
    * Implicitly converts an object of type <code>ResultOfTaggedAsInvocation</code> to an
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY  * Converts an object of type <code>ResultOfTaggedAsInvocation</code> to an
    * <code>InAndIgnoreMethodsAfterTaggedAs</code>, to enable <code>in</code> and <code>ignore</code>
    * methods to be invokable on that object.
    *
    * @param resultOfTaggedAsInvocation an <code>ResultOfTaggedAsInvocation</code> instance
    */
+  // SKIP-DOTTY-START
   protected implicit def convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation: ResultOfTaggedAsInvocation): InAndIgnoreMethodsAfterTaggedAs =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected def convertToInAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation: ResultOfTaggedAsInvocation): InAndIgnoreMethodsAfterTaggedAs =
     new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods for `ResultOfStringPassedToVerb` providing `in` and `ignore` for Dotty.
+  //DOTTY-ONLY  * Enables syntax like `"A Stack" must "pop values" in { ... }` and `"A Stack" must "pop values" ignore { ... }`.
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY extension (resultOfTaggedAsInvocation: ResultOfTaggedAsInvocation) {
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY    * Supports the registration of tagged, no-arg tests in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) in { () => ... }
+  //DOTTY-ONLY    *                                                                           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of tagged test registration, see the <a href="AnyFlatSpec.html#TaggingTests">Tagging tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def in(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+  //DOTTY-ONLY     new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)(using pos)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of tagged, ignored, no-arg tests in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) ignore { () => ... }
+  //DOTTY-ONLY    *                                                                           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of ignored test registration, see the <a href="AnyFlatSpec.html#IgnoredTests">Ignored tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * For examples of tagged test registration, see the <a href="AnyFlatSpec.html#TaggingTests">Tagging tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def ignore(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+  //DOTTY-ONLY     new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)(using pos)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of tagged, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) in { fixture => ... }
+  //DOTTY-ONLY    *                                                                           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of tagged test registration, see the <a href="AnyFlatSpec.html#TaggingTests">Tagging tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def in(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+  //DOTTY-ONLY     new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).in(testFun)(using pos)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports the registration of tagged, ignored, one-arg tests (tests that take a <code>FixtureParam</code> parameter) in shorthand form.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" must "pop values in last-in-first-out order" taggedAs(SlowTest) ignore { fixture => ... }
+  //DOTTY-ONLY    *                                                                           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For examples of ignored test registration, see the <a href="AnyFlatSpec.html#IgnoredTests">Ignored tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * For examples of tagged test registration, see the <a href="AnyFlatSpec.html#TaggingTests">Tagging tests section</a>
+  //DOTTY-ONLY    * in the main documentation for trait <code>AnyFlatSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def ignore(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = 
+  //DOTTY-ONLY     new InAndIgnoreMethodsAfterTaggedAs(resultOfTaggedAsInvocation).ignore(testFun)(using pos)
+  //DOTTY-ONLY }  
 
   /**
    * Supports the shorthand form of test registration.
@@ -2254,7 +2446,10 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
    * the function, respectively).
    * </p>
    */
+  // SKIP-DOTTY-START
   protected implicit val shorthandTestRegistrationFunction: StringVerbStringInvocation =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected val shorthandTestRegistrationFunction: StringVerbStringInvocation =
     new StringVerbStringInvocation {
       def apply(subject: String, verb: String, rest: String, pos: source.Position): ResultOfStringPassedToVerb = {
         registerFlatBranch(subject, Resources.shouldCannotAppearInsideAnIn, pos)
@@ -2277,6 +2472,7 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
         }
       }
     }
+  //DOTTY-ONLY given StringVerbStringInvocation = shorthandTestRegistrationFunction  
 
   // TODO: Get rid of unusedfixture, and use NoArgTestFunction instead
 
@@ -2300,13 +2496,17 @@ trait FixtureAsyncFlatSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
    * subject description (the  parameter to the function) and returns a <code>BehaveWord</code>.
    * </p>
    */
+  // SKIP-DOTTY-START
   protected implicit val shorthandSharedTestRegistrationFunction: StringVerbBehaveLikeInvocation =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected val shorthandSharedTestRegistrationFunction: StringVerbBehaveLikeInvocation =
     new StringVerbBehaveLikeInvocation {
       def apply(subject: String, pos: source.Position): BehaveWord = {
         registerFlatBranch(subject, Resources.shouldCannotAppearInsideAnIn, pos)
         new BehaveWord
       }
     }
+  //DOTTY-ONLY given StringVerbBehaveLikeInvocation = shorthandSharedTestRegistrationFunction  
 
   /**
    * Register a test to ignore, which has the given spec text, optional tags, and test function value that takes no arguments.

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpecLike.scala
@@ -477,7 +477,7 @@ trait AnyFreeSpecLike extends TestSuite with Informing with Notifying with Alert
   //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyFreeSpec.html">main documentation</a> for trait <code>AnyFreeSpec</code>.
   //DOTTY-ONLY    * </p>
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   def taggedAs(firstTestTag: Tag, otherTestTags: Tag*): ResultOfTaggedAsInvocationOnString = new FreeSpecStringWrapper(s, pos).taggedAs(firstTestTag, otherTestTags: _*)
+  //DOTTY-ONLY   def taggedAs(firstTestTag: Tag, otherTestTags: Tag*): ResultOfTaggedAsInvocationOnString = new FreeSpecStringWrapper(s, pos).taggedAs(firstTestTag, otherTestTags*)
   //DOTTY-ONLY }
 
   /**

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpecLike.scala
@@ -382,18 +382,102 @@ trait AnyFreeSpecLike extends TestSuite with Informing with Notifying with Alert
     }
   }
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
-  /**
-   * Implicitly converts <code>String</code>s to <code>FreeSpecStringWrapper</code>, which enables
-   * methods <code>in</code>, <code>is</code>, <code>taggedAs</code> and <code>ignore</code>,
-   * as well as the dash operator (<code>-</code>), to be invoked on <code>String</code>s.
-   */
   // SKIP-DOTTY-START
   protected implicit def convertToFreeSpecStringWrapper(s: String)(implicit pos: source.Position): FreeSpecStringWrapper = new FreeSpecStringWrapper(s, pos)
   // SKIP-DOTTY-END
-  //DOTTY-ONLY inline implicit def convertToFreeSpecStringWrapper(s: String): FreeSpecStringWrapper = {
+  //DOTTY-ONLY protected inline def convertToFreeSpecStringWrapper(s: String): FreeSpecStringWrapper = {
   //DOTTY-ONLY   ${ source.Position.withPosition[FreeSpecStringWrapper]('{(pos: source.Position) => new FreeSpecStringWrapper(s, pos) }) } 
+  //DOTTY-ONLY }
+
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods to enable methods <code>in</code>, <code>is</code>, <code>taggedAs</code> and <code>ignore</code>,
+  //DOTTY-ONLY  * as well as the dash operator (<code>-</code>), to be invoked on <code>String</code>s.
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY extension (s: String)(using pos: source.Position) {
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Register some text that may surround one or more tests. Thepassed function value may contain surrounding text
+  //DOTTY-ONLY    * registrations (defined with dash (<code>-</code>)) and/or tests (defined with <code>in</code>). This trait's
+  //DOTTY-ONLY    * implementation of this method will register the text (passed to the contructor of <code>FreeSpecStringWrapper</code>
+  //DOTTY-ONLY    * and immediately invoke the passed function.
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def -(fun: => Unit): Unit = new FreeSpecStringWrapper(s, pos).-(fun)
+
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" in { ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyFreeSpec.html">main documentation</a> for trait <code>AnyFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def in(f: => Any /* Assertion */): Unit = new FreeSpecStringWrapper(s, pos).in(f)
+
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports ignored test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" ignore { ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyFreeSpec.html">main documentation</a> for trait <code>AnyFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def ignore(f: => Any /* Assertion */): Unit = new FreeSpecStringWrapper(s, pos).ignore(f)
+
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports pending test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" is (pending)
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyFreeSpec.html">main documentation</a> for trait <code>AnyFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def is(f: => PendingStatement): Unit = new FreeSpecStringWrapper(s, pos).is(f)
+
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports tagged test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" taggedAs(SlowTest) in { ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyFreeSpec.html">main documentation</a> for trait <code>AnyFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def taggedAs(firstTestTag: Tag, otherTestTags: Tag*): ResultOfTaggedAsInvocationOnString = new FreeSpecStringWrapper(s, pos).taggedAs(firstTestTag, otherTestTags: _*)
   //DOTTY-ONLY }
 
   /**

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AnyFreeSpecLike.scala
@@ -389,10 +389,7 @@ trait AnyFreeSpecLike extends TestSuite with Informing with Notifying with Alert
   // SKIP-DOTTY-START
   protected implicit def convertToFreeSpecStringWrapper(s: String)(implicit pos: source.Position): FreeSpecStringWrapper = new FreeSpecStringWrapper(s, pos)
   // SKIP-DOTTY-END
-  //DOTTY-ONLY protected inline def convertToFreeSpecStringWrapper(s: String): FreeSpecStringWrapper = {
-  //DOTTY-ONLY   ${ source.Position.withPosition[FreeSpecStringWrapper]('{(pos: source.Position) => new FreeSpecStringWrapper(s, pos) }) } 
-  //DOTTY-ONLY }
-
+  //DOTTY-ONLY protected def convertToFreeSpecStringWrapper(s: String)(using pos: source.Position): FreeSpecStringWrapper = new FreeSpecStringWrapper(s, pos)
 
   //DOTTY-ONLY /**
   //DOTTY-ONLY  * Extension methods to enable methods <code>in</code>, <code>is</code>, <code>taggedAs</code> and <code>ignore</code>,

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpecLike.scala
@@ -395,9 +395,7 @@ trait AsyncFreeSpecLike extends AsyncTestSuite with Informing with Notifying wit
   // SKIP-DOTTY-START
   protected implicit def convertToFreeSpecStringWrapper(s: String)(implicit pos: source.Position): FreeSpecStringWrapper = new FreeSpecStringWrapper(s, pos)
   // SKIP-DOTTY-END
-  //DOTTY-ONLY inline def convertToFreeSpecStringWrapper(s: String): FreeSpecStringWrapper = {
-  //DOTTY-ONLY   ${ source.Position.withPosition[FreeSpecStringWrapper]('{(pos: source.Position) => new FreeSpecStringWrapper(s, pos) }) } 
-  //DOTTY-ONLY }
+  //DOTTY-ONLY protected def convertToFreeSpecStringWrapper(s: String)(using pos: source.Position): FreeSpecStringWrapper = new FreeSpecStringWrapper(s, pos)
 
   /**
   //DOTTY-ONLY  * Extension methods to enable methods <code>in</code>, <code>is</code>, <code>taggedAs</code> and <code>ignore</code>,

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpecLike.scala
@@ -478,7 +478,7 @@ trait AsyncFreeSpecLike extends AsyncTestSuite with Informing with Notifying wit
   //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AsyncFreeSpec.html">main documentation</a> for trait <code>AsyncFreeSpec</code>.
   //DOTTY-ONLY    * </p>
   //DOTTY-ONLY    */
-  //DOTTY-ONLY   def taggedAs(firstTestTag: Tag, otherTestTags: Tag*): ResultOfTaggedAsInvocationOnString = new FreeSpecStringWrapper(s, pos).taggedAs(firstTestTag, otherTestTags: _*)
+  //DOTTY-ONLY   def taggedAs(firstTestTag: Tag, otherTestTags: Tag*): ResultOfTaggedAsInvocationOnString = new FreeSpecStringWrapper(s, pos).taggedAs(firstTestTag, otherTestTags*)
   //DOTTY-ONLY }
 
   /**

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/AsyncFreeSpecLike.scala
@@ -383,7 +383,9 @@ trait AsyncFreeSpecLike extends AsyncTestSuite with Informing with Notifying wit
     }
   }
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
    * Implicitly converts <code>String</code>s to <code>FreeSpecStringWrapper</code>, which enables
@@ -393,8 +395,90 @@ trait AsyncFreeSpecLike extends AsyncTestSuite with Informing with Notifying wit
   // SKIP-DOTTY-START
   protected implicit def convertToFreeSpecStringWrapper(s: String)(implicit pos: source.Position): FreeSpecStringWrapper = new FreeSpecStringWrapper(s, pos)
   // SKIP-DOTTY-END
-  //DOTTY-ONLY inline implicit def convertToFreeSpecStringWrapper(s: String): FreeSpecStringWrapper = {
+  //DOTTY-ONLY inline def convertToFreeSpecStringWrapper(s: String): FreeSpecStringWrapper = {
   //DOTTY-ONLY   ${ source.Position.withPosition[FreeSpecStringWrapper]('{(pos: source.Position) => new FreeSpecStringWrapper(s, pos) }) } 
+  //DOTTY-ONLY }
+
+  /**
+  //DOTTY-ONLY  * Extension methods to enable methods <code>in</code>, <code>is</code>, <code>taggedAs</code> and <code>ignore</code>,
+  //DOTTY-ONLY  * as well as the dash operator (<code>-</code>), to be invoked on <code>String</code>s.
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY extension (s: String)(using pos: source.Position) {
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Register some text that may surround one or more tests. Thepassed function value may contain surrounding text
+  //DOTTY-ONLY    * registrations (defined with dash (<code>-</code>)) and/or tests (defined with <code>in</code>). This trait's
+  //DOTTY-ONLY    * implementation of this method will register the text (passed to the contructor of <code>FreeSpecStringWrapper</code>
+  //DOTTY-ONLY    * and immediately invoke the passed function.
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def -(fun: => Unit): Unit = new FreeSpecStringWrapper(s, pos).- (fun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" in { ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AsyncFreeSpec.html">main documentation</a> for trait <code>AsyncFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def in(f: => Future[compatible.Assertion]): Unit = new FreeSpecStringWrapper(s, pos).in(f)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports ignored test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" ignore { ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AsyncFreeSpec.html">main documentation</a> for trait <code>AsyncFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def ignore(f: => Future[compatible.Assertion]): Unit = new FreeSpecStringWrapper(s, pos).ignore(f)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports pending test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" is (pending)
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AsyncFreeSpec.html">main documentation</a> for trait <code>AsyncFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def is(f: => PendingStatement): Unit = new FreeSpecStringWrapper(s, pos).is(f)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports tagged test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" taggedAs(SlowTest) in { ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AsyncFreeSpec.html">main documentation</a> for trait <code>AsyncFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def taggedAs(firstTestTag: Tag, otherTestTags: Tag*): ResultOfTaggedAsInvocationOnString = new FreeSpecStringWrapper(s, pos).taggedAs(firstTestTag, otherTestTags: _*)
   //DOTTY-ONLY }
 
   /**

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpecLike.scala
@@ -521,7 +521,9 @@ trait FixtureAnyFreeSpecLike extends org.scalatest.FixtureTestSuite with Informi
     }
   }
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
    * Implicitly converts <code>String</code>s to <code>FreeSpecStringWrapper</code>, which enables
@@ -531,8 +533,135 @@ trait FixtureAnyFreeSpecLike extends org.scalatest.FixtureTestSuite with Informi
   // SKIP-DOTTY-START 
   protected implicit def convertToFreeSpecStringWrapper(s: String)(implicit pos: source.Position): FreeSpecStringWrapper = new FreeSpecStringWrapper(s, pos)
   // SKIP-DOTTY-END
-  //DOTTY-ONLY inline implicit def convertToFreeSpecStringWrapper(s: String): FreeSpecStringWrapper = {
-  //DOTTY-ONLY   ${ source.Position.withPosition[FreeSpecStringWrapper]('{(pos: source.Position) => new FreeSpecStringWrapper(s, pos) }) } 
+  //DOTTY-ONLY protected inline def convertToFreeSpecStringWrapper(s: String)(using pos: source.Position): FreeSpecStringWrapper = new FreeSpecStringWrapper(s, pos)
+
+  //DOTTY-ONLY  /**
+  //DOTTY-ONLY  * Extension methods to enable methods <code>in</code>, <code>is</code>, <code>taggedAs</code> and <code>ignore</code>,
+  //DOTTY-ONLY  * as well as the dash operator (<code>-</code>), to be invoked on <code>String</code>s.
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY extension (s: String)(using pos: source.Position) {
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Register some text that may surround one or more tests. Thepassed function value may contain surrounding text
+  //DOTTY-ONLY    * registrations (defined with dash (<code>-</code>)) and/or tests (defined with <code>in</code>). This trait's
+  //DOTTY-ONLY    * implementation of this method will register the text (passed to the contructor of <code>FreeSpecStringWrapper</code>
+  //DOTTY-ONLY    * and immediately invoke the passed function.
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def -(fun: => Unit): Unit = new FreeSpecStringWrapper(s, pos).-(fun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" in { fixture => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyFreeSpec.html">main documentation</a> for trait <code>FixtureAnyFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def in(testFun: FixtureParam => Any /* Assertion */): Unit = new FreeSpecStringWrapper(s, pos).in(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports registration of tests that take no fixture.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" in { () => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyFreeSpec.html">main documentation</a> for trait <code>FixtureAnyFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def in(testFun: () => Any /* Assertion */): Unit = new FreeSpecStringWrapper(s, pos).in(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports pending test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" is (pending)
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyFreeSpec.html">main documentation</a> for trait <code>FixtureAnyFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def is(testFun: => PendingStatement): Unit = new FreeSpecStringWrapper(s, pos).is(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports ignored test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" ignore { fixture => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyFreeSpec.html">main documentation</a> for trait <code>FixtureAnyFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def ignore(testFun: FixtureParam => Any /* Assertion */): Unit = new FreeSpecStringWrapper(s, pos).ignore(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports registration of ignored tests that take no fixture.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" ignore { () => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyFreeSpec.html">main documentation</a> for trait <code>FixtureAnyFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def ignore(testFun: () => Any /* Assertion */): Unit = new FreeSpecStringWrapper(s, pos).ignore(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports tagged test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" taggedAs(SlowTest) in { fixture => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyFreeSpec.html">main documentation</a> for trait <code>FixtureAnyFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param firstTestTag the first mandatory test tag
+  //DOTTY-ONLY    * @param otherTestTags the others additional test tags
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def taggedAs(firstTestTag: Tag, otherTestTags: Tag*): ResultOfTaggedAsInvocationOnString = new FreeSpecStringWrapper(s, pos).taggedAs(firstTestTag, otherTestTags*)
   //DOTTY-ONLY }
 
   /**

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAnyFreeSpecLike.scala
@@ -533,7 +533,7 @@ trait FixtureAnyFreeSpecLike extends org.scalatest.FixtureTestSuite with Informi
   // SKIP-DOTTY-START 
   protected implicit def convertToFreeSpecStringWrapper(s: String)(implicit pos: source.Position): FreeSpecStringWrapper = new FreeSpecStringWrapper(s, pos)
   // SKIP-DOTTY-END
-  //DOTTY-ONLY protected inline def convertToFreeSpecStringWrapper(s: String)(using pos: source.Position): FreeSpecStringWrapper = new FreeSpecStringWrapper(s, pos)
+  //DOTTY-ONLY protected def convertToFreeSpecStringWrapper(s: String)(using pos: source.Position): FreeSpecStringWrapper = new FreeSpecStringWrapper(s, pos)
 
   //DOTTY-ONLY  /**
   //DOTTY-ONLY  * Extension methods to enable methods <code>in</code>, <code>is</code>, <code>taggedAs</code> and <code>ignore</code>,

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/FixtureAsyncFreeSpecLike.scala
@@ -494,7 +494,9 @@ trait FixtureAsyncFreeSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
     }
   }
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
    * Implicitly converts <code>String</code>s to <code>FreeSpecStringWrapper</code>, which enables
@@ -504,8 +506,135 @@ trait FixtureAsyncFreeSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
   // SKIP-DOTTY-START 
   protected implicit def convertToFreeSpecStringWrapper(s: String)(implicit pos: source.Position): FreeSpecStringWrapper = new FreeSpecStringWrapper(s, pos)
   // SKIP-DOTTY-END
-  //DOTTY-ONLY inline implicit def convertToFreeSpecStringWrapper(s: String): FreeSpecStringWrapper = {
-  //DOTTY-ONLY   ${ source.Position.withPosition[FreeSpecStringWrapper]('{(pos: source.Position) => new FreeSpecStringWrapper(s, pos) }) } 
+  //DOTTY-ONLY protected def convertToFreeSpecStringWrapper(s: String)(using pos: source.Position): FreeSpecStringWrapper = new FreeSpecStringWrapper(s, pos)
+
+  //DOTTY-ONLY  /**
+  //DOTTY-ONLY  * Extension methods to enable methods <code>in</code>, <code>is</code>, <code>taggedAs</code> and <code>ignore</code>,
+  //DOTTY-ONLY  * as well as the dash operator (<code>-</code>), to be invoked on <code>String</code>s.
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY extension (s: String)(using pos: source.Position) {
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY    * Register some text that may surround one or more tests. Thepassed function value may contain surrounding text
+  //DOTTY-ONLY    * registrations (defined with dash (<code>-</code>)) and/or tests (defined with <code>in</code>). This trait's
+  //DOTTY-ONLY    * implementation of this method will register the text (passed to the contructor of <code>FreeSpecStringWrapper</code>
+  //DOTTY-ONLY    * and immediately invoke the passed function.
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def -(fun: => Unit): Unit = new FreeSpecStringWrapper(s, pos).-(fun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" in { fixture => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAsyncFreeSpec.html">main documentation</a> for trait <code>FixtureAsyncFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def in(testFun: FixtureParam => Future[compatible.Assertion]): Unit = new FreeSpecStringWrapper(s, pos).in(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports registration of tests that take no fixture.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" in { () => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAsyncFreeSpec.html">main documentation</a> for trait <code>FixtureAsyncFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */  
+  //DOTTY-ONLY   def in(testFun: () => Future[compatible.Assertion]): Unit = new FreeSpecStringWrapper(s, pos).in(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports pending test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" is (pending)
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAsyncFreeSpec.html">main documentation</a> for trait <code>FixtureAsyncFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def is(testFun: => PendingStatement): Unit = new FreeSpecStringWrapper(s, pos).is(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports ignored test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" ignore { fixture => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAsyncFreeSpec.html">main documentation</a> for trait <code>FixtureAsyncFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def ignore(testFun: FixtureParam => Future[compatible.Assertion]): Unit = new FreeSpecStringWrapper(s, pos).ignore(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports registration of ignored tests that take no fixture.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" ignore { () => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAsyncFreeSpec.html">main documentation</a> for trait <code>FixtureAsyncFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def ignore(testFun: () => Future[compatible.Assertion]): Unit = new FreeSpecStringWrapper(s, pos).ignore(testFun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports tagged test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" taggedAs(SlowTest) in { fixture => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAsyncFreeSpec.html">main documentation</a> for trait <code>FixtureAsyncFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param firstTestTag the first mandatory test tag
+  //DOTTY-ONLY    * @param otherTestTags the others additional test tags
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def taggedAs(firstTestTag: Tag, otherTestTags: Tag*): ResultOfTaggedAsInvocationOnString = new FreeSpecStringWrapper(s, pos).taggedAs(firstTestTag, otherTestTags*)
   //DOTTY-ONLY }
 
   /**

--- a/jvm/freespec/src/main/scala/org/scalatest/freespec/PathAnyFreeSpecLike.scala
+++ b/jvm/freespec/src/main/scala/org/scalatest/freespec/PathAnyFreeSpecLike.scala
@@ -399,8 +399,108 @@ trait PathAnyFreeSpecLike extends org.scalatest.Suite with OneInstancePerTest wi
   // SKIP-DOTTY-START
   protected implicit def convertToFreeSpecStringWrapper(s: String)(implicit pos: source.Position): FreeSpecStringWrapper = new FreeSpecStringWrapper(s, pos)
   // SKIP-DOTTY-END
-  //DOTTY-ONLY inline implicit def convertToFreeSpecStringWrapper(s: String): FreeSpecStringWrapper = {
-  //DOTTY-ONLY   ${ source.Position.withPosition[FreeSpecStringWrapper]('{(pos: source.Position) => new FreeSpecStringWrapper(s, pos) }) } 
+  //DOTTY-ONLY protected def convertToFreeSpecStringWrapper(s: String)(using pos: source.Position): FreeSpecStringWrapper = new FreeSpecStringWrapper(s, pos)
+
+  //DOTTY-ONLY  /**
+  //DOTTY-ONLY  * Extension methods to enable methods <code>in</code>, <code>is</code>, <code>taggedAs</code> and <code>ignore</code>,
+  //DOTTY-ONLY  * as well as the dash operator (<code>-</code>), to be invoked on <code>String</code>s.
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY extension (s: String)(using pos: source.Position) {
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY    * Register some text that may surround one or more tests. The passed
+  //DOTTY-ONLY    * passed function value may contain surrounding text registrations (defined with dash (<code>-</code>)) and/or tests
+  //DOTTY-ONLY    * (defined with <code>in</code>). This class's implementation of this method will decide whether to
+  //DOTTY-ONLY    * register the text (passed to the constructor of <code>FreeSpecStringWrapper</code>) and invoke the passed function
+  //DOTTY-ONLY    * based on whether or not this is part of the current "test path." For the details on this process, see
+  //DOTTY-ONLY    * the <a href="#howItExecutes">How it executes</a> section of the main documentation for trait
+  //DOTTY-ONLY    * <code>org.scalatest.freespec.PathAnyFreeSpec</code>.
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def -(fun: => Unit): Unit = new FreeSpecStringWrapper(s, pos).-(fun)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" in { ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * This trait's implementation of this method will decide whether to register the text (passed to the constructor
+  //DOTTY-ONLY    * of <code>FreeSpecStringWrapper</code>) and invoke the passed function
+  //DOTTY-ONLY    * based on whether or not this is part of the current "test path." For the details on this process, see
+  //DOTTY-ONLY    * the <a href="#howItExecutes">How it executes</a> section of the main documentation for
+  //DOTTY-ONLY    * trait <code>org.scalatest.freespec.PathAnyFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def in(f: => Unit /* Assertion */): Unit = new FreeSpecStringWrapper(s, pos).in(f)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports ignored test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" ignore { ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the
+  //DOTTY-ONLY    * <a href="AnyFreeSpec.html#ignoredTests">Ignored tests</a> section in the main documentation for sister
+  //DOTTY-ONLY    * trait <code>org.scalatest.freespec.AnyFreeSpec</code>. Note that a separate instance will be created for an ignored test,
+  //DOTTY-ONLY    * and the path to the ignored test will be executed in that instance, but the test function itself will not
+  //DOTTY-ONLY    * be executed. Instead, a <code>TestIgnored</code> event will be fired.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def ignore(f: => Unit /* Assertion */): Unit = new FreeSpecStringWrapper(s, pos).ignore(f)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports pending test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" is (pending)
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the
+  //DOTTY-ONLY    * <a href="AnyFreeSpec.html#pendingTests">Pending tests</a> section in the main documentation for
+  //DOTTY-ONLY    * sister trait <code>org.scalatest.freespec.AnyFreeSpec</code>.
+  //DOTTY-ONLY    * Note that this trait's implementation of this method will decide whether to register the text (passed to the constructor
+  //DOTTY-ONLY    * of <code>FreeSpecStringWrapper</code>) and invoke the passed function
+  //DOTTY-ONLY    * based on whether or not this is part of the current "test path." For the details on this process, see
+  //DOTTY-ONLY    * the <a href="#howItExecutes">How it executes</a> section of the main documentation for
+  //DOTTY-ONLY    * trait <code>org.scalatest.freespec.PathAnyFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def is(f: => PendingStatement): Unit = new FreeSpecStringWrapper(s, pos).is(f)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports tagged test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" taggedAs(SlowTest) in { ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the
+  //DOTTY-ONLY    * <a href="AnyFreeSpec.html#taggingTests">Tagging tests</a> section in the main documentation for sister
+  //DOTTY-ONLY    * trait <code>org.scalatest.freespec.AnyFreeSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def taggedAs(firstTestTag: Tag, otherTestTags: Tag*): ResultOfTaggedAsInvocationOnString = new FreeSpecStringWrapper(s, pos).taggedAs(firstTestTag, otherTestTags*)
   //DOTTY-ONLY }
 
   /**

--- a/jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAsyncFunSpecLike.scala
+++ b/jvm/funspec/src/main/scala/org/scalatest/funspec/FixtureAsyncFunSpecLike.scala
@@ -646,10 +646,15 @@ trait FixtureAsyncFunSpecLike extends org.scalatest.FixtureAsyncTestSuite with I
    */
   protected val behave = new BehaveWord
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
+  // SKIP-DOTTY-START
    * Implicitly converts a function that takes no parameters and results in <code>PendingStatement</code> to
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY   * Converts a function that takes no parameters and results in <code>PendingStatement</code> to
    * a function from <code>FixtureParam</code> to <code>Any</code>, to enable pending tests to registered as by-name parameters
    * by methods that require a test function that takes a <code>FixtureParam</code>.
    *
@@ -661,9 +666,13 @@ trait FixtureAsyncFunSpecLike extends org.scalatest.FixtureAsyncTestSuite with I
    * @param f a function
    * @return a function of <code>FixtureParam => Any</code>
    */
+  // SKIP-DOTTY-START 
   protected implicit def convertPendingToFixtureFunction(f: => PendingStatement): FixtureParam => compatible.Assertion = {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected def convertPendingToFixtureFunction(f: => PendingStatement): FixtureParam => compatible.Assertion = {
     fixture => { f; Succeeded }
   }
+  //DOTTY-ONLY given Conversion[PendingStatement, FixtureParam => compatible.Assertion] = convertPendingToFixtureFunction
 
   /**
    * Implicitly converts a function that takes no parameters and results in <code>Any</code> to

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatcherProducers.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatcherProducers.scala
@@ -84,6 +84,9 @@ trait MatcherProducers {
   implicit def convertToComposifier[T](f: T => Matcher[T]): Composifier[T] = new Composifier(f)
   // SKIP-DOTTY-END
   //DOTTY-ONLY def convertToComposifier[T](f: T => Matcher[T]): Composifier[T] = new Composifier(f)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension to support methods provided by <code>MatcherProducers.Composifier</code>.
+  //DOTTY-ONLY  */
   //DOTTY-ONLY extension [T](f: T => Matcher[T]) {
   //DOTTY-ONLY   /**
   //DOTTY-ONLY    * See the documentation for method <code>composeTwice</code> in class <code>MatcherProducers.Composifier</code>.

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatcherProducers.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/MatcherProducers.scala
@@ -29,8 +29,88 @@ package org.scalatest.matchers
  */
 trait MatcherProducers {
 
+  import MatcherProducers.Composifier
+
+  // SKIP-DOTTY-START
+  import scala.language.implicitConversions
+  // SKIP-DOTTY-END
+
   /**
+  // SKIP-DOTTY-START
+   * Implicit conversion that converts a function of <code>T =&gt; Matcher[T]</code> to an object that has
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY  * Converts a function of <code>T =&gt; Matcher[T]</code> to an object that has
+   * <code>composeTwice</code>, <code>mapResult</code> and <code>mapArgs</code> methods.
+   *
+   * The following shows how this trait is used to compose twice and modify error messages:
+   *
+   * <pre class="stHighlight">
+   * import org.scalatest._
+   * import matchers._
+   * import MatcherProducers._
+   *
+   * val f = be &gt; (_: Int)
+   * val g = (_: String).toInt
+   *
+   * // f composeTwice g means: (f compose g) andThen (_ compose g)
+   * val beAsIntsGreaterThan =
+   *   f composeTwice g mapResult { mr =&gt;
+   *     mr.copy(
+   *       failureMessageArgs =
+   *         mr.failureMessageArgs.map((LazyArg(_) { "\"" + _.toString + "\".toInt"})),
+   *       negatedFailureMessageArgs =
+   *         mr.negatedFailureMessageArgs.map((LazyArg(_) { "\"" + _.toString + "\".toInt"})),
+   *       midSentenceFailureMessageArgs =
+   *         mr.midSentenceFailureMessageArgs.map((LazyArg(_) { "\"" + _.toString + "\".toInt"})),
+   *       midSentenceNegatedFailureMessageArgs =
+   *         mr.midSentenceNegatedFailureMessageArgs.map((LazyArg(_) { "\"" + _.toString + "\".toInt"}))
+   *     )
+   *   }
+   *
+   * "7" should beAsIntsGreaterThan ("8")
+   * </pre>
+   *
+   * The last assertion will fail with message like this:
+   *
+   * <pre class="stHighlight">
+   * "7".toInt was not greater than "8".toInt
+   * </pre>
+   *
+   * @param f a function that takes a <code>T</code> and return a <code>Matcher[T]</code>
+   * @tparam T the type used by function <code>f</code>
+   * @return an object that has <code>composeTwice</code>, <code>mapResult</code> and <code>mapArgs</code> methods.
+   */
+  // SKIP-DOTTY-START 
+  implicit def convertToComposifier[T](f: T => Matcher[T]): Composifier[T] = new Composifier(f)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertToComposifier[T](f: T => Matcher[T]): Composifier[T] = new Composifier(f)
+  //DOTTY-ONLY extension [T](f: T => Matcher[T]) {
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * See the documentation for method <code>composeTwice</code> in class <code>MatcherProducers.Composifier</code>.
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def composeTwice[U](g: U => T): U => Matcher[U] = (new Composifier(f)).composeTwice(g)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * See the documentation for method <code>mapResult</code> in class <code>MatcherProducers.Composifier</code>.
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def mapResult(prettify: MatchResult => MatchResult): T => Matcher[T] = (new Composifier(f)).mapResult(prettify)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * See the documentation for method <code>mapArgs</code> in class <code>MatcherProducers.Composifier</code>.
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   def mapArgs(prettify: Any => String): T => Matcher[T] = (new Composifier(f)).mapArgs(prettify)
+  //DOTTY-ONLY }
+}
+
+/**
+ * Companion object that facilitates the importing of <code>MatcherProducers</code> members as
+ * an alternative to mixing it in. One use case is to import <code>MatcherProducers</code>'s members so you can use
+ * <code>MatcherProducers</code> in the Scala interpreter.
+ */
+object MatcherProducers extends MatcherProducers {
+  /**
+  // SKIP-DOTTY-START
    * Class used via an implicit conversion that adds <code>composeTwice</code>, <code>mapResult</code>, and
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY  * Class that adds <code>composeTwice</code>, <code>mapResult</code>, and
    * <code>mapArgs</code> methods to functions that produce a <code>Matcher</code>.
    */
   class Composifier[T](f: T => Matcher[T]) {
@@ -230,58 +310,5 @@ trait MatcherProducers {
     def mapArgs(prettify: Any => String): T => Matcher[T] =
       (o: T) => f(o) mapArgs prettify
   }
-
-  import scala.language.implicitConversions
-
-  /**
-   * Implicit conversion that converts a function of <code>T =&gt; Matcher[T]</code> to an object that has
-   * <code>composeTwice</code>, <code>mapResult</code> and <code>mapArgs</code> methods.
-   *
-   * The following shows how this trait is used to compose twice and modify error messages:
-   *
-   * <pre class="stHighlight">
-   * import org.scalatest._
-   * import matchers._
-   * import MatcherProducers._
-   *
-   * val f = be &gt; (_: Int)
-   * val g = (_: String).toInt
-   *
-   * // f composeTwice g means: (f compose g) andThen (_ compose g)
-   * val beAsIntsGreaterThan =
-   *   f composeTwice g mapResult { mr =&gt;
-   *     mr.copy(
-   *       failureMessageArgs =
-   *         mr.failureMessageArgs.map((LazyArg(_) { "\"" + _.toString + "\".toInt"})),
-   *       negatedFailureMessageArgs =
-   *         mr.negatedFailureMessageArgs.map((LazyArg(_) { "\"" + _.toString + "\".toInt"})),
-   *       midSentenceFailureMessageArgs =
-   *         mr.midSentenceFailureMessageArgs.map((LazyArg(_) { "\"" + _.toString + "\".toInt"})),
-   *       midSentenceNegatedFailureMessageArgs =
-   *         mr.midSentenceNegatedFailureMessageArgs.map((LazyArg(_) { "\"" + _.toString + "\".toInt"}))
-   *     )
-   *   }
-   *
-   * "7" should beAsIntsGreaterThan ("8")
-   * </pre>
-   *
-   * The last assertion will fail with message like this:
-   *
-   * <pre class="stHighlight">
-   * "7".toInt was not greater than "8".toInt
-   * </pre>
-   *
-   * @param f a function that takes a <code>T</code> and return a <code>Matcher[T]</code>
-   * @tparam T the type used by function <code>f</code>
-   * @return an object that has <code>composeTwice</code>, <code>mapResult</code> and <code>mapArgs</code> methods.
-   */
-  implicit def convertToComposifier[T](f: T => Matcher[T]): Composifier[T] = new Composifier(f) 
 }
-
-/**
- * Companion object that facilitates the importing of <code>MatcherProducers</code> members as
- * an alternative to mixing it in. One use case is to import <code>MatcherProducers</code>'s members so you can use
- * <code>MatcherProducers</code> in the Scala interpreter.
- */
-object MatcherProducers extends MatcherProducers
 

--- a/jvm/scalactic/src/main/scala/org/scalactic/Accumulation.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Accumulation.scala
@@ -39,7 +39,10 @@ trait AccumulationLowPriorityImplicits {
     * For more information and examples, see the <a href="Or.html#usingCombined">Using <code>combined</code></a> section of the main documentation for class <code>Or</code>.
     * </p>
     */
+  // SKIP-DOTTY-START  
   implicit def convertIterableOnceToCombinable[G, ERR, EVERY[b] <: Every[b], ITRONCE[+e] <: IterableOnce[e]](xs: ITRONCE[G Or EVERY[ERR]])(implicit cbf: CanBuildFrom[ITRONCE[G Or EVERY[ERR]], G, ITRONCE[G]]): Combinable[G, ERR, ITRONCE] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertIterableOnceToCombinable[G, ERR, EVERY[b] <: Every[b], ITRONCE[+e] <: IterableOnce[e]](xs: ITRONCE[G Or EVERY[ERR]])(using cbf: CanBuildFrom[ITRONCE[G Or EVERY[ERR]], G, ITRONCE[G]]): Combinable[G, ERR, ITRONCE] =
     new Combinable[G, ERR, ITRONCE] {
 
       def combined: ITRONCE[G] Or Every[ERR] = {
@@ -59,8 +62,14 @@ trait AccumulationLowPriorityImplicits {
         tempOr map (_.result())
       }
     }
+  //DOTTY-ONLY extension [G, ERR, EVERY[b] <: Every[b], ITRONCE[+e] <: IterableOnce[e]](xs: ITRONCE[G Or EVERY[ERR]])(using cbf: CanBuildFrom[ITRONCE[G Or EVERY[ERR]], G, ITRONCE[G]]) {
+  //DOTTY-ONLY   def combined: ITRONCE[G] Or Every[ERR] = convertIterableOnceToCombinable(xs)(using cbf).combined
+  //DOTTY-ONLY }
 
+  // SKIP-DOTTY-START
   implicit def convertIterableOnceToCombinable3[E, ITRONCE[+e] <: IterableOnce[e]](xs: ITRONCE[Bad[Every[E]]]): Combinable[Nothing, E, ITRONCE] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertIterableOnceToCombinable3[E, ITRONCE[+e] <: IterableOnce[e]](xs: ITRONCE[Bad[Every[E]]]): Combinable[Nothing, E, ITRONCE] =
     new Combinable[Nothing, E, ITRONCE] {
       override def combined: Or[ITRONCE[Nothing], Every[E]] = {
         val either: Either[Every[E], ITRONCE[Nothing]] =
@@ -104,8 +113,10 @@ trait AccumulationLowPriorityImplicits {
  */
 trait Accumulation extends AccumulationLowPriorityImplicits {
 
-  import scala.language.{higherKinds, implicitConversions}
-
+  import scala.language.higherKinds
+  // SKIP-DOTTY-START
+  import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
    * Implicitly converts an accumulating <code>Or</code> to an instance of <a href="Accumulation$$Acumulatable.html"><code>Accumulatable</code></a>, which
@@ -116,7 +127,10 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
    * sections of the main documentation for class <code>Or</code>.
    * </p>
    */
+  // SKIP-DOTTY-START
   implicit def convertOrToAccumulatable[G, ERR, EVERY[b] <: Every[b]](accumulatable: G Or EVERY[ERR]): Accumulatable[G, ERR, EVERY] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertOrToAccumulatable[G, ERR, EVERY[b] <: Every[b]](accumulatable: G Or EVERY[ERR]): Accumulatable[G, ERR, EVERY] =
     new Accumulatable[G, ERR, EVERY] {
       def zip[H, OTHERERR >: ERR, OTHEREVERY[c] <: Every[c]](other: H Or OTHEREVERY[OTHERERR]): (G, H) Or Every[OTHERERR] = {
         accumulatable match {
@@ -150,8 +164,15 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
         }
       }
     }
+  //DOTTY-ONLY extension [G, ERR, EVERY[b] <: Every[b]](accumulatable: G Or EVERY[ERR]) {
+  //DOTTY-ONLY   def zip[H, OTHERERR >: ERR, OTHEREVERY[c] <: Every[c]](other: H Or OTHEREVERY[OTHERERR]): (G, H) Or Every[OTHERERR] = convertOrToAccumulatable(accumulatable).zip(other)
+  //DOTTY-ONLY   def when[OTHERERR >: ERR](validations: (G => Validation[OTHERERR])*): G Or Every[OTHERERR] = convertOrToAccumulatable(accumulatable).when(validations*)
+  //DOTTY-ONLY }  
 
+  // SKIP-DOTTY-START
   implicit def convertIterableOnceToCombinable2[E, ITRONCE[+e] <: Iterable[e]](xs: ITRONCE[Good[E]])(implicit cbf: CanBuildFrom[ITRONCE[Good[E]], Good[E], ITRONCE[Good[E]]]): Combinable[E, Nothing, ITRONCE] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertIterableOnceToCombinable2[E, ITRONCE[+e] <: Iterable[e]](xs: ITRONCE[Good[E]])(using cbf: CanBuildFrom[ITRONCE[Good[E]], Good[E], ITRONCE[Good[E]]]): Combinable[E, Nothing, ITRONCE] =
     new Combinable[E, Nothing, ITRONCE] {
       override def combined: Or[ITRONCE[E], Every[Nothing]] = {
         // So now I have an empty builder
@@ -184,8 +205,10 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
    * <code>IterableOnce</code>s.
    * </p>
    */
+  // SKIP-DOTTY-START
   implicit def convertGenSetToCombinable[G, ERR, X, EVERY[b] <: Every[b], SET[e] <: GenSet[e]](xs: SET[X with (G Or EVERY[ERR])])(implicit cbf: CanBuildFrom[SET[X with (G Or EVERY[ERR])], G, SET[G]]): Combinable[G, ERR, SET] = 
-
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertGenSetToCombinable[G, ERR, X, EVERY[b] <: Every[b], SET[e] <: GenSet[e]](xs: SET[X with (G Or EVERY[ERR])])(using cbf: CanBuildFrom[SET[X with (G Or EVERY[ERR])], G, SET[G]]): Combinable[G, ERR, SET] = 
     new Combinable[G, ERR, SET] {
 
       def combined: SET[G] Or Every[ERR] = {
@@ -205,6 +228,9 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
         tempOr map (_.result())
       }
     }
+  //DOTTY-ONLY extension [G, ERR, X, EVERY[b] <: Every[b], SET[e] <: GenSet[e]](xs: SET[X with (G Or EVERY[ERR])])(using cbf: CanBuildFrom[SET[X with (G Or EVERY[ERR])], G, SET[G]]) {
+  //DOTTY-ONLY   def combined: SET[G] Or Every[ERR] = convertGenSetToCombinable(xs)(using cbf).combined
+  //DOTTY-ONLY }  
 
   /**
    * Implicitly converts a <code>Set</code> containing accumulating <code>Or</code>s whose <code>Good</code> type is inferred as <code>Nothing</code> to an
@@ -217,7 +243,10 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
    * <code>IterableOnce</code>s.
    * </p>
    */
+  // SKIP-DOTTY-START
   implicit def convertGenSetOnceToCombinable2[E, SET[e] <: GenSet[e]](xs: SET[Good[E]])(implicit cbf: CanBuildFrom[SET[Good[E]], Good[E], SET[Good[E]]]): Combinable[E, Nothing, SET] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertGenSetOnceToCombinable2[E, SET[e] <: GenSet[e]](xs: SET[Good[E]])(using cbf: CanBuildFrom[SET[Good[E]], Good[E], SET[Good[E]]]): Combinable[E, Nothing, SET] =
     new Combinable[E, Nothing, SET] {
       override def combined: Or[SET[E], Every[Nothing]] = {
         // So now I have an empty builder
@@ -244,7 +273,10 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
     * <code>IterableOnce</code>s.
     * </p>
     */
+  // SKIP-DOTTY-START
   implicit def convertGenSetOnceToCombinable3[E, SET[e] <: GenSet[e], EVERY[f] <: Every[f]](xs: SET[Bad[EVERY[E]]]): Combinable[Nothing, E, SET] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertGenSetOnceToCombinable3[E, SET[e] <: GenSet[e], EVERY[f] <: Every[f]](xs: SET[Bad[EVERY[E]]]): Combinable[Nothing, E, SET] =
     new Combinable[Nothing, E, SET] {
       override def combined: Or[SET[Nothing], EVERY[E]] = {
         val either: Either[EVERY[E], SET[Nothing]] =
@@ -271,8 +303,10 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
    * For more information and examples, see the <a href="Or.html#usingCombined">Using <code>combined</code></a> section of the main documentation for class <code>Or</code>.
    * </p>
    */
+  // SKIP-DOTTY-START
   implicit def convertEveryToCombinable[G, ERR](oneToMany: Every[G Or Every[ERR]]): Combinable[G, ERR, Every] = 
-
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEveryToCombinable[G, ERR](oneToMany: Every[G Or Every[ERR]]): Combinable[G, ERR, Every] = 
     new Combinable[G, ERR, Every] {
 
       def combined: Every[G] Or Every[ERR] = {
@@ -292,6 +326,9 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
         }
       }
     }
+  //DOTTY-ONLY extension [G, ERR](oneToMany: Every[G Or Every[ERR]]) {
+  //DOTTY-ONLY   def combined: Every[G] Or Every[ERR] = convertEveryToCombinable(oneToMany).combined
+  //DOTTY-ONLY }  
 
   /**
    * Implicitly converts an <code>Option</code> containing accumulating <code>Or</code>s to an instance of
@@ -301,7 +338,10 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
    * For more information and examples, see the <a href="Or.html#usingCombined">Using <code>combined</code></a> section of the main documentation for class <code>Or</code>.
    * </p>
    */
+  // SKIP-DOTTY-START
   implicit def convertOptionToCombinable[G, ERR](option: Option[G Or Every[ERR]]): Combinable[G, ERR, Option] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertOptionToCombinable[G, ERR](option: Option[G Or Every[ERR]]): Combinable[G, ERR, Option] = 
     new Combinable[G, ERR, Option] {
       def combined: Option[G] Or Every[ERR] =
         option match {
@@ -310,6 +350,9 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
           case None => Good(None)
         }
     }
+  //DOTTY-ONLY extension [G, ERR](option: Option[G Or Every[ERR]]) {
+  //DOTTY-ONLY   def combined: Option[G] Or Every[ERR] = convertOptionToCombinable(option).combined
+  //DOTTY-ONLY }  
 
   /**
    * Implicitly converts a <code>IterableOnce</code> to an instance of <code>Validatable</code>, which
@@ -320,7 +363,10 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
    * the main documentation for class <code>Or</code>.
    * </p>
    */
+  // SKIP-DOTTY-START
   implicit def convertIterableOnceToValidatable[G, ITRONCE[e] <: IterableOnce[e]](xs: ITRONCE[G]): TravValidatable[G, ITRONCE] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertIterableOnceToValidatable[G, ITRONCE[e] <: IterableOnce[e]](xs: ITRONCE[G]): TravValidatable[G, ITRONCE] = 
 
     new TravValidatable[G, ITRONCE] {
 
@@ -342,6 +388,10 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
         tempOr map (_.result())
       }
     }
+  //DOTTY-ONLY extension [G, ITRONCE[e] <: IterableOnce[e]](xs: ITRONCE[G]) {
+  //DOTTY-ONLY   def validatedBy[H, ERR, EVERY[e] <: Every[e]](fn: G => H Or EVERY[ERR])(using cbf: CanBuildFrom[ITRONCE[G], H, ITRONCE[H]]): ITRONCE[H] Or Every[ERR] = 
+  //DOTTY-ONLY     convertIterableOnceToValidatable(xs).validatedBy(fn)(using cbf)
+  //DOTTY-ONLY }  
 
   /**
    * Implicitly converts an <code>Every</code> to an instance of <code>Validatable</code>, which
@@ -352,7 +402,10 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
    * the main documentation for class <code>Or</code>.
    * </p>
    */
+  // SKIP-DOTTY-START
   implicit def convertEveryToValidatable[G](oneToMany: Every[G]): Validatable[G, Every] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertEveryToValidatable[G](oneToMany: Every[G]): Validatable[G, Every] = 
     new Validatable[G, Every] {
       def validatedBy[H, ERR, EVERY[e] <: Every[e]](fn: G => H Or EVERY[ERR]): Every[H] Or Every[ERR] = {
         val vec = oneToMany.toVector
@@ -371,6 +424,10 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
         }
       }
     }
+  //DOTTY-ONLY extension [G](oneToMany: Every[G]) {
+  //DOTTY-ONLY   def validatedBy[H, ERR, EVERY[e] <: Every[e]](fn: G => H Or EVERY[ERR]): Every[H] Or Every[ERR] =
+  //DOTTY-ONLY     convertEveryToValidatable(oneToMany).validatedBy(fn)
+  //DOTTY-ONLY }  
 
   /**
    * Implicitly converts an <code>Option</code> to an instance of <code>Validatable</code>, which
@@ -381,7 +438,10 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
    * the main documentation for class <code>Or</code>.
    * </p>
    */
+  // SKIP-DOTTY-START
   implicit def convertOptionToValidatable[G](option: Option[G]): Validatable[G, Option] = 
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertOptionToValidatable[G](option: Option[G]): Validatable[G, Option] = 
     new Validatable[G, Option] {
       def validatedBy[H, ERR, EVERY[e] <: Every[e]](fn: G => H Or EVERY[ERR]): Option[H] Or Every[ERR] = {
         option.map(fn) match {
@@ -391,6 +451,10 @@ trait Accumulation extends AccumulationLowPriorityImplicits {
         }
       }
     }
+  //DOTTY-ONLY extension [G](option: Option[G]) {
+  //DOTTY-ONLY   def validatedBy[H, ERR, EVERY[e] <: Every[e]](fn: G => H Or EVERY[ERR]): Option[H] Or Every[ERR] =
+  //DOTTY-ONLY     convertOptionToValidatable(option).validatedBy(fn)
+  //DOTTY-ONLY }  
 
   /**
    * Given 2 <code>Good</code> accumulating <code>Or</code>s, apply them to the given function and return the result, wrapped in a <code>Good</code>;

--- a/jvm/scalactic/src/main/scala/org/scalactic/Equality.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Equality.scala
@@ -252,6 +252,9 @@ object Equality {
    *
    * @return a default <code>Equivalence[A]</code>
    */
+  // SKIP-DOTTY-START 
   implicit def default[A]: Equality[A] = new DefaultEquality[A]
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given default[A]: Equality[A] = new DefaultEquality[A]
 }
 

--- a/jvm/scalactic/src/main/scala/org/scalactic/NormMethods.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/NormMethods.scala
@@ -48,12 +48,44 @@ package org.scalactic
  */
 trait NormMethods {
 
+  import NormMethods.Normalizer
+
+  // SKIP-DOTTY-START
+  import scala.language.implicitConversions
+  // SKIP-DOTTY-END
+
+  /**
+  // SKIP-DOTTY-START
+   * Implicit conversion that adds a <code>norm</code> method to a value of any type <code>T</code> for which
+   * an implicit <code>Normalization[T]</code> exists.
+  // SKIP-DOTTY-END 
+  //DOTTY-ONLY * Conversion that adds a <code>norm</code> method to a value of any type <code>T</code>  
+  //DOTTY-ONLY * using an existing <code>Normalization[T]</code>.
+   *
+   * @param o the object to convert
+   * @return a <a href="Normalizer.html"><code>Normalizer</code></a> that enables a <code>norm</code> method to be invoked on the passed object
+   */
+  // SKIP-DOTTY-START 
+  implicit def convertToNormalizer[T](o: T)(implicit normalization: Normalization[T]): Normalizer[T] = new Normalizer[T](o)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertToNormalizer[T](o: T)(using normalization: Normalization[T]): Normalizer[T] = new Normalizer[T](o)
+  //DOTTY-ONLY extension [T](o: T)(using normalization: Normalization[T]) {
+  //DOTTY-ONLY   def norm: T = convertToNormalizer(o).norm
+  //DOTTY-ONLY }
+}
+
+/**
+ * Companion object for <code>NormMethods</code> enabling its members to be imported as an alternative to mixing them in.
+ */
+object NormMethods extends NormMethods {
   /**
    * Class containing a <code>norm</code> method that normalizes the given object <code>o</code> of type <code>T</code>
    * via the implicitly passed <code>Normalization[T]</code>.
    */
+  // SKIP-DOTTY-START 
   final class Normalizer[T](o: T)(implicit normalization: Normalization[T]) {
-
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY final class Normalizer[T](o: T)(using normalization: Normalization[T]) {
     /**
      * Normalizes the object <code>o</code> of type <code>T</code> via the implicitly passed <code>Normalization[T]</code> passed
      * to the constructor of this <code>Normalizer</code>.
@@ -62,21 +94,5 @@ trait NormMethods {
      */
     def norm: T = normalization.normalized(o)
   }
-
-  import scala.language.implicitConversions
-
-  /**
-   * Implicit conversion that adds a <code>norm</code> method to a value of any type <code>T</code> for which
-   * an implicit <code>Normalization[T]</code> exists.
-   *
-   * @param o the object to convert
-   * @return a <a href="Normalizer.html"><code>Normalizer</code></a> that enables a <code>norm</code> method to be invoked on the passed object
-   */
-  implicit def convertToNormalizer[T](o: T)(implicit normalization: Normalization[T]): Normalizer[T] = new Normalizer[T](o)
-} 
-
-/**
- * Companion object for <code>NormMethods</code> enabling its members to be imported as an alternative to mixing them in.
- */
-object NormMethods extends NormMethods
+}
 

--- a/jvm/scalactic/src/main/scala/org/scalactic/Prettifier.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Prettifier.scala
@@ -365,7 +365,10 @@ object Prettifier {
    * For anything else, it returns the result of invoking `toString`.
    * </p>
    */
+  // SKIP-DOTTY-START
   implicit val default: Prettifier = new DefaultPrettifier()
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given default: Prettifier = new DefaultPrettifier()
 
   def withEscapingDiffer(p: Prettifier): Prettifier = 
     new Prettifier {

--- a/jvm/scalactic/src/main/scala/org/scalactic/TimesOnInt.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/TimesOnInt.scala
@@ -67,6 +67,49 @@ package org.scalactic
  */
 trait TimesOnInt {
 
+  import TimesOnInt.Repeater
+
+  // SKIP-DOTTY-START
+  import scala.language.implicitConversions
+  // SKIP-DOTTY-END
+
+  /**
+   * Implicit conversion that adds a <code>times</code> method to <code>Int</code>s that
+   * will repeat a given side-effecting operation multiple times.
+   *
+   * @param num the integer to which the <code>times</code> method will be added.
+   */
+  // SKIP-DOTTY-START 
+  implicit def convertIntToRepeater(num: Int): Repeater = new Repeater(num)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertIntToRepeater(num: Int): Repeater = new Repeater(num)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods for <code>Int</code> to enable the <code>times</code> method.
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY extension (num: Int) {
+  //DOTTY-ONLY   def times(fun: => Unit): Unit = convertIntToRepeater(num).times(fun)
+  //DOTTY-ONLY }
+}
+
+/**
+ * Companion object that facilitates the importing of <code>TimesOnInt</code> members as an alternative to mixing it in.
+ *
+ * <p>
+ * One use case of this companion object is to import <code>TimesOnInt</code> members so you can use them in the Scala interpreter.
+ * Here's an example: 
+ * </p>
+ *
+ * <pre class="stREPL">
+ * scala&gt; import org.scalatest.TimesOnInt._
+ * import org.scalatest.TimesOnInt._
+ * 
+ * scala&gt; 3 times println("Hello again, world!")
+ * Hello again, world!
+ * Hello again, world!
+ * Hello again, world!
+ * </pre>
+ */
+object TimesOnInt extends TimesOnInt {
   /**
    * Class used via an implicit conversion to enable a <code>times</code> method to be invoked
    * on <code>Int</code>s to repeat a given side-effecting operation multiple times.
@@ -104,35 +147,5 @@ trait TimesOnInt {
       }
     }
   }
-
-  import scala.language.implicitConversions
-
-  /**
-   * Implicit conversion that adds a <code>times</code> method to <code>Int</code>s that
-   * will repeat a given side-effecting operation multiple times.
-   *
-   * @param num the integer to which the <code>times</code> method will be added.
-   */
-  implicit def convertIntToRepeater(num: Int): Repeater = new Repeater(num)
 }
-
-/**
- * Companion object that facilitates the importing of <code>TimesOnInt</code> members as an alternative to mixing it in.
- *
- * <p>
- * One use case of this companion object is to import <code>TimesOnInt</code> members so you can use them in the Scala interpreter.
- * Here's an example: 
- * </p>
- *
- * <pre class="stREPL">
- * scala&gt; import org.scalatest.TimesOnInt._
- * import org.scalatest.TimesOnInt._
- * 
- * scala&gt; 3 times println("Hello again, world!")
- * Hello again, world!
- * Hello again, world!
- * Hello again, world!
- * </pre>
- */
-object TimesOnInt extends TimesOnInt
 

--- a/jvm/scalactic/src/main/scala/org/scalactic/TimesOnInt.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/TimesOnInt.scala
@@ -74,10 +74,13 @@ trait TimesOnInt {
   // SKIP-DOTTY-END
 
   /**
+  // SKIP-DOTTY-START
    * Implicit conversion that adds a <code>times</code> method to <code>Int</code>s that
    * will repeat a given side-effecting operation multiple times.
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY * Convert an <code>Int</code> to a <code>Repeater</code>.
    *
-   * @param num the integer to which the <code>times</code> method will be added.
+   * @param num the integer to be converted.
    */
   // SKIP-DOTTY-START 
   implicit def convertIntToRepeater(num: Int): Repeater = new Repeater(num)

--- a/jvm/scalactic/src/main/scala/org/scalactic/Tolerance.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Tolerance.scala
@@ -34,6 +34,74 @@ import TripleEqualsSupport.Spread
  */
 trait Tolerance {
 
+  import Tolerance.PlusOrMinusWrapper
+
+  // SKIP-DOTTY-START
+  import scala.language.implicitConversions
+  // SKIP-DOTTY-END
+
+  /**
+  // SKIP-DOTTY-START
+   * Implicitly converts an object of a <code>Numeric</code> type to a <code>PlusOrMinusWrapper</code>,
+   * to enable a <code>+-</code> method to be invoked on that object.
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY * Converts an object of a <code>Numeric</code> type to a <code>PlusOrMinusWrapper</code>. 
+   */
+  // SKIP-DOTTY-START
+  implicit def convertNumericToPlusOrMinusWrapper[T : Numeric](pivot: T): PlusOrMinusWrapper[T] = new PlusOrMinusWrapper(pivot)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertNumericToPlusOrMinusWrapper[T : Numeric](pivot: T): PlusOrMinusWrapper[T] = new PlusOrMinusWrapper(pivot)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods for <code>Numeric</code> types to enable the <code>+-</code> method.
+  //DOTTY-ONLY  */
+
+  //DOTTY-ONLY extension (pivot: Int) {
+  //DOTTY-ONLY   def +-(tolerance: Int): Spread[Int] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
+  //DOTTY-ONLY }
+  //DOTTY-ONLY extension (pivot: Long) {
+  //DOTTY-ONLY   def +-(tolerance: Long): Spread[Long] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
+  //DOTTY-ONLY }
+  //DOTTY-ONLY extension (pivot: Short) {
+  //DOTTY-ONLY   def +-(tolerance: Short): Spread[Short] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
+  //DOTTY-ONLY }
+  //DOTTY-ONLY extension (pivot: Byte) {
+  //DOTTY-ONLY   def +-(tolerance: Byte): Spread[Byte] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
+  //DOTTY-ONLY }
+  //DOTTY-ONLY extension (pivot: Char) {
+  //DOTTY-ONLY   def +-(tolerance: Char): Spread[Char] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
+  //DOTTY-ONLY }
+  //DOTTY-ONLY extension (pivot: Float) {
+  //DOTTY-ONLY   def +-(tolerance: Float): Spread[Float] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
+  //DOTTY-ONLY }
+  //DOTTY-ONLY extension (pivot: Double) {
+  //DOTTY-ONLY   def +-(tolerance: Double): Spread[Double] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
+  //DOTTY-ONLY }
+  //DOTTY-ONLY extension [T: Numeric](pivot: T) {
+  //DOTTY-ONLY   def +-(tolerance: T): Spread[T] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
+  //DOTTY-ONLY }
+}
+
+/**
+ * Companion object to trait <code>Tolerance</code> that facilitates the importing of <code>Tolerance</code> members as 
+ * an alternative to mixing it in. One use case is to import <code>Tolerance</code> members so you can use
+ * them in the Scala interpreter:
+ *
+ * <pre class="stREPL">
+ * $ scala -classpath scalactic.jar
+ * Welcome to Scala 2.13.6 (OpenJDK 64-Bit Server VM, Java yyy).
+ * Type in expressions for evaluation. Or try :help.
+ *
+ * scala&gt; import org.scalactic._
+ * import org.scalactic._
+ *
+ * scala&gt; import Tolerance._
+ * import Tolerance._
+ *
+ * scala&gt; 1.0 +- 0.1
+ * res0: org.scalactic.TripleEqualsSupport.Spread[Double] = Spread(1.0,0.1)
+ * </pre>
+ */
+object Tolerance extends Tolerance {
   /**
    * Wrapper class with a <code>+-</code> method that, given a <code>Numeric</code> argument, returns a <code>Spread</code>.
    * 
@@ -57,35 +125,5 @@ trait Tolerance {
       Spread(pivot, tolerance)
     }
   }
-
-  import scala.language.implicitConversions
-
-  /**
-   * Implicitly converts an object of a <code>Numeric</code> type to a <code>PlusOrMinusWrapper</code>,
-   * to enable a <code>+-</code> method to be invoked on that object.
-   */
-  implicit def convertNumericToPlusOrMinusWrapper[T : Numeric](pivot: T): PlusOrMinusWrapper[T] = new PlusOrMinusWrapper(pivot)
 }
-
-/**
- * Companion object to trait <code>Tolerance</code> that facilitates the importing of <code>Tolerance</code> members as 
- * an alternative to mixing it in. One use case is to import <code>Tolerance</code> members so you can use
- * them in the Scala interpreter:
- *
- * <pre class="stREPL">
- * $ scala -classpath scalactic.jar
- * Welcome to Scala 2.13.6 (OpenJDK 64-Bit Server VM, Java yyy).
- * Type in expressions for evaluation. Or try :help.
- *
- * scala&gt; import org.scalactic._
- * import org.scalactic._
- *
- * scala&gt; import Tolerance._
- * import Tolerance._
- *
- * scala&gt; 1.0 +- 0.1
- * res0: org.scalactic.TripleEqualsSupport.Spread[Double] = Spread(1.0,0.1)
- * </pre>
- */
-object Tolerance extends Tolerance
 

--- a/jvm/scalactic/src/main/scala/org/scalactic/Tolerance.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/Tolerance.scala
@@ -51,31 +51,52 @@ trait Tolerance {
   implicit def convertNumericToPlusOrMinusWrapper[T : Numeric](pivot: T): PlusOrMinusWrapper[T] = new PlusOrMinusWrapper(pivot)
   // SKIP-DOTTY-END
   //DOTTY-ONLY def convertNumericToPlusOrMinusWrapper[T : Numeric](pivot: T): PlusOrMinusWrapper[T] = new PlusOrMinusWrapper(pivot)
+  
   //DOTTY-ONLY /**
-  //DOTTY-ONLY  * Extension methods for <code>Numeric</code> types to enable the <code>+-</code> method.
+  //DOTTY-ONLY  * Extension methods for <code>Int</code> types to enable the <code>+-</code> method.
   //DOTTY-ONLY  */
-
   //DOTTY-ONLY extension (pivot: Int) {
   //DOTTY-ONLY   def +-(tolerance: Int): Spread[Int] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
   //DOTTY-ONLY }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods for <code>Long</code> types to enable the <code>+-</code> method.
+  //DOTTY-ONLY  */
   //DOTTY-ONLY extension (pivot: Long) {
   //DOTTY-ONLY   def +-(tolerance: Long): Spread[Long] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
   //DOTTY-ONLY }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods for <code>Short</code> types to enable the <code>+-</code> method.
+  //DOTTY-ONLY  */
   //DOTTY-ONLY extension (pivot: Short) {
   //DOTTY-ONLY   def +-(tolerance: Short): Spread[Short] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
   //DOTTY-ONLY }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods for <code>Byte</code> types to enable the <code>+-</code> method.
+  //DOTTY-ONLY  */
   //DOTTY-ONLY extension (pivot: Byte) {
   //DOTTY-ONLY   def +-(tolerance: Byte): Spread[Byte] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
   //DOTTY-ONLY }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods for <code>Char</code> types to enable the <code>+-</code> method.
+  //DOTTY-ONLY  */
   //DOTTY-ONLY extension (pivot: Char) {
   //DOTTY-ONLY   def +-(tolerance: Char): Spread[Char] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
   //DOTTY-ONLY }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods for <code>Float</code> types to enable the <code>+-</code> method.
+  //DOTTY-ONLY  */
   //DOTTY-ONLY extension (pivot: Float) {
   //DOTTY-ONLY   def +-(tolerance: Float): Spread[Float] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
   //DOTTY-ONLY }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods for <code>Double</code> types to enable the <code>+-</code> method.
+  //DOTTY-ONLY  */
   //DOTTY-ONLY extension (pivot: Double) {
   //DOTTY-ONLY   def +-(tolerance: Double): Spread[Double] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
   //DOTTY-ONLY }
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods for general <code>Numeric</code> types to enable the <code>+-</code> method.
+  //DOTTY-ONLY  */
   //DOTTY-ONLY extension [T: Numeric](pivot: T) {
   //DOTTY-ONLY   def +-(tolerance: T): Spread[T] = convertNumericToPlusOrMinusWrapper(pivot).+-(tolerance)
   //DOTTY-ONLY }

--- a/jvm/scalactic/src/main/scala/org/scalactic/TripleEquals.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/TripleEquals.scala
@@ -120,14 +120,26 @@ import TripleEqualsSupport._
  */
 trait TripleEquals extends TripleEqualsSupport {
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   // Inherit the Scaladoc for these methods
 
+  // SKIP-DOTTY-START
   implicit override def convertToEqualizer[T](left: T): Equalizer[T] = new Equalizer(left)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def convertToEqualizer[T](left: T): Equalizer[T] = new Equalizer(left)
+  //DOTTY-ONLY given[T]: Conversion[T, Equalizer[T]] with {
+  //DOTTY-ONLY   def apply(left: T): Equalizer[T] = convertToEqualizer(left)
+  //DOTTY-ONLY }
   override def convertToCheckingEqualizer[T](left: T): CheckingEqualizer[T] = new CheckingEqualizer(left)
 
+  // SKIP-DOTTY-START
   implicit override def unconstrainedEquality[A, B](implicit equalityOfA: Equality[A]): A CanEqual B = new EqualityConstraint[A, B](equalityOfA)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY override def unconstrainedEquality[A, B](using equalityOfA: Equality[A]): A CanEqual B = new EqualityConstraint[A, B](equalityOfA)
+  //DOTTY-ONLY given[A, B](using equalityOfA: Equality[A]): (A CanEqual B) = unconstrainedEquality(using equalityOfA)
 
   override def lowPriorityTypeCheckedConstraint[A, B](implicit equivalenceOfB: Equivalence[B], ev: A <:< B): A CanEqual B = new AToBEquivalenceConstraint[A, B](equivalenceOfB, ev)
   override def convertEquivalenceToAToBConstraint[A, B](equivalenceOfB: Equivalence[B])(implicit ev: A <:< B): A CanEqual B = new AToBEquivalenceConstraint[A, B](equivalenceOfB, ev)

--- a/jvm/scalactic/src/main/scala/org/scalactic/TripleEquals.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/TripleEquals.scala
@@ -120,26 +120,14 @@ import TripleEqualsSupport._
  */
 trait TripleEquals extends TripleEqualsSupport {
 
-  // SKIP-DOTTY-START
   import scala.language.implicitConversions
-  // SKIP-DOTTY-END
-
+  
   // Inherit the Scaladoc for these methods
 
-  // SKIP-DOTTY-START
   implicit override def convertToEqualizer[T](left: T): Equalizer[T] = new Equalizer(left)
-  // SKIP-DOTTY-END
-  //DOTTY-ONLY def convertToEqualizer[T](left: T): Equalizer[T] = new Equalizer(left)
-  //DOTTY-ONLY given[T]: Conversion[T, Equalizer[T]] with {
-  //DOTTY-ONLY   def apply(left: T): Equalizer[T] = convertToEqualizer(left)
-  //DOTTY-ONLY }
   override def convertToCheckingEqualizer[T](left: T): CheckingEqualizer[T] = new CheckingEqualizer(left)
 
-  // SKIP-DOTTY-START
   implicit override def unconstrainedEquality[A, B](implicit equalityOfA: Equality[A]): A CanEqual B = new EqualityConstraint[A, B](equalityOfA)
-  // SKIP-DOTTY-END
-  //DOTTY-ONLY override def unconstrainedEquality[A, B](using equalityOfA: Equality[A]): A CanEqual B = new EqualityConstraint[A, B](equalityOfA)
-  //DOTTY-ONLY given[A, B](using equalityOfA: Equality[A]): (A CanEqual B) = unconstrainedEquality(using equalityOfA)
 
   override def lowPriorityTypeCheckedConstraint[A, B](implicit equivalenceOfB: Equivalence[B], ev: A <:< B): A CanEqual B = new AToBEquivalenceConstraint[A, B](equivalenceOfB, ev)
   override def convertEquivalenceToAToBConstraint[A, B](equivalenceOfB: Equivalence[B])(implicit ev: A <:< B): A CanEqual B = new AToBEquivalenceConstraint[A, B](equivalenceOfB, ev)

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
@@ -1121,7 +1121,7 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
   //DOTTY-ONLY protected def convertToWordSpecStringWrapper(s: String): WordSpecStringWrapper = new WordSpecStringWrapper(s)
 
   //DOTTY-ONLY /**
-  //DOTTY-ONLY  * Extension methods that provide methods that can be invoked on <code>String</code>s, such as <code>in</code>, <code>is</code>, <code>taggedAs</code>, and <code>ignore</code>.
+  //DOTTY-ONLY  * Extension that provide methods that can be invoked on <code>String</code>s, such as <code>in</code>, <code>is</code>, <code>taggedAs</code>, and <code>ignore</code>.
   //DOTTY-ONLY  *
   //DOTTY-ONLY  * <p>
   //DOTTY-ONLY  * The extension methods enables syntax such as the following test registration:

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
@@ -1104,7 +1104,9 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
    */
   protected val they = new TheyWord
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
    * Implicitly converts <code>String</code>s to <code>WordSpecStringWrapper</code>, which enables
@@ -1183,7 +1185,10 @@ one error found
    * subject and executes the block.
    * </p>
    */
+  // SKIP-DOTTY-START 
   protected implicit val subjectWithAfterWordRegistrationFunction: SubjectWithAfterWordRegistration =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected given SubjectWithAfterWordRegistration =
     new SubjectWithAfterWordRegistration {
       def apply(left: String, verb: String, resultOfAfterWordApplication: ResultOfAfterWordApplication, pos: source.Position): Unit = {
         val afterWordFunction =

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
@@ -398,8 +398,8 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
       registerTestToRun(string, List(), "in", () => f, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(f: => Any /* Assertion */): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToRun(string, List(), "in", () => f, pos)}) } 
+    //DOTTY-ONLY def in(f: => Any /* Assertion */)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY  registerTestToRun(string, List(), "in", () => f, pos)
     //DOTTY-ONLY }
 
     /**
@@ -423,8 +423,8 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
       registerTestToIgnore(string, List(), "ignore", () => f, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(f: => Any /* Assertion */): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToIgnore(string, List(), "ignore", () => f, pos)}) } 
+    //DOTTY-ONLY def ignore(f: => Any /* Assertion */)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerTestToIgnore(string, List(), "ignore", () => f, pos)
     //DOTTY-ONLY }
 
     /**
@@ -448,8 +448,8 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
       registerTestToRun(string, List(), "is", () => { f; succeed }, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def is(f: => PendingStatement): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToRun(string, List(), "is", () => { f; succeed }, pos)}) } 
+    //DOTTY-ONLY def is(f: => PendingStatement)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerTestToRun(string, List(), "is", () => { f; succeed }, pos) 
     //DOTTY-ONLY }
 
     /**
@@ -468,7 +468,6 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
      * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
      * </p>
      */
-    //DOTTY-ONLY     infix  
     def taggedAs(firstTestTag: Tag, otherTestTags: Tag*) = {
       val tagList = firstTestTag :: otherTestTags.toList
       new ResultOfTaggedAsInvocationOnString(string, tagList)
@@ -499,8 +498,8 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
       registerBranch(string, Some("when"), "when", "when", stackDepth, -2, pos, () => f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def when(f: => Unit): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string, Some("when"), "when", "when", 4, -2, pos, () => f)}) } 
+    //DOTTY-ONLY def when(f: => Unit)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string, Some("when"), "when", "when", 4, -2, pos, () => f) 
     //DOTTY-ONLY }
 
     /**
@@ -526,8 +525,8 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
       registerBranch(string, Some("when " + resultOfAfterWordApplication.text), "when", "when", 4, -2, pos, resultOfAfterWordApplication.f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def when(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string, Some("when " + resultOfAfterWordApplication.text), "when", "when", 4, -2, pos, resultOfAfterWordApplication.f)}) } 
+    //DOTTY-ONLY def when(resultOfAfterWordApplication: ResultOfAfterWordApplication)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string, Some("when " + resultOfAfterWordApplication.text), "when", "when", 4, -2, pos, resultOfAfterWordApplication.f)
     //DOTTY-ONLY }
 
     /**
@@ -555,8 +554,8 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
       registerBranch(string.trim + " that", None, "that", "that", stackDepth, -2, pos, () => f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def that(f: => Unit): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " that", None, "that", "that", 4, -2, pos, () => f)}) } 
+    //DOTTY-ONLY def that(f: => Unit)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string.trim + " that", None, "that", "that", 4, -2, pos, () => f)
     //DOTTY-ONLY }
 
     /**
@@ -584,8 +583,8 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
       registerBranch(string.trim + " which", None, "which", "which", stackDepth, -2, pos, () => f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def which(f: => Unit): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " which", None, "which", "which", 4, -2, pos, () => f)}) } 
+    //DOTTY-ONLY def which(f: => Unit)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string.trim + " which", None, "which", "which", 4, -2, pos, () => f)
     //DOTTY-ONLY }
 
     /**
@@ -611,8 +610,8 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
       registerBranch(string.trim + " that " + resultOfAfterWordApplication.text.trim, None, "that", "that", 4, -2, pos, resultOfAfterWordApplication.f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def that(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " that " + resultOfAfterWordApplication.text.trim, None, "that", "that", 4, -2, pos, resultOfAfterWordApplication.f)}) } 
+    //DOTTY-ONLY def that(resultOfAfterWordApplication: ResultOfAfterWordApplication)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string.trim + " that " + resultOfAfterWordApplication.text.trim, None, "that", "that", 4, -2, pos, resultOfAfterWordApplication.f)
     //DOTTY-ONLY }
     
     /**
@@ -638,8 +637,8 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
       registerBranch(string.trim + " which " + resultOfAfterWordApplication.text.trim, None, "which", "which", 4, -2, pos, resultOfAfterWordApplication.f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def which(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " which " + resultOfAfterWordApplication.text.trim, None, "which", "which", 4, -2, pos, resultOfAfterWordApplication.f)}) } 
+    //DOTTY-ONLY def which(resultOfAfterWordApplication: ResultOfAfterWordApplication)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string.trim + " which " + resultOfAfterWordApplication.text.trim, None, "which", "which", 4, -2, pos, resultOfAfterWordApplication.f)
     //DOTTY-ONLY }
   }
 
@@ -1113,7 +1112,217 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
    * methods <code>when</code>, <code>which</code>, <code>in</code>, <code>is</code>, <code>taggedAs</code>
    * and <code>ignore</code> to be invoked on <code>String</code>s.
    */
+  // SKIP-DOTTY-START
   protected implicit def convertToWordSpecStringWrapper(s: String): WordSpecStringWrapper = new WordSpecStringWrapper(s)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected def convertToWordSpecStringWrapper(s: String): WordSpecStringWrapper = new WordSpecStringWrapper(s)
+
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension methods that provide methods that can be invoked on <code>String</code>s, such as <code>in</code>, <code>is</code>, <code>taggedAs</code>, and <code>ignore</code>.
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <p>
+  //DOTTY-ONLY  * The extension methods enables syntax such as the following test registration:
+  //DOTTY-ONLY  * </p>
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <pre class="stHighlight">
+  //DOTTY-ONLY  * "A Stack" when { ... }
+  //DOTTY-ONLY  * 
+  //DOTTY-ONLY  * "should pop values in last-in-first-out order" in { ... }
+  //DOTTY-ONLY  * ^
+  //DOTTY-ONLY  * </pre>
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <p>
+  //DOTTY-ONLY  * For more information and examples of the use of this syntax, see the main documentation 
+  //DOTTY-ONLY  * for <code>AnyWordSpec</code>.
+  //DOTTY-ONLY  * </p>
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY extension (s: String) {
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" in { ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   infix inline def in(f: => Any /* Assertion */): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => new WordSpecStringWrapper(s).in(f)(using pos)}) }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports ignored test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" ignore { ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   infix inline def ignore(f: => Any /* Assertion */): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => new WordSpecStringWrapper(s).ignore(f)(using pos)}) }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports pending test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" is (pending)
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   infix inline def is(f: => PendingStatement): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => new WordSpecStringWrapper(s).is(f)(using pos)}) }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports tagged test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" taggedAs(SlowTest) in { ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   infix def taggedAs(firstTestTag: Tag, otherTestTags: Tag*) = new WordSpecStringWrapper(s).taggedAs(firstTestTag, otherTestTags*)
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>when</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" when { ... }
+  //DOTTY-ONLY    *           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   infix inline def when(f: => Unit): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => new WordSpecStringWrapper(s).when(f)(using pos)}) }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>when</code> clause that is followed by an <em>after word</em>.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * val theUser = afterWord("the user")
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * "A Stack" when theUser { ... }
+  //DOTTY-ONLY    *           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   infix inline def when(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => new WordSpecStringWrapper(s).when(resultOfAfterWordApplication)(using pos)}) }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>that</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "a rerun button" that {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   infix inline def that(f: => Unit): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => new WordSpecStringWrapper(s).that(f)(using pos)}) }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>which</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "a rerun button," which {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   infix inline def which(f: => Unit): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => new WordSpecStringWrapper(s).which(f)(using pos)}) }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>that</code> clause that is followed by an <em>after word</em>.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * def is = afterWord("is")
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * "a rerun button" that is {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   infix inline def that(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => new WordSpecStringWrapper(s).that(resultOfAfterWordApplication)(using pos)}) }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>which</code> clause that is followed by an <em>after word</em>.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * def is = afterWord("is")
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * "a rerun button," which is {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   infix inline def which(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = 
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => new WordSpecStringWrapper(s).which(resultOfAfterWordApplication)(using pos)}) }
+  //DOTTY-ONLY }
 
   // Used to enable should/can/must to take a block (except one that results in type string. May
   // want to mention this as a gotcha.)

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
@@ -1367,7 +1367,7 @@ one error found
   // SKIP-DOTTY-START 
   protected implicit val subjectRegistrationFunction: StringVerbBlockRegistration =
   // SKIP-DOTTY-END
-  //DOTTY-ONLY protected given StringVerbBlockRegistration = 
+  //DOTTY-ONLY protected given subjectRegistrationFunction: StringVerbBlockRegistration = 
     new StringVerbBlockRegistration {
       def apply(left: String, verb: String, pos: source.Position, f: () => Unit): Unit = registerBranch(left, Some(verb), verb, "apply", 6, -2, pos, f)
     }
@@ -1397,7 +1397,7 @@ one error found
   // SKIP-DOTTY-START 
   protected implicit val subjectWithAfterWordRegistrationFunction: SubjectWithAfterWordRegistration =
   // SKIP-DOTTY-END
-  //DOTTY-ONLY protected given SubjectWithAfterWordRegistration =
+  //DOTTY-ONLY protected given subjectWithAfterWordRegistrationFunction: SubjectWithAfterWordRegistration =
     new SubjectWithAfterWordRegistration {
       def apply(left: String, verb: String, resultOfAfterWordApplication: ResultOfAfterWordApplication, pos: source.Position): Unit = {
         val afterWordFunction =

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
@@ -1153,7 +1153,10 @@ one error found
    * subject and executes the block.
    * </p>
    */
+  // SKIP-DOTTY-START 
   protected implicit val subjectRegistrationFunction: StringVerbBlockRegistration =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected given StringVerbBlockRegistration = 
     new StringVerbBlockRegistration {
       def apply(left: String, verb: String, pos: source.Position, f: () => Unit): Unit = registerBranch(left, Some(verb), verb, "apply", 6, -2, pos, f)
     }

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
@@ -1108,7 +1108,10 @@ trait AnyWordSpecLike extends TestSuite with ShouldVerb with MustVerb with CanVe
   // SKIP-DOTTY-END
 
   /**
+   // SKIP-DOTTY-START
    * Implicitly converts <code>String</code>s to <code>WordSpecStringWrapper</code>, which enables
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY  * Converts <code>String</code>s to <code>WordSpecStringWrapper</code>, which enables
    * methods <code>when</code>, <code>which</code>, <code>in</code>, <code>is</code>, <code>taggedAs</code>
    * and <code>ignore</code> to be invoked on <code>String</code>s.
    */

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpecLike.scala
@@ -1112,6 +1112,20 @@ trait AsyncWordSpecLike extends AsyncTestSuite with ShouldVerb with MustVerb wit
   protected implicit def convertToWordSpecStringWrapper(s: String): WordSpecStringWrapper = new WordSpecStringWrapper(s)
   // SKIP-DOTTY-END
   //DOTTY-ONLY protected def convertToWordSpecStringWrapper(s: String): WordSpecStringWrapper = new WordSpecStringWrapper(s)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension that  enables methods <code>when</code>, <code>which</code>, <code>in</code>, <code>is</code>, <code>taggedAs</code>
+  //DOTTY-ONLY  * and <code>ignore</code> to be invoked on <code>String</code>s.
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <p>
+  //DOTTY-ONLY  * This class provides much of the syntax for <code>AsyncWordSpec</code>, however, it does not add
+  //DOTTY-ONLY  * the verb methods (<code>should</code>, <code>must</code>, and <code>can</code>) to <code>String</code>.
+  //DOTTY-ONLY  * Instead, these are added via the <code>ShouldVerb</code>, <code>MustVerb</code>, and <code>CanVerb</code>
+  //DOTTY-ONLY  * traits, which <code>AsyncWordSpec</code> mixes in, to avoid a conflict with implicit conversions provided
+  //DOTTY-ONLY  * in <code>Matchers</code> and <code>MustMatchers</code>.
+  //DOTTY-ONLY  * </p>
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * @author Bill Venners
+  //DOTTY-ONLY  */
   //DOTTY-ONLY extension (s: String) {
   //DOTTY-ONLY   /**
   //DOTTY-ONLY    * Supports test registration.

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/AsyncWordSpecLike.scala
@@ -403,8 +403,8 @@ trait AsyncWordSpecLike extends AsyncTestSuite with ShouldVerb with MustVerb wit
       registerTestToRun(string, List(), "in", () => f, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(f: => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToRun(string, List(), "in", () => f, pos) }) } 
+    //DOTTY-ONLY def in(f: => Future[compatible.Assertion])(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerTestToRun(string, List(), "in", () => f, pos)
     //DOTTY-ONLY }
 
     /**
@@ -428,8 +428,8 @@ trait AsyncWordSpecLike extends AsyncTestSuite with ShouldVerb with MustVerb wit
       registerTestToIgnore(string, List(), "ignore", () => f, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(f: => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToIgnore(string, List(), "ignore", () => f, pos) }) } 
+    //DOTTY-ONLY def ignore(f: => Future[compatible.Assertion])(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerTestToIgnore(string, List(), "ignore", () => f, pos)
     //DOTTY-ONLY }
 
     /**
@@ -453,8 +453,8 @@ trait AsyncWordSpecLike extends AsyncTestSuite with ShouldVerb with MustVerb wit
       registerPendingTestToRun(string, List(), "is", () => f, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def is(f: => PendingStatement): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerPendingTestToRun(string, List(), "is", () => f, pos) }) } 
+    //DOTTY-ONLY def is(f: => PendingStatement)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerPendingTestToRun(string, List(), "is", () => f, pos)
     //DOTTY-ONLY }
 
     /**
@@ -473,7 +473,6 @@ trait AsyncWordSpecLike extends AsyncTestSuite with ShouldVerb with MustVerb wit
      * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
      * </p>
      */
-    //DOTTY-ONLY     infix  
     def taggedAs(firstTestTag: Tag, otherTestTags: Tag*) = {
       val tagList = firstTestTag :: otherTestTags.toList
       new ResultOfTaggedAsInvocationOnString(string, tagList)
@@ -500,8 +499,8 @@ trait AsyncWordSpecLike extends AsyncTestSuite with ShouldVerb with MustVerb wit
       registerBranch(string, Some("when"), "when", pos, () => f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def when(f: => Unit)(implicit pos: source.Position): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string, Some("when"), "when", pos, () => f) }) } 
+    //DOTTY-ONLY def when(f: => Unit)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string, Some("when"), "when", pos, () => f)
     //DOTTY-ONLY }
 
     /**
@@ -527,8 +526,8 @@ trait AsyncWordSpecLike extends AsyncTestSuite with ShouldVerb with MustVerb wit
       registerBranch(string, Some("when " + resultOfAfterWordApplication.text), "when", pos, resultOfAfterWordApplication.f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def when(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string, Some("when " + resultOfAfterWordApplication.text), "when", pos, resultOfAfterWordApplication.f) }) } 
+    //DOTTY-ONLY def when(resultOfAfterWordApplication: ResultOfAfterWordApplication)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string, Some("when " + resultOfAfterWordApplication.text), "when", pos, resultOfAfterWordApplication.f)
     //DOTTY-ONLY }
 
     /**
@@ -552,8 +551,8 @@ trait AsyncWordSpecLike extends AsyncTestSuite with ShouldVerb with MustVerb wit
       registerBranch(string.trim + " that", None, "that", pos, () => f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def that(f: => Unit): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " that", None, "that", pos, () => f) }) } 
+    //DOTTY-ONLY def that(f: => Unit)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string.trim + " that", None, "that", pos, () => f)
     //DOTTY-ONLY }
 
     /**
@@ -577,8 +576,8 @@ trait AsyncWordSpecLike extends AsyncTestSuite with ShouldVerb with MustVerb wit
       registerBranch(string.trim + " which", None, "which", pos, () => f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def which(f: => Unit): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " which", None, "which", pos, () => f) }) } 
+    //DOTTY-ONLY inline infix def which(f: => Unit)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string.trim + " which", None, "which", pos, () => f)
     //DOTTY-ONLY }
 
     /**
@@ -604,8 +603,8 @@ trait AsyncWordSpecLike extends AsyncTestSuite with ShouldVerb with MustVerb wit
       registerBranch(string.trim + " that " + resultOfAfterWordApplication.text.trim, None, "that", pos, resultOfAfterWordApplication.f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def that(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " that " + resultOfAfterWordApplication.text.trim, None, "that", pos, resultOfAfterWordApplication.f) }) } 
+    //DOTTY-ONLY def that(resultOfAfterWordApplication: ResultOfAfterWordApplication)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string.trim + " that " + resultOfAfterWordApplication.text.trim, None, "that", pos, resultOfAfterWordApplication.f)
     //DOTTY-ONLY }
 
     /**
@@ -631,8 +630,8 @@ trait AsyncWordSpecLike extends AsyncTestSuite with ShouldVerb with MustVerb wit
       registerBranch(string.trim + " which " + resultOfAfterWordApplication.text.trim, None, "which", pos, resultOfAfterWordApplication.f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def which(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " which " + resultOfAfterWordApplication.text.trim, None, "which", pos, resultOfAfterWordApplication.f) }) } 
+    //DOTTY-ONLY def which(resultOfAfterWordApplication: ResultOfAfterWordApplication)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string.trim + " which " + resultOfAfterWordApplication.text.trim, None, "which", pos, resultOfAfterWordApplication.f)
     //DOTTY-ONLY }
   }
 
@@ -1097,14 +1096,221 @@ trait AsyncWordSpecLike extends AsyncTestSuite with ShouldVerb with MustVerb wit
    */
   protected val they = new TheyWord
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
+   // SKIP-DOTTY-START
    * Implicitly converts <code>String</code>s to <code>WordSpecStringWrapper</code>, which enables
+   // SKIP-DOTTY-END
+   //DOTTY-ONLY  * Converts <code>String</code>s to <code>WordSpecStringWrapper</code>, which enables
    * methods <code>when</code>, <code>which</code>, <code>in</code>, <code>is</code>, <code>taggedAs</code>
    * and <code>ignore</code> to be invoked on <code>String</code>s.
    */
+  // SKIP-DOTTY-START 
   protected implicit def convertToWordSpecStringWrapper(s: String): WordSpecStringWrapper = new WordSpecStringWrapper(s)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected def convertToWordSpecStringWrapper(s: String): WordSpecStringWrapper = new WordSpecStringWrapper(s)
+  //DOTTY-ONLY extension (s: String) {
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" in { ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def in(f: => Future[compatible.Assertion]): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToRun(s, List(), "in", () => f, pos) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports ignored test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" ignore { ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def ignore(f: => Future[compatible.Assertion]): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToIgnore(s, List(), "ignore", () => f, pos) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports pending test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" is (pending)
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def is(f: => PendingStatement): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerPendingTestToRun(s, List(), "is", () => f, pos) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports tagged test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" taggedAs(SlowTest) in { ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   infix def taggedAs(firstTestTag: Tag, otherTestTags: Tag*) = {
+  //DOTTY-ONLY     val tagList = firstTestTag :: otherTestTags.toList
+  //DOTTY-ONLY     new ResultOfTaggedAsInvocationOnString(s, tagList)
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>when</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" when { ... }
+  //DOTTY-ONLY    *           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def when(f: => Unit)(implicit pos: source.Position): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(s, Some("when"), "when", pos, () => f) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>when</code> clause that is followed by an <em>after word</em>.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * val theUser = afterWord("the user")
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * "A Stack" when theUser { ... }
+  //DOTTY-ONLY    *           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def when(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(s, Some("when " + resultOfAfterWordApplication.text), "when", pos, resultOfAfterWordApplication.f) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>that</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "a rerun button" that {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def that(f: => Unit): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(s.trim + " that", None, "that", pos, () => f) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>which</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "a rerun button," which {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def which(f: => Unit): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(s.trim + " which", None, "which", pos, () => f) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>that</code> clause that is followed by an <em>after word</em>.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * def is = afterWord("is")
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * "a rerun button" that is {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def that(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(s.trim + " that " + resultOfAfterWordApplication.text.trim, None, "that", pos, resultOfAfterWordApplication.f) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>which</code> clause that is followed by an <em>after word</em>.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * def is = afterWord("is")
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * "a rerun button," which is {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="AnyWordSpec.html">main documentation</a> for trait <code>AnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def which(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(s.trim + " which " + resultOfAfterWordApplication.text.trim, None, "which", pos, resultOfAfterWordApplication.f) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY }
 
   // Used to enable should/can/must to take a block (except one that results in type string. May
   // want to mention this as a gotcha.)
@@ -1146,7 +1352,10 @@ one error found
    * subject and executes the block.
    * </p>
    */
+  // SKIP-DOTTY-START
   protected implicit val subjectRegistrationFunction: StringVerbBlockRegistration =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected given subjectRegistrationFunction: StringVerbBlockRegistration =
     new StringVerbBlockRegistration {
       def apply(left: String, verb: String, pos: source.Position, f: () => Unit): Unit = registerBranch(left, Some(verb), verb, pos, f)
     }
@@ -1173,7 +1382,10 @@ one error found
    * subject and executes the block.
    * </p>
    */
+  // SKIP-DOTTY-START
   protected implicit val subjectWithAfterWordRegistrationFunction: SubjectWithAfterWordRegistration =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected given subjectWithAfterWordRegistrationFunction: SubjectWithAfterWordRegistration =
     new SubjectWithAfterWordRegistration {
       def apply(left: String, verb: String, resultOfAfterWordApplication: ResultOfAfterWordApplication, pos: source.Position): Unit = {
       val afterWordFunction =

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpecLike.scala
@@ -1296,7 +1296,9 @@ trait FixtureAnyWordSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
    */
   protected val they = new TheyWord
 
+  // SKIP-DOTTY-START
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
    * Implicitly converts <code>String</code>s to <code>WordSpecStringWrapper</code>, which enables
@@ -1306,7 +1308,291 @@ trait FixtureAnyWordSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
    * @param s <code>String</code> to be wrapped
    * @return an instance of <code>WordSpecStringWrapper</code>
    */
+  // SKIP-DOTTY-START
   protected implicit def convertToWordSpecStringWrapper(s: String): WordSpecStringWrapper = new WordSpecStringWrapper(s)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected def convertToWordSpecStringWrapper(s: String): WordSpecStringWrapper = new WordSpecStringWrapper(s)
+  //DOTTY-ONLY /**
+  //DOTTY-ONLY  * Extension that enables methods <code>when</code>, <code>which</code>, <code>in</code>, <code>is</code>, <code>taggedAs</code>
+  //DOTTY-ONLY  * and <code>ignore</code> to be invoked on <code>String</code>s.
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * <p>
+  //DOTTY-ONLY  * This class provides much of the syntax for <code>FixtureAnyWordSpec</code>, however, it does not add
+  //DOTTY-ONLY  * the verb methods (<code>should</code>, <code>must</code>, and <code>can</code>) to <code>String</code>.
+  //DOTTY-ONLY  * Instead, these are added via the <code>ShouldVerb</code>, <code>MustVerb</code>, and <code>CanVerb</code>
+  //DOTTY-ONLY  * traits, which <code>FixtureAnyWordSpec</code> mixes in, to avoid a conflict with implicit conversions provided
+  //DOTTY-ONLY  * in <code>Matchers</code> and <code>MustMatchers</code>.
+  //DOTTY-ONLY  * </p>
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * @param string the string that is being extended
+  //DOTTY-ONLY  *
+  //DOTTY-ONLY  * @author Bill Venners
+  //DOTTY-ONLY  */
+  //DOTTY-ONLY extension (string: String) {
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" in { fixture => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def in(testFun: FixtureParam => Any /* Assertion */): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToRun(string, List(), "in", testFun, pos)}) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   private final def inImpl(testFun: () => Any /* Assertion */, pos: source.Position): Unit = {
+  //DOTTY-ONLY     registerTestToRun(string, List(), "in", new org.scalatest.fixture.NoArgTestWrapper(testFun), pos)
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports registration of tests that take no fixture.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" in { () => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def in(testFun: () => Any /* Assertion */): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => inImpl(testFun, pos) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports pending test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" is (pending)
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def is(testFun: => PendingStatement): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerPendingTestToRun(string, List(), "is", unusedFixtureParam => testFun, pos)}) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports ignored test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" ignore { fixture => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def ignore(testFun: FixtureParam => Any /* Assertion */): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerTestToIgnore(string, List(), "ignore", testFun, pos)}) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   private final def ignoreImpl(testFun: () => Any /* Assertion */, pos: source.Position): Unit = {
+  //DOTTY-ONLY     registerTestToIgnore(string, List(), "ignore", new org.scalatest.fixture.NoArgTestWrapper(testFun), pos)
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports registration of ignored tests that take no fixture.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" ignore { () => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def ignore(testFun: () => Any /* Assertion */): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => ignoreImpl(testFun, pos) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports tagged test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" taggedAs(SlowTest) in { fixture => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param firstTestTag the first mandatory test tag
+  //DOTTY-ONLY    * @param otherTestTags the others additional test tags
+  //DOTTY-ONLY    * @return an new instance of <code>ResultOfTaggedAsInvocationOnString</code>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   infix def taggedAs(firstTestTag: Tag, otherTestTags: Tag*) = {
+  //DOTTY-ONLY     val tagList = firstTestTag :: otherTestTags.toList
+  //DOTTY-ONLY     new ResultOfTaggedAsInvocationOnString(string, tagList)
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>when</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" when { ... }
+  //DOTTY-ONLY    *           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param f the function which is the body of the scope
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def when(f: => Unit): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string, Some("when"), "when", "when", 4, -2, pos, () => f)}) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>when</code> clause that is followed by an <em>after word</em>.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * val theUser = afterWord("the user")
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * "A Stack" when theUser { ... }
+  //DOTTY-ONLY    *           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param resultOfAfterWordApplication a <code>ResultOfAfterWordApplication</code>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def when(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string, Some("when " + resultOfAfterWordApplication.text), "when", "when", 4, -2, pos, resultOfAfterWordApplication.f)}) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>that</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "a rerun button" that {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param f the function which is the body of the scope
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def that(f: => Unit): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " that", None, "that", "that", stackDepth, -2, pos, () => f)}) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>which</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "a rerun button," which {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param f the function which is the body of the scope
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def which(f: => Unit): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " which", None, "which", "which", stackDepth, -2, pos, () => f)}) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>that</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "a rerun button," that {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param resultOfAfterWordApplication a <code>ResultOfAfterWordApplication</code>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def that(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " that " + resultOfAfterWordApplication.text.trim, None, "that", "that", 4, -2, pos, resultOfAfterWordApplication.f)}) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>which</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "a rerun button," which {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param resultOfAfterWordApplication a <code>ResultOfAfterWordApplication</code>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def which(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " which " + resultOfAfterWordApplication.text.trim, None, "which", "which", 4, -2, pos, resultOfAfterWordApplication.f)}) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY }
 
   /**
    * Supports the registration of subjects.
@@ -1328,7 +1614,10 @@ trait FixtureAnyWordSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
    * subject and executes the block.
    * </p>
    */
+  // SKIP-DOTTY-START 
   protected implicit val subjectRegistrationFunction: StringVerbBlockRegistration =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected given subjectRegistrationFunction: StringVerbBlockRegistration =
     new StringVerbBlockRegistration {
       def apply(left: String, verb: String, pos: source.Position, f: () => Unit): Unit = registerBranch(left, Some(verb), verb, "apply", 6, -2, pos, f)
     }
@@ -1355,7 +1644,10 @@ trait FixtureAnyWordSpecLike extends org.scalatest.FixtureTestSuite with ShouldV
    * subject and executes the block.
    * </p>
    */
+  // SKIP-DOTTY-START 
   protected implicit val subjectWithAfterWordRegistrationFunction: SubjectWithAfterWordRegistration =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected given subjectWithAfterWordRegistrationFunction: SubjectWithAfterWordRegistration =
     new SubjectWithAfterWordRegistration {
       def apply(left: String, verb: String, resultOfAfterWordApplication: ResultOfAfterWordApplication, pos: source.Position): Unit = {
         val afterWordFunction =

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLike.scala
@@ -1254,7 +1254,9 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
    */
   protected val they = new TheyWord
 
+  // SKIP-DOTTY-START 
   import scala.language.implicitConversions
+  // SKIP-DOTTY-END
 
   /**
   // SKIP-DOTTY-START

--- a/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLike.scala
+++ b/jvm/wordspec/src/main/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLike.scala
@@ -462,8 +462,8 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       registerAsyncTestToRun(string, List(), "in", testFun, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: FixtureParam => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerAsyncTestToRun(string, List(), "in", testFun, pos) }) } 
+    //DOTTY-ONLY def in(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerAsyncTestToRun(string, List(), "in", testFun, pos) 
     //DOTTY-ONLY }
 
     private final def inImpl(testFun: () => Future[compatible.Assertion], pos: source.Position): Unit = {
@@ -493,8 +493,8 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       inImpl(testFun, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def in(testFun: () => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => inImpl(testFun, pos) }) } 
+    //DOTTY-ONLY def in(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   inImpl(testFun, pos) 
     //DOTTY-ONLY }
 
     /**
@@ -520,8 +520,8 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       registerPendingTestToRun(string, List(), "is", unusedFixtureParam => testFun, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def is(testFun: => PendingStatement): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerPendingTestToRun(string, List(), "is", unusedFixtureParam => testFun, pos) }) } 
+    //DOTTY-ONLY def is(testFun: => PendingStatement)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerPendingTestToRun(string, List(), "is", unusedFixtureParam => testFun, pos)
     //DOTTY-ONLY }
 
     /**
@@ -547,8 +547,8 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       registerAsyncTestToIgnore(string, List(), "ignore", testFun, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(testFun: FixtureParam => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerAsyncTestToIgnore(string, List(), "ignore", testFun, pos) }) } 
+    //DOTTY-ONLY def ignore(testFun: FixtureParam => Future[compatible.Assertion])(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerAsyncTestToIgnore(string, List(), "ignore", testFun, pos)
     //DOTTY-ONLY }
 
     private final def ignoreImpl(testFun: () => Future[compatible.Assertion], pos: source.Position): Unit = {
@@ -578,8 +578,8 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       ignoreImpl(testFun, pos)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def ignore(testFun: () => Future[compatible.Assertion]): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => ignoreImpl(testFun, pos) }) } 
+    //DOTTY-ONLY def ignore(testFun: () => Future[compatible.Assertion])(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   ignoreImpl(testFun, pos) 
     //DOTTY-ONLY }
 
     /**
@@ -602,7 +602,6 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
      * @param otherTestTags the others additional test tags
      * @return an new instance of <code>ResultOfTaggedAsInvocationOnString</code>
      */
-    //DOTTY-ONLY     infix  
     def taggedAs(firstTestTag: Tag, otherTestTags: Tag*) = {
       val tagList = firstTestTag :: otherTestTags.toList
       new ResultOfTaggedAsInvocationOnString(string, tagList)
@@ -631,8 +630,8 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       registerBranch(string, Some("when"), "when", pos, () => f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def when(f: => Unit): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string, Some("when"), "when", pos, () => f) }) } 
+    //DOTTY-ONLY def when(f: => Unit)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string, Some("when"), "when", pos, () => f)
     //DOTTY-ONLY }
 
     /**
@@ -660,8 +659,8 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       registerBranch(string, Some("when " + resultOfAfterWordApplication.text), "when", pos, resultOfAfterWordApplication.f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def when(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string, Some("when " + resultOfAfterWordApplication.text), "when", pos, resultOfAfterWordApplication.f) }) } 
+    //DOTTY-ONLY def when(resultOfAfterWordApplication: ResultOfAfterWordApplication)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string, Some("when " + resultOfAfterWordApplication.text), "when", pos, resultOfAfterWordApplication.f)
     //DOTTY-ONLY }
 
     /**
@@ -687,8 +686,8 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       registerBranch(string.trim + " that", None, "that", pos, () => f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def that(f: => Unit): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " that", None, "that", pos, () => f) }) } 
+    //DOTTY-ONLY def that(f: => Unit)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string.trim + " that", None, "that", pos, () => f)
     //DOTTY-ONLY }
 
     /**
@@ -714,8 +713,8 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       registerBranch(string.trim + " which", None, "which", pos, () => f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def which(f: => Unit): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " which", None, "which", pos, () => f) }) } 
+    //DOTTY-ONLY def which(f: => Unit)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string.trim + " which", None, "which", pos, () => f)
     //DOTTY-ONLY }
 
     /**
@@ -741,8 +740,8 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       registerBranch(string.trim + " that " + resultOfAfterWordApplication.text.trim, None, "that", pos, resultOfAfterWordApplication.f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def that(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " that " + resultOfAfterWordApplication.text.trim, None, "that", pos, resultOfAfterWordApplication.f) }) } 
+    //DOTTY-ONLY def that(resultOfAfterWordApplication: ResultOfAfterWordApplication)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string.trim + " that " + resultOfAfterWordApplication.text.trim, None, "that", pos, resultOfAfterWordApplication.f)
     //DOTTY-ONLY }
 
     /**
@@ -768,8 +767,8 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       registerBranch(string.trim + " which " + resultOfAfterWordApplication.text.trim, None, "which", pos, resultOfAfterWordApplication.f)
     }
     // SKIP-DOTTY-END
-    //DOTTY-ONLY inline infix def which(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
-    //DOTTY-ONLY   ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " which " + resultOfAfterWordApplication.text.trim, None, "which", pos, resultOfAfterWordApplication.f) }) } 
+    //DOTTY-ONLY def which(resultOfAfterWordApplication: ResultOfAfterWordApplication)(using pos: source.Position): Unit = {
+    //DOTTY-ONLY   registerBranch(string.trim + " which " + resultOfAfterWordApplication.text.trim, None, "which", pos, resultOfAfterWordApplication.f)
     //DOTTY-ONLY }
   }
 
@@ -1258,14 +1257,286 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
   import scala.language.implicitConversions
 
   /**
+  // SKIP-DOTTY-START
    * Implicitly converts <code>String</code>s to <code>WordSpecStringWrapper</code>, which enables
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY   * Converts <code>String</code>s to <code>WordSpecStringWrapper</code>, which enables
    * methods <code>when</code>, <code>which</code>, <code>in</code>, <code>is</code>, <code>taggedAs</code>
    * and <code>ignore</code> to be invoked on <code>String</code>s.
    *
    * @param s <code>String</code> to be wrapped
    * @return an instance of <code>WordSpecStringWrapper</code>
    */
+  // SKIP-DOTTY-START 
   protected implicit def convertToWordSpecStringWrapper(s: String): WordSpecStringWrapper = new WordSpecStringWrapper(s)
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected def convertToWordSpecStringWrapper(s: String): WordSpecStringWrapper = new WordSpecStringWrapper(s)
+
+  //DOTTY-ONLY extension (string: String) {
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" in { fixture => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def in(testFun: FixtureParam => Future[compatible.Assertion]): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerAsyncTestToRun(string, List(), "in", testFun, pos) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   private final def inImpl(testFun: () => Future[compatible.Assertion], pos: source.Position): Unit = {
+  //DOTTY-ONLY     registerAsyncTestToRun(string, List(), "in", new org.scalatest.fixture.NoArgTestWrapper(testFun), pos)
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports registration of tests that take no fixture.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" in { () => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def in(testFun: () => Future[compatible.Assertion]): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => inImpl(testFun, pos) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports pending test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" is (pending)
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def is(testFun: => PendingStatement): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerPendingTestToRun(string, List(), "is", unusedFixtureParam => testFun, pos) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports ignored test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" ignore { fixture => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def ignore(testFun: FixtureParam => Future[compatible.Assertion]): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerAsyncTestToIgnore(string, List(), "ignore", testFun, pos) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   private final def ignoreImpl(testFun: () => Future[compatible.Assertion], pos: source.Position): Unit = {
+  //DOTTY-ONLY     registerAsyncTestToIgnore(string, List(), "ignore", new org.scalatest.fixture.NoArgTestWrapper(testFun), pos)
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports registration of ignored tests that take no fixture.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" ignore { () => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param testFun the test function
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def ignore(testFun: () => Future[compatible.Assertion]): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => ignoreImpl(testFun, pos) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Supports tagged test registration.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "complain on peek" taggedAs(SlowTest) in { fixture => ... }
+  //DOTTY-ONLY    *                    ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param firstTestTag the first mandatory test tag
+  //DOTTY-ONLY    * @param otherTestTags the others additional test tags
+  //DOTTY-ONLY    * @return an new instance of <code>ResultOfTaggedAsInvocationOnString</code>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   infix def taggedAs(firstTestTag: Tag, otherTestTags: Tag*) = {
+  //DOTTY-ONLY     val tagList = firstTestTag :: otherTestTags.toList
+  //DOTTY-ONLY     new ResultOfTaggedAsInvocationOnString(string, tagList)
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>when</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "A Stack" when { ... }
+  //DOTTY-ONLY    *           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param f the function which is the body of the scope
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def when(f: => Unit): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string, Some("when"), "when", pos, () => f) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>when</code> clause that is followed by an <em>after word</em>.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * val theUser = afterWord("the user")
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * "A Stack" when theUser { ... }
+  //DOTTY-ONLY    *           ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param resultOfAfterWordApplication a <code>ResultOfAfterWordApplication</code>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def when(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string, Some("when " + resultOfAfterWordApplication.text), "when", pos, resultOfAfterWordApplication.f) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>that</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "a rerun button" that {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param f the function which is the body of the scope
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def that(f: => Unit): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " that", None, "that", pos, () => f) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>which</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "a rerun button," which {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param f the function which is the body of the scope
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def which(f: => Unit): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " which", None, "which", pos, () => f) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>that</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "a rerun button," that {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param resultOfAfterWordApplication a <code>ResultOfAfterWordApplication</code>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def that(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " that " + resultOfAfterWordApplication.text.trim, None, "that", pos, resultOfAfterWordApplication.f) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY   /**
+  //DOTTY-ONLY    * Registers a <code>which</code> clause.
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For example, this method supports syntax such as the following:
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <pre class="stHighlight">
+  //DOTTY-ONLY    * "a rerun button," which {
+  //DOTTY-ONLY    *                  ^
+  //DOTTY-ONLY    * </pre>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * <p>
+  //DOTTY-ONLY    * For more information and examples of this method's use, see the <a href="FixtureAnyWordSpec.html">main documentation</a> for trait <code>FixtureAnyWordSpec</code>.
+  //DOTTY-ONLY    * </p>
+  //DOTTY-ONLY    *
+  //DOTTY-ONLY    * @param resultOfAfterWordApplication a <code>ResultOfAfterWordApplication</code>
+  //DOTTY-ONLY    */
+  //DOTTY-ONLY   inline infix def which(resultOfAfterWordApplication: ResultOfAfterWordApplication): Unit = {
+  //DOTTY-ONLY     ${ source.Position.withPosition[Unit]('{(pos: source.Position) => registerBranch(string.trim + " which " + resultOfAfterWordApplication.text.trim, None, "which", pos, resultOfAfterWordApplication.f) }) } 
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY }
 
   /**
    * Supports the registration of subjects.
@@ -1287,7 +1558,10 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
    * subject and executes the block.
    * </p>
    */
+  // SKIP-DOTTY-START
   protected implicit val subjectRegistrationFunction: StringVerbBlockRegistration =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected given subjectRegistrationFunction: StringVerbBlockRegistration =
     new StringVerbBlockRegistration {
       def apply(left: String, verb: String, pos: source.Position, f: () => Unit): Unit = registerBranch(left, Some(verb), verb, pos, f)
     }
@@ -1314,7 +1588,10 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
    * subject and executes the block.
    * </p>
    */
+  // SKIP-DOTTY-START
   protected implicit val subjectWithAfterWordRegistrationFunction: SubjectWithAfterWordRegistration =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY protected given subjectWithAfterWordRegistrationFunction: SubjectWithAfterWordRegistration =
     new SubjectWithAfterWordRegistration {
       def apply(left: String, verb: String, resultOfAfterWordApplication: ResultOfAfterWordApplication, pos: source.Position): Unit = {
         val afterWordFunction =

--- a/project/GenEvery.scala
+++ b/project/GenEvery.scala
@@ -22,6 +22,9 @@ object GenEvery {
       if (scalaVersion.startsWith("3.")) 
         scala213Compatible.replace(": _*", "*")
                           .replace("uncheckedVariance => uV", "uncheckedVariance as uV")
+                          .replace("import scala.language.implicitConversions", "")
+                          .replace("implicit def everyToIterableOnce[E](every: Every[E]): scala.collection.immutable.IndexedSeq[E] = every.toVector", 
+                                   "given everyToIterableOnce[E]: Conversion[Every[E], scala.collection.immutable.IndexedSeq[E]] with { def apply(every: Every[E]): scala.collection.immutable.IndexedSeq[E] = every.toVector}")
       else
         scala213Compatible      
     }

--- a/project/GenFactoriesDotty.scala
+++ b/project/GenFactoriesDotty.scala
@@ -2817,7 +2817,6 @@ $endif$
  */
 object MatcherFactory$arity$ {
 
-  import scala.language.implicitConversions
   import scala.quoted.*
 
   /**
@@ -2826,8 +2825,10 @@ object MatcherFactory$arity$ {
    * @param matcherFactory a MatcherFactory$arity$ to convert
    * @return a Matcher produced by the passed MatcherFactory$arity$
    */
-  implicit def produceMatcher[SC, $typeConstructors$, T <: SC : $colonSeparatedTCNs$](matcherFactory: MatcherFactory$arity$[SC, $commaSeparatedTCNs$]): Matcher[T] =
+  def produceMatcher[SC, $typeConstructors$, T <: SC : $colonSeparatedTCNs$](matcherFactory: MatcherFactory$arity$[SC, $commaSeparatedTCNs$]): Matcher[T] =
     matcherFactory.matcher
+  given [SC, $typeConstructors$, T <: SC : $colonSeparatedTCNs$]: Conversion[MatcherFactory$arity$[SC, $commaSeparatedTCNs$], Matcher[T]] =
+    produceMatcher[SC, $commaSeparatedTCNs$, T]
 
   /**
    * This method is called by macro that supports 'and not a [Type]' syntax.

--- a/project/templates/FloatAnyVal.template
+++ b/project/templates/FloatAnyVal.template
@@ -661,7 +661,6 @@ object $typeName$ {
     if ($typeName$Macro.isValid(value)) new $typeName$(value) else default
 
   import language.experimental.macros
-  import scala.language.implicitConversions
 
   /**
    * A factory method, implemented via a macro, that produces a


### PR DESCRIPTION
Refactor enablers to use 'given' and 'using' replacing 'implicit def'.