### PR TITLE
Opaque Types Tweaks

### DIFF
--- a/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyArraySpec.scala
+++ b/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyArraySpec.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.scalactic.{Every, One, Many, StringNormalizations}
 import org.scalactic.UnitSpec
 import org.scalactic.NormalizingEquality
+import org.scalactic.Resources
 
 import org.scalatest.CompatParColls.Converters._
 
@@ -52,7 +53,13 @@ class NonEmptyArraySpec extends UnitSpec {
     NonEmptyArray.from(Array(1, 2, 3).par).get shouldBe NonEmptyArray(1, 2, 3)
     // SKIP-SCALATESTJS,NATIVE-END
   }
-  // This does not compile with scala 2.10
+  it can "be constructed with ensuringValid method" in {
+    //NonEmptyArray.ensuringValid(Array(1, 2, 3)) shouldBe NonEmptyArray(1, 2, 3)
+    //NonEmptyArray.ensuringValid(Array("hi")) shouldBe NonEmptyArray("hi")
+    the [IllegalArgumentException] thrownBy {
+      NonEmptyArray.ensuringValid(Array.empty[Int])
+    } should have message Resources.nonEmptyArrayEmpty
+  }
   it can "be constructed with null elements" in {
     noException should be thrownBy NonEmptyArray[String]("hi", null, "ho")
     noException should be thrownBy NonEmptyArray[String](null)

--- a/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyArraySpec.scala
+++ b/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyArraySpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.opaques
+package org.scalactic.opaquetypes
 
 import org.scalactic.ColCompatHelper.Iterable
 import scala.collection.mutable.Buffer

--- a/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyArraySpec.scala
+++ b/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyArraySpec.scala
@@ -54,9 +54,9 @@ class NonEmptyArraySpec extends UnitSpec {
     // SKIP-SCALATESTJS,NATIVE-END
   }
   it can "be constructed with ensuringValid method" in {
-    //NonEmptyArray.ensuringValid(Array(1, 2, 3)) shouldBe NonEmptyArray(1, 2, 3)
-    //NonEmptyArray.ensuringValid(Array("hi")) shouldBe NonEmptyArray("hi")
-    the [IllegalArgumentException] thrownBy {
+    NonEmptyArray.ensuringValid(Array(1, 2, 3)) shouldBe NonEmptyArray(1, 2, 3)
+    NonEmptyArray.ensuringValid(Array("hi")) shouldBe NonEmptyArray("hi")
+    the [AssertionError] thrownBy {
       NonEmptyArray.ensuringValid(Array.empty[Int])
     } should have message Resources.nonEmptyArrayEmpty
   }

--- a/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyListSpec.scala
+++ b/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyListSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.opaques
+package org.scalactic.opaquetypes
 
 import org.scalactic.ColCompatHelper.Iterable
 import scala.collection.mutable.Buffer
@@ -24,7 +24,6 @@ import org.scalactic.UnitSpec
 import org.scalactic.NormalizingEquality
 
 import org.scalatest.CompatParColls.Converters._
-import org.scalactic.opaques._
 
 class NonEmptyListSpec extends UnitSpec {
   "A NonEmptyList" can "be constructed with one element" in {

--- a/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyListSpec.scala
+++ b/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyListSpec.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.ListBuffer
 import org.scalactic.{Every, One, Many, StringNormalizations}
 import org.scalactic.UnitSpec
 import org.scalactic.NormalizingEquality
+import org.scalactic.Resources
 
 import org.scalatest.CompatParColls.Converters._
 
@@ -41,6 +42,13 @@ class NonEmptyListSpec extends UnitSpec {
     threesie(0) shouldBe 1
     threesie(1) shouldBe 2
     threesie(2) shouldBe 3
+  }
+  it can "be constructed with ensuringValid method" in {
+    NonEmptyList.ensuringValid(List(1, 2, 3)) shouldBe NonEmptyList(1, 2, 3)
+    NonEmptyList.ensuringValid(List("hi")) shouldBe NonEmptyList("hi")
+    the [AssertionError] thrownBy {
+      NonEmptyList.ensuringValid(List.empty[Int])
+    } should have message Resources.nonEmptyListEmpty
   }
   it can "be constructed from a Iterable via the from method on NonEmptyList singleton" in {
     NonEmptyList.from(List.empty[String]) shouldBe None

--- a/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyMapSpec.scala
+++ b/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyMapSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.opaques
+package org.scalactic.opaquetypes
 
 import org.scalactic.ColCompatHelper.Iterable
 import scala.collection.mutable.Buffer

--- a/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyMapSpec.scala
+++ b/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyMapSpec.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.ListBuffer
 import org.scalactic.{Every, One, Many, StringNormalizations}
 import org.scalactic.UnitSpec
 import org.scalactic.NormalizingEquality
+import org.scalactic.Resources
 
 import org.scalatest.CompatParColls.Converters._
 
@@ -41,6 +42,13 @@ class NonEmptyMapSpec extends UnitSpec {
     threesie(1) shouldBe "one"
     threesie(2) shouldBe "two"
     threesie(3) shouldBe "three"
+  }
+  it can "be constructed with ensuringValid method" in {
+    NonEmptyMap.ensuringValid(Map(1 -> "one", 2 -> "two", 3 -> "three")) shouldBe NonEmptyMap(1 -> "one", 2 -> "two", 3 -> "three")
+    NonEmptyMap.ensuringValid(Map("hi" -> "hello")) shouldBe NonEmptyMap("hi" -> "hello")
+    the [AssertionError] thrownBy {
+      NonEmptyMap.ensuringValid(Map.empty[Int, String])
+    } should have message Resources.nonEmptyMapEmpty
   }
   it can "be constructed from a Iterable via the from method on NonEmptyMap singleton" in {
     NonEmptyMap.from(Map.empty[Int, String]) shouldBe None

--- a/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptySetSpec.scala
+++ b/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptySetSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.opaques
+package org.scalactic.opaquetypes
 
 import org.scalactic.ColCompatHelper.Iterable
 import scala.collection.mutable.Buffer

--- a/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptySetSpec.scala
+++ b/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptySetSpec.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.ListBuffer
 import org.scalactic.{Every, One, Many, StringNormalizations}
 import org.scalactic.UnitSpec
 import org.scalactic.NormalizingEquality
+import org.scalactic.Resources
 
 import org.scalatest.CompatParColls.Converters._
 
@@ -43,6 +44,13 @@ class NonEmptySetSpec extends UnitSpec {
     threesie(2) shouldBe true
     threesie(3) shouldBe true
     threesie(4) shouldBe false
+  }
+  it can "be constructed with ensuringValid method" in {
+    NonEmptySet.ensuringValid(Set(1, 2, 3)) shouldBe NonEmptySet(1, 2, 3)
+    NonEmptySet.ensuringValid(Set("hi")) shouldBe NonEmptySet("hi")
+    the [AssertionError] thrownBy {
+      NonEmptySet.ensuringValid(Set.empty[Int])
+    } should have message Resources.nonEmptySetEmpty
   }
   it can "be constructed from a Iterable via the from method on NonEmptySet singleton" in {
     NonEmptySet.from(Set.empty[String]) shouldBe None

--- a/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyStringSpec.scala
+++ b/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyStringSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.opaques
+package org.scalactic.opaquetypes
 
 import org.scalactic.ColCompatHelper.Iterable
 import scala.collection.mutable.Buffer
@@ -23,7 +23,7 @@ import org.scalactic.{Every, One, Many, StringNormalizations}
 import org.scalactic.UnitSpec
 import org.scalactic.NormalizingEquality
 
-import org.scalactic.opaques.NonEmptyStrings.NonEmptyString
+import org.scalactic.opaquetypes.NonEmptyStrings.NonEmptyString
 
 class NonEmptyStringSpec extends UnitSpec {
   "A NonEmptyString" can "be constructed with one character" in {

--- a/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyStringSpec.scala
+++ b/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyStringSpec.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.ListBuffer
 import org.scalactic.{Every, One, Many, StringNormalizations}
 import org.scalactic.UnitSpec
 import org.scalactic.NormalizingEquality
+import org.scalactic.Resources
 
 import org.scalactic.opaquetypes.NonEmptyStrings.NonEmptyString
 
@@ -57,6 +58,12 @@ class NonEmptyStringSpec extends UnitSpec {
     threesie2(0) shouldBe '1'
     threesie2(1) shouldBe '2'
     threesie2(2) shouldBe '3'
+  }
+  it can "be constructed with ensuringValid method" in {
+    NonEmptyString.ensuringValid("hi") shouldBe NonEmptyString("hi")
+    the [AssertionError] thrownBy {
+      NonEmptyString.ensuringValid("")
+    } should have message Resources.nonEmptyStringEmpty
   }
   it can "be constructed from a Iterable via the from method on NonEmptyString singleton" in {
     NonEmptyString.from("") shouldBe None

--- a/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyVectorSpec.scala
+++ b/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyVectorSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.opaques
+package org.scalactic.opaquetypes
 
 import org.scalactic.ColCompatHelper.Iterable
 import scala.collection.mutable.Buffer

--- a/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyVectorSpec.scala
+++ b/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/NonEmptyVectorSpec.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.ListBuffer
 import org.scalactic.{Every, One, Many, StringNormalizations}
 import org.scalactic.UnitSpec
 import org.scalactic.NormalizingEquality
+import org.scalactic.Resources
 
 import org.scalatest.CompatParColls.Converters._
 
@@ -41,6 +42,13 @@ class NonEmptyVectorSpec extends UnitSpec {
     threesie(0) shouldBe 1
     threesie(1) shouldBe 2
     threesie(2) shouldBe 3
+  }
+  it can "be constructed with ensuringValid method" in {
+    NonEmptyVector.ensuringValid(Vector(1, 2, 3)) shouldBe NonEmptyVector(1, 2, 3)
+    NonEmptyVector.ensuringValid(Vector("hi")) shouldBe NonEmptyVector("hi")
+    the [AssertionError] thrownBy {
+      NonEmptyVector.ensuringValid(Vector.empty[Int])
+    } should have message Resources.nonEmptyVectorEmpty
   }
   it can "be constructed from a Iterable via the from method on NonEmptyVector singleton" in {
     NonEmptyVector.from(Vector.empty[String]) shouldBe None

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/End.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/End.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.opaques
+package org.scalactic.opaquetypes
 
 /**
   * Object that can be used as an endpoint for <code>NonEmptyList</code> construction expressions

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyArray.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyArray.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.opaques
+package org.scalactic.opaquetypes
 
 import scala.annotation.unchecked.{ uncheckedVariance => uV }
 import scala.collection.GenSeq
@@ -41,7 +41,7 @@ import scala.language.higherKinds
   *
   * <pre class="stHighlight">
   * scala&gt; NonEmptyArray(1, 2, 3)
-  * res0: org.scalactic.opaques.NonEmptyArray[Int] = NonEmptyArray(1, 2, 3)
+  * res0: org.scalactic.opaquetypes.NonEmptyArray[Int] = NonEmptyArray(1, 2, 3)
   * </pre>
   *
   * <h2>Working with <code>NonEmptyArray</code>s</h2>
@@ -78,11 +78,11 @@ import scala.language.higherKinds
   * </p>
   *
   * <pre class="stREPL">
-  * scala&gt; import org.scalactic.opaques._
-  * import org.scalactic.opaques._
+  * scala&gt; import org.scalactic.opaquetypes._
+  * import org.scalactic.opaquetypes._
   *
   * scala&gt; for (i &lt;- NonEmptyArray(1, 2, 3)) yield i + 1
-  * res0: org.scalactic.opaques.NonEmptyArray[Int] = NonEmptyArray(2, 3, 4)
+  * res0: org.scalactic.opaquetypes.NonEmptyArray[Int] = NonEmptyArray(2, 3, 4)
   *
   * scala&gt; for (i &lt;- NonEmptyArray(1, 2, 3) if i &lt; 10) yield i + 1
   * res1: Array[Int] = Array(2, 3, 4)
@@ -91,7 +91,7 @@ import scala.language.higherKinds
   *      |   i &lt;- NonEmptyArray(1, 2, 3)
   *      |   j &lt;- NonEmptyArray('a', 'b', 'c')
   *      | } yield (i, j)
-  * res3: org.scalactic.opaques.NonEmptyArray[(Int, Char)] =
+  * res3: org.scalactic.opaquetypes.NonEmptyArray[(Int, Char)] =
   *         NonEmptyArray((1,a), (1,b), (1,c), (2,a), (2,b), (2,c), (3,a), (3,b), (3,c))
   *
   * scala&gt; for {

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyArray.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyArray.scala
@@ -136,6 +136,12 @@ object NonEmptyArray {
     def unapplySeq[T](nonEmptyArray: NonEmptyArray[T]): Option[(T, Seq[T])] = Some(nonEmptyArray.head, nonEmptyArray.tail)
   */
 
+  def ensuringValid[T](array: Array[T]): NonEmptyArray[T] =
+    if (array.length == 0)
+      throw new IllegalArgumentException(Resources.nonEmptyArrayEmpty)
+    else
+      array
+
   /**
     * Optionally construct a <code>NonEmptyArray</code> containing the elements, if any, of a given <code>GenSeq</code>.
     *

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyArray.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyArray.scala
@@ -136,9 +136,27 @@ object NonEmptyArray {
     def unapplySeq[T](nonEmptyArray: NonEmptyArray[T]): Option[(T, Seq[T])] = Some(nonEmptyArray.head, nonEmptyArray.tail)
   */
 
+  /**
+   *
+   * A factory/assertion method that produces a <code>NonEmptyArray</code>
+   * given a valid <code>Array</code> value, or throws
+   * <code>AssertionError</code>, if given an invalid <code>Array</code> value.
+   *
+   * Note: you should use this method only when you are convinced that it will
+   * always succeed, i.e., never throw an exception. It is good practice to
+   * add a comment near the invocation of this method indicating ''why'' you
+   * think it will always succeed to document your reasoning. If you are not
+   * sure an `ensuringValid` call will always succeed, you should use one of
+   * the other factory or validation methods provided on this object instead:
+   * `from'.
+   *
+   * @param array the <code>Array</code> to check to see if it is a valid.
+   * @return the <code>NonEmptyArray</code> if the passed array is valid..
+   * @throws AssertionError if the passed array is not valid.
+   */
   def ensuringValid[T](array: Array[T]): NonEmptyArray[T] =
     if (array.length == 0)
-      throw new IllegalArgumentException(Resources.nonEmptyArrayEmpty)
+      throw new AssertionError(Resources.nonEmptyArrayEmpty)
     else
       array
 

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyList.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyList.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.opaques
+package org.scalactic.opaquetypes
 
 import scala.annotation.unchecked.{ uncheckedVariance => uV }
 import scala.collection.GenSeq

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyList.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyList.scala
@@ -172,7 +172,7 @@ object NonEmptyList {
    *
    * @param list the <code>List</code> to check to see if it is a valid.
    * @return the <code>NonEmptyList</code> if the passed list is valid..
-   * @throws AssertionError if the passed array is not valid.
+   * @throws AssertionError if the passed list is not valid.
    */
   def ensuringValid[T](list: List[T]): NonEmptyList[T] =
     if (list.length == 0)

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyList.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyList.scala
@@ -19,6 +19,7 @@ import scala.annotation.unchecked.{ uncheckedVariance => uV }
 import scala.collection.GenSeq
 import scala.reflect.ClassTag
 import org.scalactic.Every
+import org.scalactic.Resources
 import scala.collection.mutable.{ArrayBuffer, Buffer}
 
 /**
@@ -154,6 +155,30 @@ object NonEmptyList {
    * @return an <code>Seq</code> containing this <code>NonEmptyList</code>s elements, wrapped in a <code>Some</code> 
    */
   def unapplySeq[T](nonEmptyList: NonEmptyList[T]): Option[Seq[T]] = Some(nonEmptyList.toList)
+
+  /**
+   *
+   * A factory/assertion method that produces a <code>NonEmptyList</code>
+   * given a valid <code>List</code> value, or throws
+   * <code>AssertionError</code>, if given an invalid <code>List</code> value.
+   *
+   * Note: you should use this method only when you are convinced that it will
+   * always succeed, i.e., never throw an exception. It is good practice to
+   * add a comment near the invocation of this method indicating ''why'' you
+   * think it will always succeed to document your reasoning. If you are not
+   * sure an `ensuringValid` call will always succeed, you should use one of
+   * the other factory or validation methods provided on this object instead:
+   * `from'.
+   *
+   * @param list the <code>List</code> to check to see if it is a valid.
+   * @return the <code>NonEmptyList</code> if the passed list is valid..
+   * @throws AssertionError if the passed array is not valid.
+   */
+  def ensuringValid[T](list: List[T]): NonEmptyList[T] =
+    if (list.length == 0)
+      throw new AssertionError(Resources.nonEmptyListEmpty)
+    else
+      list
 
   /**
    * Optionally construct a <code>NonEmptyList</code> containing the elements, if any, of a given <code>GenSeq</code>.

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyMap.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyMap.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.opaques
+package org.scalactic.opaquetypes
 
 import scala.collection.GenSeq
 import scala.collection.mutable.{ArrayBuffer, Buffer}

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyMap.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyMap.scala
@@ -20,6 +20,7 @@ import scala.collection.mutable.{ArrayBuffer, Buffer}
 import scala.language.higherKinds
 import scala.annotation.unchecked.{ uncheckedVariance => uV }
 import scala.reflect.ClassTag
+import org.scalactic.Resources
 
 /**
   * A non-empty map: an ordered, immutable, non-empty collection of key-value tuples with <code>LinearSeq</code> performance characteristics.
@@ -125,6 +126,30 @@ object NonEmptyMap {
     * @return an <code>Seq</code> containing this <code>NonEmptyMap</code>s elements, wrapped in a <code>Some</code> 
     */
   def unapplySeq[K, V](nonEmptyMap: NonEmptyMap[K, V]): Option[Seq[(K, V)]] = Some(nonEmptyMap.toSeq)
+
+  /**
+   *
+   * A factory/assertion method that produces a <code>NonEmptyMap</code>
+   * given a valid <code>Map</code> value, or throws
+   * <code>AssertionError</code>, if given an invalid <code>Map</code> value.
+   *
+   * Note: you should use this method only when you are convinced that it will
+   * always succeed, i.e., never throw an exception. It is good practice to
+   * add a comment near the invocation of this method indicating ''why'' you
+   * think it will always succeed to document your reasoning. If you are not
+   * sure an `ensuringValid` call will always succeed, you should use one of
+   * the other factory or validation methods provided on this object instead:
+   * `from'.
+   *
+   * @param map the <code>Map</code> to check to see if it is a valid.
+   * @return the <code>NonEmptyMap</code> if the passed map is valid..
+   * @throws AssertionError if the passed map is not valid.
+   */
+  def ensuringValid[K, V](map: Map[K, V]): NonEmptyMap[K, V] =
+    if (map.size == 0)
+      throw new AssertionError(Resources.nonEmptyMapEmpty)
+    else
+      map
 
   /**
     * Optionally construct a <code>NonEmptyMap</code> containing the elements, if any, of a given <code>GenSeq</code>.

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptySet.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptySet.scala
@@ -172,7 +172,7 @@ object NonEmptySet {
    *
    * @param set the <code>Set</code> to check to see if it is a valid.
    * @return the <code>NonEmptySet</code> if the passed set is valid..
-   * @throws AssertionError if the passed array is not valid.
+   * @throws AssertionError if the passed set is not valid.
    */
   def ensuringValid[T](set: Set[T]): NonEmptySet[T] =
     if (set.size == 0)

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptySet.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptySet.scala
@@ -20,6 +20,7 @@ import scala.collection.mutable.{ArrayBuffer, Buffer}
 import scala.language.higherKinds
 import scala.annotation.unchecked.{ uncheckedVariance => uV }
 import scala.reflect.ClassTag
+import org.scalactic.Resources
 
 /**
   * A non-empty Set: an ordered, immutable, non-empty collection of elements with <code>LinearSeq</code> performance characteristics.
@@ -154,6 +155,30 @@ object NonEmptySet {
     * @return an <code>Seq</code> containing this <code>NonEmptySet</code>s elements, wrapped in a <code>Some</code> 
     */
   def unapplySeq[T](nonEmptySet: NonEmptySet[T]): Option[Seq[T]] = Some(nonEmptySet.toSeq)
+
+  /**
+   *
+   * A factory/assertion method that produces a <code>NonEmptySet</code>
+   * given a valid <code>Set</code> value, or throws
+   * <code>AssertionError</code>, if given an invalid <code>Set</code> value.
+   *
+   * Note: you should use this method only when you are convinced that it will
+   * always succeed, i.e., never throw an exception. It is good practice to
+   * add a comment near the invocation of this method indicating ''why'' you
+   * think it will always succeed to document your reasoning. If you are not
+   * sure an `ensuringValid` call will always succeed, you should use one of
+   * the other factory or validation methods provided on this object instead:
+   * `from'.
+   *
+   * @param set the <code>Set</code> to check to see if it is a valid.
+   * @return the <code>NonEmptySet</code> if the passed set is valid..
+   * @throws AssertionError if the passed array is not valid.
+   */
+  def ensuringValid[T](set: Set[T]): NonEmptySet[T] =
+    if (set.size == 0)
+      throw new AssertionError(Resources.nonEmptySetEmpty)
+    else
+      set
 
   /**
     * Optionally construct a <code>NonEmptySet</code> containing the elements, if any, of a given <code>GenSet</code>.

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptySet.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptySet.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.opaques
+package org.scalactic.opaquetypes
 
 import scala.collection.GenSet
 import scala.collection.mutable.{ArrayBuffer, Buffer}

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyString.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyString.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.opaques
+package org.scalactic.opaquetypes
 
 import scala.collection.{GenSeq, StringOps}
 import scala.collection.mutable.Buffer

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyString.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyString.scala
@@ -18,6 +18,7 @@ package org.scalactic.opaquetypes
 import scala.collection.{GenSeq, StringOps}
 import scala.collection.mutable.Buffer
 import org.scalactic.Every
+import org.scalactic.Resources
 import scala.annotation.targetName
 import org.scalactic.Resources
 import scala.annotation.unchecked.{ uncheckedVariance => uV }
@@ -175,6 +176,30 @@ object NonEmptyStrings {
       * @return an <code>Seq</code> containing this <code>NonEmptyString</code>s elements, wrapped in a <code>Some</code> 
       */
     def unapplySeq(nonEmptyString: NonEmptyString): Option[Seq[String]] = Some(Seq(nonEmptyString))
+
+    /**
+      *
+      * A factory/assertion method that produces a <code>NonEmptyString</code>
+      * given a valid <code>String</code> value, or throws
+      * <code>AssertionError</code>, if given an invalid <code>String</code> value.
+      *
+      * Note: you should use this method only when you are convinced that it will
+      * always succeed, i.e., never throw an exception. It is good practice to
+      * add a comment near the invocation of this method indicating ''why'' you
+      * think it will always succeed to document your reasoning. If you are not
+      * sure an `ensuringValid` call will always succeed, you should use one of
+      * the other factory or validation methods provided on this object instead:
+      * `from'.
+      *
+      * @param string the <code>String</code> to check to see if it is a valid.
+      * @return the <code>NonEmptyString</code> if the passed string is valid..
+      * @throws AssertionError if the passed string is not valid.
+      */
+    def ensuringValid(string: String): NonEmptyString =
+      if (string.length == 0)
+        throw new AssertionError(Resources.nonEmptyStringEmpty)
+      else
+        string
 
     /**
       * Optionally construct a <code>NonEmptyString</code> containing the characters, if any, of a given <code>GenSeq</code>.

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyVector.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyVector.scala
@@ -21,6 +21,7 @@ import scala.language.higherKinds
 import scala.annotation.unchecked.{ uncheckedVariance => uV }
 import scala.reflect.ClassTag
 import scala.collection.generic.CanBuildFrom
+import org.scalactic.Resources
 
 /**
   * A non-empty list: an ordered, immutable, non-empty collection of elements with <code>LinearSeq</code> performance characteristics.
@@ -155,6 +156,30 @@ object NonEmptyVector {
     * @return an <code>Seq</code> containing this <code>NonEmptyVector</code>s elements, wrapped in a <code>Some</code> 
     */
   def unapplySeq[T](nonEmptyVector: NonEmptyVector[T]): Option[Seq[T]] = Some(nonEmptyVector)
+
+  /**
+   *
+   * A factory/assertion method that produces a <code>NonEmptyVector</code>
+   * given a valid <code>Vector</code> value, or throws
+   * <code>AssertionError</code>, if given an invalid <code>Vector</code> value.
+   *
+   * Note: you should use this method only when you are convinced that it will
+   * always succeed, i.e., never throw an exception. It is good practice to
+   * add a comment near the invocation of this method indicating ''why'' you
+   * think it will always succeed to document your reasoning. If you are not
+   * sure an `ensuringValid` call will always succeed, you should use one of
+   * the other factory or validation methods provided on this object instead:
+   * `from'.
+   *
+   * @param vector the <code>Vector</code> to check to see if it is a valid.
+   * @return the <code>NonEmptyVector</code> if the passed vector is valid..
+   * @throws AssertionError if the passed vector is not valid.
+   */
+  def ensuringValid[T](vector: Vector[T]): NonEmptyVector[T] =
+    if (vector.length == 0)
+      throw new AssertionError(Resources.nonEmptyVectorEmpty)
+    else
+      vector
 
   /**
     * Optionally construct a <code>NonEmptyVector</code> containing the elements, if any, of a given <code>GenSeq</code>.

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyVector.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NonEmptyVector.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalactic.opaques
+package org.scalactic.opaquetypes
 
 import scala.collection.GenSeq
 import scala.collection.mutable.{ArrayBuffer, Buffer}

--- a/jvm/scalactic-macro/src/main/resources/org/scalactic/ScalacticBundle.properties
+++ b/jvm/scalactic-macro/src/main/resources/org/scalactic/ScalacticBundle.properties
@@ -116,3 +116,4 @@ lhsContainsAtLeastOneEntryWithCharactersThatMightCauseProblem=LHS contains at le
 rhsContainsAtLeastOneStringWithCharactersThatMightCauseProblem=RHS contains at least one string with characters that might cause problem, the escaped string: {0}
 rhsContainsAtLeastOneEntryWithCharactersThatMightCauseProblem=RHS contains at least one entry with characters that might cause problem, the escaped string: {0}
 rhsContainsAtLeastOneCharThatMightCauseProblem=RHS contains at least one character that might cause problem, the escaped char: {0}00
+nonEmptyArrayEmpty=NonEmptyArray must contain at least one element.

--- a/jvm/scalactic-macro/src/main/resources/org/scalactic/ScalacticBundle.properties
+++ b/jvm/scalactic-macro/src/main/resources/org/scalactic/ScalacticBundle.properties
@@ -117,4 +117,5 @@ rhsContainsAtLeastOneStringWithCharactersThatMightCauseProblem=RHS contains at l
 rhsContainsAtLeastOneEntryWithCharactersThatMightCauseProblem=RHS contains at least one entry with characters that might cause problem, the escaped string: {0}
 rhsContainsAtLeastOneCharThatMightCauseProblem=RHS contains at least one character that might cause problem, the escaped char: {0}00
 nonEmptyArrayEmpty=NonEmptyArray must contain at least one element.
-nonEmptyListEmpty=NonEmptyList must contain at least one element.
+nonEmptyListEmpty=NonEmptyList must contain at least one element
+nonEmptyMapEmpty=NonEmptyMap must contain at least one entry.

--- a/jvm/scalactic-macro/src/main/resources/org/scalactic/ScalacticBundle.properties
+++ b/jvm/scalactic-macro/src/main/resources/org/scalactic/ScalacticBundle.properties
@@ -117,5 +117,6 @@ rhsContainsAtLeastOneStringWithCharactersThatMightCauseProblem=RHS contains at l
 rhsContainsAtLeastOneEntryWithCharactersThatMightCauseProblem=RHS contains at least one entry with characters that might cause problem, the escaped string: {0}
 rhsContainsAtLeastOneCharThatMightCauseProblem=RHS contains at least one character that might cause problem, the escaped char: {0}00
 nonEmptyArrayEmpty=NonEmptyArray must contain at least one element.
-nonEmptyListEmpty=NonEmptyList must contain at least one element
+nonEmptyListEmpty=NonEmptyList must contain at least one element.
 nonEmptyMapEmpty=NonEmptyMap must contain at least one entry.
+nonEmptySetEmpty=NonEmptySet must contain at least one element.

--- a/jvm/scalactic-macro/src/main/resources/org/scalactic/ScalacticBundle.properties
+++ b/jvm/scalactic-macro/src/main/resources/org/scalactic/ScalacticBundle.properties
@@ -121,3 +121,4 @@ nonEmptyListEmpty=NonEmptyList must contain at least one element.
 nonEmptyMapEmpty=NonEmptyMap must contain at least one entry.
 nonEmptySetEmpty=NonEmptySet must contain at least one element.
 nonEmptyStringEmpty=NonEmptyString must contain at least one character.
+nonEmptyVectorEmpty=NonEmptyVector must contain at least one element.

--- a/jvm/scalactic-macro/src/main/resources/org/scalactic/ScalacticBundle.properties
+++ b/jvm/scalactic-macro/src/main/resources/org/scalactic/ScalacticBundle.properties
@@ -120,3 +120,4 @@ nonEmptyArrayEmpty=NonEmptyArray must contain at least one element.
 nonEmptyListEmpty=NonEmptyList must contain at least one element.
 nonEmptyMapEmpty=NonEmptyMap must contain at least one entry.
 nonEmptySetEmpty=NonEmptySet must contain at least one element.
+nonEmptyStringEmpty=NonEmptyString must contain at least one character.

--- a/jvm/scalactic-macro/src/main/resources/org/scalactic/ScalacticBundle.properties
+++ b/jvm/scalactic-macro/src/main/resources/org/scalactic/ScalacticBundle.properties
@@ -117,3 +117,4 @@ rhsContainsAtLeastOneStringWithCharactersThatMightCauseProblem=RHS contains at l
 rhsContainsAtLeastOneEntryWithCharactersThatMightCauseProblem=RHS contains at least one entry with characters that might cause problem, the escaped string: {0}
 rhsContainsAtLeastOneCharThatMightCauseProblem=RHS contains at least one character that might cause problem, the escaped char: {0}00
 nonEmptyArrayEmpty=NonEmptyArray must contain at least one element.
+nonEmptyListEmpty=NonEmptyList must contain at least one element.

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyStringSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NonEmptyStringSpec.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.ListBuffer
 import org.scalactic.{Every, One, Many, StringNormalizations}
 import org.scalactic.UnitSpec
 import org.scalactic.NormalizingEquality
+import org.scalactic.Resources
 
 import org.scalatest.CompatParColls.Converters._
 
@@ -78,6 +79,10 @@ class NonEmptyStringSpec extends UnitSpec {
     NonEmptyString("123")(1) shouldEqual '2'
     NonEmptyString("hi")(0) shouldEqual 'h'
     NonEmptyString("789")(2) shouldEqual '9'
+
+    the [AssertionError] thrownBy {
+      NonEmptyString("")
+    } should have message Resources.nonEmptyStringEmpty
 
     // SKIP-SCALATESTJS,NATIVE-START
     val iobe = 

--- a/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyArray.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyArray.scala
@@ -121,7 +121,7 @@ import org.scalactic.{Every, Resources}
   *
   * @tparam T the type of elements contained in this <code>NonEmptyArray</code>
   */
-//DOTTY-ONLY @deprecated("Please use org.scalactic.opaques.NonEmptyArray.", "3.3.0")
+//DOTTY-ONLY @deprecated("Please use org.scalactic.opaquetypes.NonEmptyArray.", "3.3.0")
 final class NonEmptyArray[T] private (val toArray: Array[T]) extends AnyVal {
 
   /**
@@ -1458,7 +1458,7 @@ final class NonEmptyArray[T] private (val toArray: Array[T]) extends AnyVal {
 /**
   * Companion object for class <code>NonEmptyArray</code>.
   */
-//DOTTY-ONLY @deprecated("Please use org.scalactic.opaques.NonEmptyArray.", "3.3.0")  
+//DOTTY-ONLY @deprecated("Please use org.scalactic.opaquetypes.NonEmptyArray.", "3.3.0")  
 object NonEmptyArray {
 
   /**

--- a/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyList.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyList.scala
@@ -151,7 +151,7 @@ import org.scalactic.Every
  *
  * @tparam T the type of elements contained in this <code>NonEmptyList</code>
  */
-//DOTTY-ONLY @deprecated("Please use org.scalactic.opaques.NonEmptyList.", "3.3.0")
+//DOTTY-ONLY @deprecated("Please use org.scalactic.opaquetypes.NonEmptyList.", "3.3.0")
 final class NonEmptyList[+T] private (val toList: List[T]) extends AnyVal {
 
   /**
@@ -1666,7 +1666,7 @@ final class NonEmptyList[+T] private (val toList: List[T]) extends AnyVal {
 /**
  * Companion object for class <code>NonEmptyList</code>.
  */
-//DOTTY-ONLY @deprecated("Please use org.scalactic.opaques.NonEmptyList.", "3.3.0") 
+//DOTTY-ONLY @deprecated("Please use org.scalactic.opaquetypes.NonEmptyList.", "3.3.0") 
 object NonEmptyList {
 
   /**

--- a/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyMap.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyMap.scala
@@ -104,7 +104,7 @@ import org.scalactic.Every
   * @tparam K the type of key contained in this <code>NonEmptyMap</code>
   * @tparam V the type of value contained in this <code>NonEmptyMap</code>
   */
-//DOTTY-ONLY @deprecated("Please use org.scalactic.opaques.NonEmptyMap.", "3.3.0")  
+//DOTTY-ONLY @deprecated("Please use org.scalactic.opaquetypes.NonEmptyMap.", "3.3.0")  
 final class NonEmptyMap[K, +V] private (val toMap: Map[K, V]) extends AnyVal {
 
   /**
@@ -900,7 +900,7 @@ final class NonEmptyMap[K, +V] private (val toMap: Map[K, V]) extends AnyVal {
 /**
   * Companion object for class <code>NonEmptyMap</code>.
   */
-//DOTTY-ONLY @deprecated("Please use org.scalactic.opaques.NonEmptyMap.", "3.3.0")  
+//DOTTY-ONLY @deprecated("Please use org.scalactic.opaquetypes.NonEmptyMap.", "3.3.0")  
 object NonEmptyMap {
 
   /**

--- a/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptySet.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptySet.scala
@@ -151,7 +151,7 @@ import org.scalactic.Every
   *
   * @tparam T the type of elements contained in this <code>NonEmptySet</code>
   */
-//DOTTY-ONLY @deprecated("Please use org.scalactic.opaques.NonEmptySet.", "3.3.0")  
+//DOTTY-ONLY @deprecated("Please use org.scalactic.opaquetypes.NonEmptySet.", "3.3.0")  
 final class NonEmptySet[T] private (val toSet: Set[T]) extends AnyVal {
 
   /**
@@ -1022,7 +1022,7 @@ final class NonEmptySet[T] private (val toSet: Set[T]) extends AnyVal {
 /**
   * Companion object for class <code>NonEmptySet</code>.
   */
-//DOTTY-ONLY @deprecated("Please use org.scalactic.opaques.NonEmptySet.", "3.3.0")  
+//DOTTY-ONLY @deprecated("Please use org.scalactic.opaquetypes.NonEmptySet.", "3.3.0")  
 object NonEmptySet {
 
   /**

--- a/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyString.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyString.scala
@@ -1540,8 +1540,12 @@ object NonEmptyString {
     * Constructs a new <code>NonEmptyString</code> given at least one element.
     *
     * @param s the <code>String</code> represented by this <code>NonEmptyString</code>
+    * @throws AssertionError if the passed <code>String</code> is empty
     */
-  def apply(s: String): NonEmptyString = new NonEmptyString(s)
+  def apply(s: String): NonEmptyString = {
+    if (s.isEmpty) throw new AssertionError(Resources.nonEmptyStringEmpty)
+    new NonEmptyString(s)
+  }
 
   /**
     * Constructs a new <code>NonEmptyString</code> given at least one character.

--- a/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyString.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyString.scala
@@ -151,7 +151,7 @@ import org.scalactic.Resources
   * </pre>
   *
   */
-//DOTTY-ONLY @deprecated("Please use org.scalactic.opaques.NonEmptyString.", "3.3.0")  
+//DOTTY-ONLY @deprecated("Please use org.scalactic.opaquetypes.NonEmptyString.", "3.3.0")  
 final class NonEmptyString private (val theString: String) extends AnyVal {
 
   /**
@@ -1533,7 +1533,7 @@ final class NonEmptyString private (val theString: String) extends AnyVal {
 /**
   * Companion object for class <code>NonEmptyString</code>.
   */
-//DOTTY-ONLY @deprecated("Please use org.scalactic.opaques.NonEmptyString.", "3.3.0")  
+//DOTTY-ONLY @deprecated("Please use org.scalactic.opaquetypes.NonEmptyString.", "3.3.0")  
 object NonEmptyString {
 
   /**

--- a/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyVector.scala
+++ b/jvm/scalactic/src/main/scala/org/scalactic/anyvals/NonEmptyVector.scala
@@ -151,7 +151,7 @@ import org.scalactic.Every
   *
   * @tparam T the type of elements contained in this <code>NonEmptyVector</code>
   */
-//DOTTY-ONLY @deprecated("Please use org.scalactic.opaques.NonEmptyVector.", "3.3.0")  
+//DOTTY-ONLY @deprecated("Please use org.scalactic.opaquetypes.NonEmptyVector.", "3.3.0")  
 final class NonEmptyVector[+T] private (val toVector: Vector[T]) extends AnyVal {
 
   /**
@@ -1559,7 +1559,7 @@ final class NonEmptyVector[+T] private (val toVector: Vector[T]) extends AnyVal 
 /**
   * Companion object for class <code>NonEmptyVector</code>.
   */
-//DOTTY-ONLY @deprecated("Please use org.scalactic.opaques.NonEmptyVector.", "3.3.0")  
+//DOTTY-ONLY @deprecated("Please use org.scalactic.opaquetypes.NonEmptyVector.", "3.3.0")  
 object NonEmptyVector {
 
   /**

--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -72,7 +72,7 @@ trait DottyBuild { this: BuildCommons =>
     OsgiKeys.exportPackage := Seq(
       "org.scalactic",
       "org.scalactic.anyvals",
-      "org.scalactic.opaques",
+      "org.scalactic.opaquetypes",
       "org.scalactic.exceptions",
       "org.scalactic.source"
     ),
@@ -130,7 +130,7 @@ trait DottyBuild { this: BuildCommons =>
     OsgiKeys.exportPackage := Seq(
       "org.scalactic",
       "org.scalactic.anyvals",
-      "org.scalactic.opaques",
+      "org.scalactic.opaquetypes",
       "org.scalactic.exceptions",
       "org.scalactic.source"
     ),
@@ -188,7 +188,7 @@ trait DottyBuild { this: BuildCommons =>
     OsgiKeys.exportPackage := Seq(
       "org.scalactic",
       "org.scalactic.anyvals",
-      "org.scalactic.opaques",
+      "org.scalactic.opaquetypes",
       "org.scalactic.exceptions",
       "org.scalactic.source"
     ),
@@ -995,7 +995,7 @@ trait DottyBuild { this: BuildCommons =>
         "org.scalatest.wordspec",
         "org.scalactic",
         "org.scalactic.anyvals",
-        "org.scalactic.opaques",
+        "org.scalactic.opaquetypes",
         "org.scalactic.exceptions",
         "org.scalactic.source"
       ),
@@ -1135,7 +1135,7 @@ trait DottyBuild { this: BuildCommons =>
         "org.scalatest.wordspec",
         "org.scalactic",
         "org.scalactic.anyvals",
-        "org.scalactic.opaques",
+        "org.scalactic.opaquetypes",
         "org.scalactic.exceptions",
         "org.scalactic.source"
       ),
@@ -1273,7 +1273,7 @@ trait DottyBuild { this: BuildCommons =>
           "org.scalatest.wordspec",
           "org.scalactic",
           "org.scalactic.anyvals",
-          "org.scalactic.opaques",
+          "org.scalactic.opaquetypes",
           "org.scalactic.exceptions",
           "org.scalactic.source"
         ),

--- a/project/GenScalacticDotty.scala
+++ b/project/GenScalacticDotty.scala
@@ -261,7 +261,7 @@ object GenScalacticDotty {
     copyDir("jvm/scalactic/src/main/scala/org/scalactic/anyvals", "org/scalactic/anyvals", targetDir, List.empty) ++
     copyDir("dotty/scalactic/src/main/scala/org/scalactic", "org/scalactic", targetDir, List.empty) ++
     copyDir("dotty/scalactic/src/main/scala/org/scalactic/source", "org/scalactic/source", targetDir, List.empty) ++
-    copyDir("dotty/scalactic/src/main/scala/org/scalactic/opaques", "org/scalactic/opaques", targetDir, List.empty) ++
+    copyDir("dotty/scalactic/src/main/scala/org/scalactic/opaquetypes", "org/scalactic/opaquetypes", targetDir, List.empty) ++
     copyDirJS("dotty/scalactic/src/main/scala/org/scalactic/anyvals", "org/scalactic/anyvals", targetDir, List.empty) ++ 
     copyDir("js/scalactic/src/main/scala/org/scalactic/source", "org/scalactic/source", targetDir, List.empty) 
 
@@ -283,7 +283,7 @@ object GenScalacticDotty {
     copyDir("jvm/scalactic/src/main/scala/org/scalactic/anyvals", "org/scalactic/anyvals", targetDir, List.empty) ++
     copyDir("dotty/scalactic/src/main/scala/org/scalactic", "org/scalactic", targetDir, List.empty) ++
     copyDir("dotty/scalactic/src/main/scala/org/scalactic/source", "org/scalactic/source", targetDir, List.empty) ++
-    copyDir("dotty/scalactic/src/main/scala/org/scalactic/opaques", "org/scalactic/opaques", targetDir, List.empty) ++
+    copyDir("dotty/scalactic/src/main/scala/org/scalactic/opaquetypes", "org/scalactic/opaquetypes", targetDir, List.empty) ++
     copyDirNative("dotty/scalactic/src/main/scala/org/scalactic/anyvals", "org/scalactic/anyvals", targetDir, List.empty)
 
   def genMacroScala(targetDir: File, version: String, scalaVersion: String): Seq[File] =
@@ -341,7 +341,7 @@ object GenScalacticDotty {
         "OddIntMacro.scala",  // not used, scala2 macros
         "OddInt.scala"        // not used, scala2 macros
       )) ++
-    copyDirJS("dotty/scalactic-test/src/test/scala/org/scalactic/opaques", "org/scalactic/opaques", targetDir, List.empty) ++
+    copyDirJS("dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes", "org/scalactic/opaquetypes", targetDir, List.empty) ++
     copyDirJS("jvm/scalactic-test/src/test/scala/org/scalactic/source", "org/scalactic/source", targetDir, List.empty)
 
   def genTestNative(targetDir: File, version: String, scalaVersion: String): Seq[File] =
@@ -357,7 +357,7 @@ object GenScalacticDotty {
         "OddIntMacro.scala",  // not used, scala2 macros
         "OddInt.scala"        // not used, scala2 macros
       )) ++
-    copyDirNative("dotty/scalactic-test/src/test/scala/org/scalactic/opaques", "org/scalactic/opaques", targetDir, List.empty) ++  
+    copyDirNative("dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes", "org/scalactic/opaquetypes", targetDir, List.empty) ++  
     copyDirNative("jvm/scalactic-test/src/test/scala/org/scalactic/source", "org/scalactic/source", targetDir, List("ObjectMetaSpec.scala"))  
 
 }


### PR DESCRIPTION
- Changed org.scalactic.opaques package as org.scalactic.opaquetypes .
- Added ensuringValid to opaquetypes.NonEmptyXXX classes.
- Added check to apply method of anyvals.NonEmptyString that takes String, without the checking we consider it a bug.