### PR TITLE
Add support for passing initial seed to ScalaCheck properties

### DIFF
--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/ConfigurationSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/ConfigurationSpec.scala
@@ -30,7 +30,8 @@ class ConfigurationSpec extends AnyFunSpec with Matchers with GeneratorDrivenPro
         minSize <- posZInts
         sizeRange <- posZIntsBetween(0, PosZInt.ensuringValid(PosZInt.MaxValue - minSize))
         workers <- posInts
-      } yield Configuration.Parameter(minSuccessful, maxDiscardedFactor, minSize, sizeRange, workers)
+        intialSeed <- Generator.longGenerator.map(Seed(_))
+      } yield Configuration.Parameter(minSuccessful, maxDiscardedFactor, minSize, sizeRange, workers, intialSeed)
 
     it("should offer a maxSize method that is minSize + SizeRange") {
       forAll { (param: Configuration.Parameter) =>
@@ -40,7 +41,7 @@ class ConfigurationSpec extends AnyFunSpec with Matchers with GeneratorDrivenPro
 
     it("should throw IllegalArgumentException when the result of minSize + sizeRange goes out of range") {
       assertThrows[IllegalArgumentException] {
-        Configuration.Parameter(PosInt(5), PosZDouble(0.5), PosZInt.MaxValue, PosZInt(1), PosInt(1))
+        Configuration.Parameter(PosInt(5), PosZDouble(0.5), PosZInt.MaxValue, PosZInt(1), PosInt(1), Seed(2L))
       }
     }
   }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/PropertyCheckConfigParamSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/PropertyCheckConfigParamSuite.scala
@@ -87,4 +87,13 @@ class PropertyCheckConfigParamSuite extends AnyFunSuite with Matchers {
     Workers(2).value.value should be (2)
     Workers(5678).value.value should be (5678)
   }
+
+  test("initialSeed value is passed value, if valid") {
+    InitialSeed(-2).value should be (-2)
+    InitialSeed(-1).value should be (-1)
+    InitialSeed(0).value should be (0)
+    InitialSeed(1).value should be (1)
+    InitialSeed(2).value should be (2)
+    InitialSeed(5678).value should be (5678)
+  }
 }


### PR DESCRIPTION
It's not always possible to configure the ScalaCheck seed via `-S <seed>` argument. For example when using the JUnit runner via Gradle (see #2397). This PR allows us to specify a seed at the property or spec level to help reproducing property failures. This will be used by a subsequent PR in https://github.com/s-nel/scalatestplus-scalacheck that will use this parameter and fall back to the global seed in `org.scalatest.prop.Seed`, or a random seed if the global seed is absent.

Fixes: https://github.com/scalatest/scalatest/issues/2397