### PR TITLE
Fix implicit conversion comment in ExampleSuite

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/Fact.scala
+++ b/jvm/core/src/main/scala/org/scalatest/Fact.scala
@@ -591,6 +591,7 @@ import org.scalatest.exceptions._
  *   test("addition") {
  *     val fact = expect(2 + 2 == 4)
  *     // Implicit conversion to Assertion happens here
+ *     fact
  *   }
  * }
  * </pre>


### PR DESCRIPTION
The example as it stands has one line of code that evaluates to `Unit`, so no implicit conversion should be happening. Only when the return value is a `Fact` it would be converted to an `Assertion`.