### PR TITLE
Continue Opaque Pos Types

### DIFF
--- a/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/PosFiniteDoubleSpec.scala
+++ b/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/PosFiniteDoubleSpec.scala
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2001-2025 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalactic.opaquetypes
+
+import org.scalatest.*
+import org.scalactic.Equality
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.prop.PropertyChecks
+// SKIP-SCALATESTJS,NATIVE-START
+import scala.collection.immutable.NumericRange
+// SKIP-SCALATESTJS,NATIVE-END
+import scala.collection.mutable.WrappedArray
+import OptionValues.*
+import scala.util.{Failure, Success, Try}
+import org.scalatest.Inspectors
+import org.scalactic.{Good, Bad}
+import org.scalactic.{Pass, Fail}
+
+import PosDoubles.PosFiniteDouble
+import NegDoubles.NegFiniteDouble
+
+trait PosFiniteDoubleSpecSupport {
+
+  implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
+    override def areEqual(a: Try[T], b: Any): Boolean = a match {
+      case Success(double: Double) if double.isNaN =>  // This is because in scala.js x/0 results to NaN not ArithmetricException like in jvm, and we need to make sure Success(NaN) == Success(NaN) is true to pass the test.
+        b match {
+          case Success(bDouble: Double) if bDouble.isNaN => true
+          case _ => false
+        }
+      case _: Success[_] => a == b
+      case Failure(ex) => b match {
+        case _: Success[_] => false
+        case Failure(otherEx) => ex.getClass == otherEx.getClass && ex.getMessage == otherEx.getMessage
+        case _ => false
+      }
+    }
+  }
+
+}
+
+class PosFiniteDoubleSpec extends funspec.AnyFunSpec with matchers.should.Matchers with PropertyChecks with TypeCheckedTripleEquals with PosFiniteDoubleSpecSupport {
+
+  describe("A PosFiniteDouble") {
+    describe("should offer a from factory method that") {
+      it("returns Some[PosFiniteDouble] if the passed Double is greater than 0") {
+        PosFiniteDouble.from(50.23).value.value shouldBe 50.23
+        PosFiniteDouble.from(100.0).value.value shouldBe 100.0
+      }
+      it("returns None if the passed Double is NOT greater than 0") {
+        PosFiniteDouble.from(0.0) shouldBe None
+        PosFiniteDouble.from(-0.00001) shouldBe None
+        PosFiniteDouble.from(-99.9) shouldBe None
+      }
+    }
+    describe("should offer an ensuringValid factory method that") {
+      it("returns PosFiniteDouble if the passed Double is greater than 0") {
+        PosFiniteDouble.ensuringValid(50.23).value shouldBe 50.23
+        PosFiniteDouble.ensuringValid(100.0).value shouldBe 100.0
+      }
+      it("throws AssertionError if the passed Double is NOT greater than 0") {
+        an [AssertionError] should be thrownBy PosFiniteDouble.ensuringValid(0.0)
+        an [AssertionError] should be thrownBy PosFiniteDouble.ensuringValid(-0.00001)
+        an [AssertionError] should be thrownBy PosFiniteDouble.ensuringValid(-99.9)
+        an [AssertionError] should be thrownBy PosFiniteDouble.ensuringValid(Double.PositiveInfinity)
+        an [AssertionError] should be thrownBy PosFiniteDouble.ensuringValid(Double.NegativeInfinity)
+      }
+    }
+    describe("should offer a tryingValid factory method that") {
+      import TryValues.*
+      it("returns a PosFiniteDouble wrapped in a Success if the passed PosFiniteDouble is greater than 0") {
+        PosFiniteDouble.tryingValid(50.3).success.value.value shouldBe 50.3
+        PosFiniteDouble.tryingValid(100.0).success.value.value shouldBe 100.0
+      }
+
+      it("returns an AssertionError wrapped in a Failure if the passed Double is NOT greater than 0") {
+        PosFiniteDouble.tryingValid(0.0).failure.exception shouldBe an [AssertionError]
+        PosFiniteDouble.tryingValid(-1.0).failure.exception shouldBe an [AssertionError]
+        PosFiniteDouble.tryingValid(-99.9).failure.exception shouldBe an [AssertionError]
+      }
+    }
+    describe("should offer a passOrElse factory method that") {
+      it("returns a Pass if the given Double is greater than 0") {
+        PosFiniteDouble.passOrElse(50.0)(i => i) shouldBe Pass
+        PosFiniteDouble.passOrElse(100.0)(i => i) shouldBe Pass
+      }
+      it("returns an error value produced by passing the given Double to the given function if the passed Double is NOT greater than 0, wrapped in a Fail") {
+        PosFiniteDouble.passOrElse(0.0)(i => s"$i did not taste good") shouldBe Fail(0.0 + " did not taste good")
+        PosFiniteDouble.passOrElse(-1.1)(i => i) shouldBe Fail(-1.1)
+        PosFiniteDouble.passOrElse(-99.0)(i => i + 3.0) shouldBe Fail(-96.0)
+      }
+    }
+    describe("should offer a goodOrElse factory method that") {
+      it("returns a PosFiniteDouble wrapped in a Good if the given Double is greater than 0") {
+        PosFiniteDouble.goodOrElse(50.3)(i => i) shouldBe Good(PosFiniteDouble(50.3))
+        PosFiniteDouble.goodOrElse(100.0)(i => i) shouldBe Good(PosFiniteDouble(100.0))
+      }
+      it("returns an error value produced by passing the given Double to the given function if the passed Double is NOT greater than 0, wrapped in a Bad") {
+        PosFiniteDouble.goodOrElse(0.0)(i => s"$i did not taste good") shouldBe Bad(0.0 + " did not taste good")
+        PosFiniteDouble.goodOrElse(-1.1)(i => i) shouldBe Bad(-1.1)
+        PosFiniteDouble.goodOrElse(-99.0)(i => i + 3.0) shouldBe Bad(-96.0)
+      }
+    }
+    describe("should offer a rightOrElse factory method that") {
+      it("returns a PosFiniteDouble wrapped in a Right if the given Double is greater than 0") {
+        PosFiniteDouble.rightOrElse(50.3)(i => i) shouldBe Right(PosFiniteDouble(50.3))
+        PosFiniteDouble.rightOrElse(100.0)(i => i) shouldBe Right(PosFiniteDouble(100.0))
+      }
+      it("returns an error value produced by passing the given Double to the given function if the passed Double is NOT greater than 0, wrapped in a Left") {
+        PosFiniteDouble.rightOrElse(0.0)(i => s"$i did not taste good") shouldBe Left(0.0 + " did not taste good")
+        PosFiniteDouble.rightOrElse(-1.1)(i => i) shouldBe Left(-1.1)
+        PosFiniteDouble.rightOrElse(-99.9)(i => i + 3.0) shouldBe Left(-96.9)
+      }
+    }
+    describe("should offer an isValid predicate method that") {
+      it("returns true if the passed Double is greater than 0") {
+        PosFiniteDouble.isValid(50.23) shouldBe true
+        PosFiniteDouble.isValid(100.0) shouldBe true
+        PosFiniteDouble.isValid(0.0) shouldBe false
+        PosFiniteDouble.isValid(-0.0) shouldBe false
+        PosFiniteDouble.isValid(-0.00001) shouldBe false
+        PosFiniteDouble.isValid(-99.9) shouldBe false
+      }
+    }
+    describe("should offer a fromOrElse factory method that") {
+      it("returns a PosFiniteDouble if the passed Double is greater than 0") {
+        PosFiniteDouble.fromOrElse(50.23, PosFiniteDouble(42.0)).value shouldBe 50.23
+        PosFiniteDouble.fromOrElse(100.0, PosFiniteDouble(42.0)).value shouldBe 100.0
+      }
+      it("returns a given default if the passed Double is NOT greater than 0") {
+        PosFiniteDouble.fromOrElse(0.0, PosFiniteDouble(42.0)).value shouldBe 42.0
+        PosFiniteDouble.fromOrElse(-0.00001, PosFiniteDouble(42.0)).value shouldBe 42.0
+        PosFiniteDouble.fromOrElse(-99.9, PosFiniteDouble(42.0)).value shouldBe 42.0
+      }
+    }
+    it("should offer MaxValue, MinValue, and MinPositiveValue factory methods") {
+      PosFiniteDouble.MaxValue shouldEqual PosFiniteDouble.from(Double.MaxValue).get
+      PosFiniteDouble.MinValue shouldEqual
+        PosFiniteDouble.from(Double.MinPositiveValue).get
+      PosFiniteDouble.MinPositiveValue shouldEqual
+        PosFiniteDouble.from(Double.MinPositiveValue).get
+    }
+    it("should not offer a PositiveInfinity") {
+      "PosFiniteDouble.PositiveInfinity" shouldNot compile
+    }
+    it("should not offer a NegativeInfinity factory method") {
+      "PosFiniteDouble.NegativeInfinity" shouldNot compile
+    }
+    it("should not ffer a isPosInfinity method") {
+      "PosFiniteDouble(1.0).isPosInfinity" shouldNot compile
+    }
+
+    it("should be sortable") {
+      val xs = List(PosFiniteDouble(2.2), PosFiniteDouble(4.4), PosFiniteDouble(1.1),
+        PosFiniteDouble(3.3))
+      xs.sorted shouldEqual List(PosFiniteDouble(1.1), PosFiniteDouble(2.2), PosFiniteDouble(3.3),
+        PosFiniteDouble(4.4))
+    }
+
+    describe("when created with apply method") {
+
+      it("should compile when 8 is passed in") {
+        "PosFiniteDouble(8)" should compile
+        PosFiniteDouble(8).value shouldEqual 8.0
+        "PosFiniteDouble(8L)" should compile
+        PosFiniteDouble(8L).value shouldEqual 8.0
+        "PosFiniteDouble(8.0F)" should compile
+        PosFiniteDouble(8.0F).value shouldEqual 8.0
+        "PosFiniteDouble(8.0)" should compile
+        PosFiniteDouble(8.0).value shouldEqual 8.0
+      }
+
+      it("should not compile when 0 is passed in") {
+        "PosFiniteDouble(0)" shouldNot compile
+        "PosFiniteDouble(0L)" shouldNot compile
+        "PosFiniteDouble(0.0F)" shouldNot compile
+        "PosFiniteDouble(0.0)" shouldNot compile
+      }
+
+      it("should not compile when -8 is passed in") {
+        "PosFiniteDouble(-8)" shouldNot compile
+        "PosFiniteDouble(-8L)" shouldNot compile
+        "PosFiniteDouble(-8.0F)" shouldNot compile
+        "PosFiniteDouble(-8.0)" shouldNot compile
+      }
+      it("should not compile when x is passed in") {
+        val a: Int = -8
+        "PosFiniteDouble(a)" shouldNot compile
+        val b: Long = -8L
+        "PosFiniteDouble(b)" shouldNot compile
+        val c: Float = -8.0F
+        "PosFiniteDouble(c)" shouldNot compile
+        val d: Double = -8.0
+        "PosFiniteDouble(d)" shouldNot compile
+      }
+    }
+    describe("when specified as a plain-old Double") {
+
+      def takesPosFiniteDouble(pos: PosFiniteDouble): Double = pos.value
+
+      it("should compile when 8 is passed in") {
+        "takesPosFiniteDouble(8)" should compile
+        takesPosFiniteDouble(8) shouldEqual 8.0
+        "takesPosFiniteDouble(8L)" shouldNot compile
+        "takesPosFiniteDouble(8.0F)" should compile
+        takesPosFiniteDouble(8.0F) shouldEqual 8.0
+        "takesPosFiniteDouble(8.0)" should compile
+        takesPosFiniteDouble(8.0) shouldEqual 8.0
+      }
+
+      it("should not compile when 0 is passed in") {
+        "takesPosFiniteDouble(0)" shouldNot compile
+        "takesPosFiniteDouble(0L)" shouldNot compile
+        "takesPosFiniteDouble(0.0F)" shouldNot compile
+        "takesPosFiniteDouble(0.0)" shouldNot compile
+      }
+
+      it("should not compile when -8 is passed in") {
+        "takesPosFiniteDouble(-8)" shouldNot compile
+        "takesPosFiniteDouble(-8L)" shouldNot compile
+        "takesPosFiniteDouble(-8.0F)" shouldNot compile
+        "takesPosFiniteDouble(-8.0)" shouldNot compile
+      }
+
+      it("should not compile when x is passed in") {
+        val x: Int = -8
+        "takesPosFiniteDouble(x)" shouldNot compile
+        val b: Long = -8L
+        "takesPosFiniteDouble(b)" shouldNot compile
+        val c: Float = -8.0F
+        "takesPosFiniteDouble(c)" shouldNot compile
+        val d: Double = -8.0
+        "takesPosFiniteDouble(d)" shouldNot compile
+      }
+    }
+
+    it("should offer a unary + method that is consistent with Double") {
+      forAll { (p: PosFiniteDouble) =>
+        (+p).toDouble shouldEqual (+(p.toDouble))
+      }
+    }
+
+    it("should offer a unary - method that returns NegFiniteDouble") {
+      forAll { (p: PosFiniteDouble) =>
+        (-p) shouldEqual (NegFiniteDouble.ensuringValid(-(p.toDouble)))
+      }
+    }
+
+    it("should offer 'min' and 'max' methods that are consistent with Double") {
+      forAll { (pdouble1: PosFiniteDouble, pdouble2: PosFiniteDouble) =>
+        pdouble1.max(pdouble2).toDouble shouldEqual pdouble1.toDouble.max(pdouble2.toDouble)
+        pdouble1.min(pdouble2).toDouble shouldEqual pdouble1.toDouble.min(pdouble2.toDouble)
+      }
+    }
+
+    it("should offer an 'isWhole' method that is consistent with Double") {
+      forAll { (pdouble: PosFiniteDouble) =>
+        pdouble.isWhole shouldEqual pdouble.toDouble.isWhole
+      }
+    }
+
+    it("should offer 'round', 'ceil', and 'floor' methods that are consistent with Double") {
+      forAll { (pdouble: PosFiniteDouble) =>
+        pdouble.round.toDouble shouldEqual pdouble.toDouble.round
+        pdouble.ceil.toDouble shouldEqual pdouble.toDouble.ceil
+        pdouble.floor.toDouble shouldEqual pdouble.toDouble.floor
+      }
+    }
+
+    it("should offer 'toRadians' and 'toDegrees' methods that are consistent with Double") {
+      forAll { (pdouble: PosFiniteDouble) =>
+        pdouble.toRadians shouldEqual pdouble.toDouble.toRadians
+      }
+    }
+
+    it("should offer an ensuringValid method that takes a Double => Double, throwing AssertionError if the result is invalid") {
+      PosFiniteDouble(33.0).ensuringValid(_ + 1.0) shouldEqual PosFiniteDouble(34.0)
+      an [AssertionError] should be thrownBy { PosFiniteDouble.MaxValue.ensuringValid(_ - PosFiniteDouble.MaxValue) }
+      an [AssertionError] should be thrownBy { PosFiniteDouble.MaxValue.ensuringValid(_ => Double.PositiveInfinity) }
+      an [AssertionError] should be thrownBy { PosFiniteDouble.MaxValue.ensuringValid(_ => Double.NegativeInfinity) }
+    }
+  }
+}
+

--- a/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/PosZFiniteDoubleSpec.scala
+++ b/dotty/scalactic-test/src/test/scala/org/scalactic/opaquetypes/PosZFiniteDoubleSpec.scala
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2001-2025 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalactic.opaquetypes
+
+import org.scalatest.*
+import org.scalatest.prop.PropertyChecks
+// SKIP-SCALATESTJS,NATIVE-START
+import scala.collection.immutable.NumericRange
+// SKIP-SCALATESTJS,NATIVE-END
+import OptionValues.*
+import scala.collection.mutable.WrappedArray
+//import org.scalactic.StrictCheckedEquality
+import Double.NaN
+import org.scalactic.Equality
+import org.scalactic.{Pass, Fail}
+import org.scalactic.{Good, Bad}
+import scala.util.{Try, Success, Failure}
+
+import PosDoubles.{PosZFiniteDouble, PosZDouble}
+import NegDoubles.NegZFiniteDouble
+
+trait PosZFiniteDoubleSpecSupport {
+
+  implicit val doubleEquality: Equality[Double] =
+    new Equality[Double] {
+      override def areEqual(a: Double, b: Any): Boolean =
+        (a, b) match {
+          case (a, bDouble: Double) if a.isNaN && bDouble.isNaN  => true
+          case _ => a == b
+        }
+    }
+
+  implicit val floatEquality: Equality[Float] =
+    new Equality[Float] {
+      override def areEqual(a: Float, b: Any): Boolean =
+        (a, b) match {
+          case (a, bFloat: Float) if a.isNaN && bFloat.isNaN => true
+          case _ => a == b
+        }
+    }
+
+  implicit def tryEquality[T]: Equality[Try[T]] = new Equality[Try[T]] {
+    override def areEqual(a: Try[T], b: Any): Boolean = a match {
+      case Success(double: Double) if double.isNaN =>  // This is because in scala.js x/0 results to NaN not ArithmetricException like in jvm, and we need to make sure Success(NaN) == Success(NaN) is true to pass the test.
+        b match {
+          case Success(bDouble: Double) if bDouble.isNaN => true
+          case _ => false
+        }
+      case _: Success[_] => a == b
+      case Failure(ex) => b match {
+        case _: Success[_] => false
+        case Failure(otherEx) => ex.getClass == otherEx.getClass && ex.getMessage == otherEx.getMessage
+        case _ => false
+      }
+    }
+  }
+
+}
+
+class PosZFiniteDoubleSpec extends funspec.AnyFunSpec with matchers.should.Matchers with PropertyChecks with PosZFiniteDoubleSpecSupport {
+
+  describe("A PosZFiniteDouble") {
+    describe("should offer a from factory method that") {
+      it("returns Some[PosZFiniteDouble] if the passed Double is greater than or equal to 0") {
+        PosZFiniteDouble.from(0.0).value.value shouldBe 0.0
+        PosZFiniteDouble.from(50.23).value.value shouldBe 50.23
+        PosZFiniteDouble.from(100.0).value.value shouldBe 100.0
+      }
+      it("returns None if the passed Double is NOT greater than or equal to 0") {
+        PosZFiniteDouble.from(-0.00001) shouldBe None
+        PosZFiniteDouble.from(-99.9) shouldBe None
+      }
+    }
+    describe("should offer an ensuringValid factory method that") {
+      it("returns PosZFiniteDouble if the passed Double is greater than or equal to 0") {
+        PosZFiniteDouble.ensuringValid(0.0).value shouldBe 0.0
+        PosZFiniteDouble.ensuringValid(50.23).value shouldBe 50.23
+        PosZFiniteDouble.ensuringValid(100.0).value shouldBe 100.0
+      }
+      it("throws AssertionError if the passed Double is NOT greater than or equal to 0") {
+        an [AssertionError] should be thrownBy PosZFiniteDouble.ensuringValid(-0.00001)
+        an [AssertionError] should be thrownBy PosZFiniteDouble.ensuringValid(-99.9)
+        an [AssertionError] should be thrownBy PosZFiniteDouble.ensuringValid(Double.PositiveInfinity)
+        an [AssertionError] should be thrownBy PosZFiniteDouble.ensuringValid(Double.NegativeInfinity)
+      }
+    }
+    describe("should offer a tryingValid factory method that") {
+      import TryValues.*
+      it("returns a PosZFiniteDouble wrapped in a Success if the passed Double is greater than or equal 0") {
+        PosZFiniteDouble.tryingValid(0.0).success.value.value shouldBe 0.0
+        PosZFiniteDouble.tryingValid(50.0).success.value.value shouldBe 50.0
+        PosZFiniteDouble.tryingValid(100.0f).success.value.value shouldBe 100.0
+      }
+
+      it("returns an AssertionError wrapped in a Failure if the passed Double is lesser than 0") {
+        PosZFiniteDouble.tryingValid(-1.0).failure.exception shouldBe an [AssertionError]
+        PosZFiniteDouble.tryingValid(-99.0).failure.exception shouldBe an [AssertionError]
+      }
+    }
+    describe("should offer a passOrElse factory method that") {
+      it("returns a Pass if the given Double is greater than or equal 0") {
+        PosZFiniteDouble.passOrElse(0.0)(i => i) shouldBe Pass
+        PosZFiniteDouble.passOrElse(50.0)(i => i) shouldBe Pass
+        PosZFiniteDouble.passOrElse(100.0)(i => i) shouldBe Pass
+      }
+      it("returns an error value produced by passing the given Double to the given function if the passed Double is lesser than 0, wrapped in a Fail") {
+        PosZFiniteDouble.passOrElse(-1.0)(i => i) shouldBe Fail(-1.0)
+        PosZFiniteDouble.passOrElse(-99.0)(i => i + 3.0) shouldBe Fail(-96.0)
+      }
+    }
+    describe("should offer a goodOrElse factory method that") {
+      it("returns a PosZFiniteDouble wrapped in a Good if the given Double is greater than or equal 0") {
+        PosZFiniteDouble.goodOrElse(0.0)(i => i) shouldBe Good(PosZFiniteDouble(0.0))
+        PosZFiniteDouble.goodOrElse(50.0)(i => i) shouldBe Good(PosZFiniteDouble(50.0))
+        PosZFiniteDouble.goodOrElse(100.0)(i => i) shouldBe Good(PosZFiniteDouble(100.0))
+      }
+      it("returns an error value produced by passing the given Double to the given function if the passed Double is lesser than 0, wrapped in a Bad") {
+        PosZFiniteDouble.goodOrElse(-1.0)(i => i) shouldBe Bad(-1.0)
+        PosZFiniteDouble.goodOrElse(-99.0)(i => i + 3.0f) shouldBe Bad(-96.0)
+      }
+    }
+    describe("should offer a rightOrElse factory method that") {
+      it("returns a PosZFiniteDouble wrapped in a Right if the given Double is greater than or equal 0") {
+        PosZFiniteDouble.rightOrElse(0.0)(i => i) shouldBe Right(PosZFiniteDouble(0.0))
+        PosZFiniteDouble.rightOrElse(50.0)(i => i) shouldBe Right(PosZFiniteDouble(50.0))
+        PosZFiniteDouble.rightOrElse(100.0)(i => i) shouldBe Right(PosZFiniteDouble(100.0))
+      }
+      it("returns an error value produced by passing the given Double to the given function if the passed Double is lesser than 0, wrapped in a Left") {
+        PosZFiniteDouble.rightOrElse(-1.0)(i => i) shouldBe Left(-1.0)
+        PosZFiniteDouble.rightOrElse(-99.0)(i => i + 3.0f) shouldBe Left(-96.0)
+      }
+    }
+    describe("should offer an isValid predicate method that") {
+      it("returns true if the passed Double is greater than or equal to 0") {
+        PosZFiniteDouble.isValid(50.23) shouldBe true
+        PosZFiniteDouble.isValid(100.0) shouldBe true
+        PosZFiniteDouble.isValid(0.0) shouldBe true
+        PosZFiniteDouble.isValid(-0.0) shouldBe true
+        PosZFiniteDouble.isValid(-0.00001) shouldBe false
+        PosZFiniteDouble.isValid(-99.9) shouldBe false
+      }
+    }
+    describe("should offer a fromOrElse factory method that") {
+      it("returns a PosZFiniteDouble if the passed Double is greater than or equal to 0") {
+        PosZFiniteDouble.fromOrElse(50.23, PosZFiniteDouble(42.0)).value shouldBe 50.23
+        PosZFiniteDouble.fromOrElse(100.0, PosZFiniteDouble(42.0)).value shouldBe 100.0
+        PosZFiniteDouble.fromOrElse(0.0, PosZFiniteDouble(42.0)).value shouldBe 0.0
+      }
+      it("returns a given default if the passed Double is NOT greater than or equal to 0") {
+        PosZFiniteDouble.fromOrElse(-0.00001, PosZFiniteDouble(42.0)).value shouldBe 42.0
+        PosZFiniteDouble.fromOrElse(-99.9, PosZFiniteDouble(42.0)).value shouldBe 42.0
+      }
+    }
+    it("should offer MaxValue, MinValue, and MinPositiveValue factory methods") {
+      PosZFiniteDouble.MaxValue shouldEqual PosZFiniteDouble.from(Double.MaxValue).get
+      PosZFiniteDouble.MinValue shouldEqual PosZFiniteDouble(0.0)
+      PosZFiniteDouble.MinPositiveValue shouldEqual
+        PosZFiniteDouble.from(Double.MinPositiveValue).get
+    }
+    it("should not offer a PositiveInfinity factory method") {
+      "PosZFiniteDouble.PositiveInfinity" shouldNot compile
+    }
+    it("should not offer a NegativeInfinity factory method") {
+      "PosZFiniteDouble.NegativeInfinity" shouldNot compile
+    }
+/* This now compiles because of the newly added implicit PosZFiniteDouble => PosZDouble method
+    PosZFiniteDouble(1.0f).isPosInfinity
+*/
+    it("should not offer a isNegInfinity method") {
+      "PosZFiniteDouble(1.0f).isNegInfinity" shouldNot compile
+    }
+
+    it("should be sortable") {
+      val xs = List(PosZFiniteDouble(2.2), PosZFiniteDouble(0.0), PosZFiniteDouble(1.1),
+        PosZFiniteDouble(3.3))
+      xs.sorted shouldEqual List(PosZFiniteDouble(0.0), PosZFiniteDouble(1.1),
+        PosZFiniteDouble(2.2), PosZFiniteDouble(3.3))
+    }
+
+    describe("when created with apply method") {
+
+      it("should compile when 8 is passed in") {
+        "PosZFiniteDouble(8)" should compile
+        PosZFiniteDouble(8).value shouldEqual 8.0
+        "PosZFiniteDouble(8L)" shouldNot compile
+        "PosZFiniteDouble(8.0F)" should compile
+        PosZFiniteDouble(8.0F).value shouldEqual 8.0
+        "PosZFiniteDouble(8.0)" should compile
+        PosZFiniteDouble(8.0).value shouldEqual 8.0
+      }
+
+      it("should compile when 0 is passed in") {
+        "PosZFiniteDouble(0)" should compile
+        PosZFiniteDouble(0).value shouldEqual 0.0
+        "PosZFiniteDouble(0L)" shouldNot compile
+        "PosZFiniteDouble(0.0F)" should compile
+        PosZFiniteDouble(0.0F).value shouldEqual 0.0
+        "PosZFiniteDouble(0.0)" should compile
+        PosZFiniteDouble(0.0).value shouldEqual 0.0
+      }
+
+      it("should not compile when -8 is passed in") {
+        "PosZFiniteDouble(-8)" shouldNot compile
+        "PosZFiniteDouble(-8L)" shouldNot compile
+        "PosZFiniteDouble(-8.0F)" shouldNot compile
+        "PosZFiniteDouble(-8.0)" shouldNot compile
+      }
+      it("should not compile when x is passed in") {
+        val a: Int = -8
+        "PosZFiniteDouble(a)" shouldNot compile
+        val b: Long = -8L
+        "PosZFiniteDouble(b)" shouldNot compile
+        val c: Float = -8.0F
+        "PosZFiniteDouble(c)" shouldNot compile
+        val d: Double = -8.0
+        "PosZFiniteDouble(d)" shouldNot compile
+      }
+    }
+    describe("when specified as a plain-old Double") {
+
+      def takesPosZFiniteDouble(poz: PosZFiniteDouble): Double = poz.value
+
+      it("should compile when 8 is passed in") {
+        "takesPosZFiniteDouble(8)" should compile
+        takesPosZFiniteDouble(8) shouldEqual 8.0
+        "takesPosZFiniteDouble(8L)" shouldNot compile
+        "takesPosZFiniteDouble(8.0F)" should compile
+        takesPosZFiniteDouble(8.0F) shouldEqual 8.0
+        "takesPosZFiniteDouble(8.0)" should compile
+        takesPosZFiniteDouble(8.0) shouldEqual 8.0
+      }
+
+      it("should compile when 0 is passed in") {
+        "takesPosZFiniteDouble(0)" should compile
+        takesPosZFiniteDouble(0) shouldEqual 0.0
+        "takesPosZFiniteDouble(0L)" shouldNot compile
+        "takesPosZFiniteDouble(0.0F)" should compile
+        takesPosZFiniteDouble(0.0F) shouldEqual 0.0
+        "takesPosZFiniteDouble(0.0)" should compile
+        takesPosZFiniteDouble(0.0) shouldEqual 0.0
+      }
+
+      it("should not compile when -8 is passed in") {
+        "takesPosZFiniteDouble(-8)" shouldNot compile
+        "takesPosZFiniteDouble(-8L)" shouldNot compile
+        "takesPosZFiniteDouble(-8.0F)" shouldNot compile
+        "takesPosZFiniteDouble(-8.0)" shouldNot compile
+      }
+
+      it("should not compile when x is passed in") {
+        val x: Int = -8
+        "takesPosZFiniteDouble(x)" shouldNot compile
+        val b: Long = -8L
+        "takesPosZFiniteDouble(b)" shouldNot compile
+        val c: Float = -8.0F
+        "takesPosZFiniteDouble(c)" shouldNot compile
+        val d: Double = -8.0
+        "takesPosZFiniteDouble(d)" shouldNot compile
+      }
+    }
+
+    it("should offer a unary + method that is consistent with Double") {
+      forAll { (p: PosZFiniteDouble) =>
+        (+p).toDouble shouldEqual (+(p.toDouble))
+      }
+    }
+
+    it("should offer a unary - method that returns NegZFiniteDouble") {
+      forAll { (p: PosZFiniteDouble) =>
+        (-p) shouldEqual (NegZFiniteDouble.ensuringValid(-(p.toDouble)))
+      }
+    }
+
+    it("should offer 'min' and 'max' methods that are consistent with Double") {
+      forAll { (pzdouble1: PosZFiniteDouble, pzdouble2: PosZFiniteDouble) =>
+        pzdouble1.max(pzdouble2).toDouble shouldEqual pzdouble1.toDouble.max(pzdouble2.toDouble)
+        pzdouble1.min(pzdouble2).toDouble shouldEqual pzdouble1.toDouble.min(pzdouble2.toDouble)
+      }
+    }
+
+    it("should offer an 'isWhole' method that is consistent with Double") {
+      forAll { (pzdouble: PosZFiniteDouble) =>
+        pzdouble.isWhole shouldEqual pzdouble.toDouble.isWhole
+      }
+    }
+
+    it("should offer 'round', 'ceil', and 'floor' methods that are consistent with Double") {
+      forAll { (pzdouble: PosZFiniteDouble) =>
+        pzdouble.round.toDouble shouldEqual pzdouble.toDouble.round
+        pzdouble.ceil.toDouble shouldEqual pzdouble.toDouble.ceil
+        pzdouble.floor.toDouble shouldEqual pzdouble.toDouble.floor
+      }
+    }
+
+    it("should offer 'toRadians' and 'toDegrees' methods that are consistent with Double") {
+      forAll { (pzdouble: PosZFiniteDouble) =>
+        pzdouble.toRadians shouldEqual pzdouble.toDouble.toRadians
+      }
+    }
+
+    it("should offer widening methods for basic types that are consistent with Double") {
+      forAll { (pzdouble: PosZFiniteDouble) =>
+        def widen(value: Double): Double = value
+        widen(pzdouble) shouldEqual widen(pzdouble.toDouble)
+      }
+    }
+    it("should offer an ensuringValid method that takes a Double => Double, throwing AssertionError if the result is invalid") {
+      PosZFiniteDouble(33.0).ensuringValid(_ + 1.0) shouldEqual PosZFiniteDouble(34.0)
+      an [AssertionError] should be thrownBy { PosZFiniteDouble.MaxValue.ensuringValid(_ - PosZFiniteDouble.MaxValue - 1) }
+      an [AssertionError] should be thrownBy { PosZFiniteDouble.MaxValue.ensuringValid(_ => Double.PositiveInfinity) }
+      an [AssertionError] should be thrownBy { PosZFiniteDouble.MaxValue.ensuringValid(_ => Double.NegativeInfinity) }
+    }
+  }
+}

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NegDoubles.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/NegDoubles.scala
@@ -32,4 +32,20 @@ object NegDoubles {
         throw new AssertionError(Resources.invalidNegDouble)
       else d
   }
+
+  opaque type NegZFiniteDouble = Double
+  object NegZFiniteDouble {
+    def ensuringValid(d: Double): NegZFiniteDouble =
+      if (d > 0 || d == Double.NegativeInfinity || d == Double.PositiveInfinity)
+        throw new AssertionError(Resources.invalidNegZDouble)
+      else d
+  }
+
+  opaque type NegFiniteDouble = Double
+  object NegFiniteDouble {
+    def ensuringValid(d: Double): NegFiniteDouble =
+      if (d >= 0 || d == Double.NegativeInfinity || d == Double.PositiveInfinity)
+        throw new AssertionError(Resources.invalidNegDouble)
+      else d
+  }
 }

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/PosDoubles.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/PosDoubles.scala
@@ -23,7 +23,7 @@ import org.scalactic.{Or, Good, Bad}
 
 import PosLongs.PosZLong
 import NonZeroDoubles.NonZeroDouble
-import NegDoubles.NegFiniteDouble
+import NegDoubles.{NegFiniteDouble, NegZFiniteDouble}
 
 object PosDoubles {
 
@@ -472,8 +472,89 @@ object PosDoubles {
       def apply(x: PosZFiniteDouble): Double = x.toDouble
     }
 
+    /** Convert a compile-time Int literal or runtime Int to a [[PosZFiniteDouble]]. */
+    given Conversion[Int, PosZFiniteDouble] with {
+      inline def apply[I <: Int & Singleton](inline x: I): PosZFiniteDouble =
+        inline constValueOpt[I] match {
+          case Some(v: Int) =>
+            inline if v < 0 then
+              error("PosZFiniteDouble cannot be instantiated with a negative integer literal")
+            else
+              v.toDouble.asInstanceOf[PosZFiniteDouble]
+          case None =>
+            error("PosZFiniteDouble conversion requires an integer literal")
+        }
+      def apply(x: Int): PosZFiniteDouble = x.toDouble
+    }
+
+    /** Convert a compile-time Float literal or runtime Float to a [[PosZFiniteDouble]]. */
+    given Conversion[Float, PosZFiniteDouble] with {
+      inline def apply[F <: Float & Singleton](inline x: F): PosZFiniteDouble =
+        inline constValueOpt[F] match {
+          case Some(v: Float) =>
+            inline if v < 0.0f then
+              error("PosZFiniteDouble cannot be instantiated with a negative float literal")
+            else
+              v.toDouble.asInstanceOf[PosZFiniteDouble]
+          case None =>
+            error("PosZFiniteDouble conversion requires a float literal")
+        }
+      def apply(x: Float): PosZFiniteDouble = x.toDouble
+    }
+
+    /** Convert a compile-time Double literal or runtime Double to a [[PosZFiniteDouble]]. */
+    given Conversion[Double, PosZFiniteDouble] with {
+      inline def apply[D <: Double & Singleton](inline x: D): PosZFiniteDouble =
+        inline constValueOpt[D] match {
+          case Some(v: Double) =>
+            inline if v < 0.0 || v == Double.PositiveInfinity || v == Double.NegativeInfinity then
+              error("PosZFiniteDouble cannot be instantiated with a negative or infinite double literal")
+            else
+              v.asInstanceOf[PosZFiniteDouble]
+          case None =>
+            error("PosZFiniteDouble conversion requires a double literal")
+        }
+      def apply(x: Double): PosZFiniteDouble = x
+    }
+
+    /** Compile-time factory for creating a [[PosZFiniteDouble]] from a double literal. */
+    inline def apply[D <: Double & Singleton](inline d: D): PosZFiniteDouble =
+      inline constValueOpt[D] match {
+        case Some(v: Double) =>
+          inline if v < 0.0 || v == Double.PositiveInfinity || v == Double.NegativeInfinity then
+            error("PosZFiniteDouble cannot be instantiated with a negative or infinite double literal")
+          else
+            v.asInstanceOf[PosZFiniteDouble]
+        case None =>
+          error("PosZFiniteDouble.apply requires an integer, float or double literal")
+      }
+
+    /** Compile-time factory for creating a [[PosZFiniteDouble]] from a float literal. */
+    inline def apply[F <: Float & Singleton](inline f: F): PosZFiniteDouble =
+      inline constValueOpt[F] match {
+        case Some(v: Float) =>
+          inline if v < 0.0f then
+            error("PosZFiniteDouble cannot be instantiated with a negative float literal")
+          else
+            v.toDouble.asInstanceOf[PosZFiniteDouble]
+        case None =>
+          error("PosZFiniteDouble.apply requires an integer, float or double literal")
+      }
+
+    /** Compile-time factory for creating a [[PosZFiniteDouble]] from an integer literal. */
+    inline def apply[I <: Int & Singleton](inline i: I): PosZFiniteDouble =
+      inline constValueOpt[I] match {
+        case Some(v: Int) =>
+          inline if v < 0 then
+            error("PosZFiniteDouble cannot be instantiated with a negative integer literal")
+          else
+            v.toDouble.asInstanceOf[PosZFiniteDouble]
+        case None =>
+          error("PosZFiniteDouble.apply requires an integer, float or double literal")
+      }
+
     /** Returns true if the passed Double is non-negative and finite. */
-    def isValid(value: Double): Boolean = value >= 0.0 && value != Double.PositiveInfinity && value != Double.NegativeInfinity
+    def isValid(value: Double): Boolean = value >= 0.0 && value.isFinite
 
     /** Construct a [[PosZFiniteDouble]] from a runtime Double if it is non-negative and finite. */
     def from(value: Double): Option[PosZFiniteDouble] =
@@ -488,10 +569,26 @@ object PosDoubles {
       if (isValid(value)) value
       else throw new AssertionError(Resources.invalidPosZDouble)
 
+    /** Produce a PosZFiniteDouble in a Success if valid, or an AssertionError in a Failure. */
+    def tryingValid(value: Double): Try[PosZFiniteDouble] =
+      if (isValid(value))
+        Success(value)
+      else
+        Failure(new AssertionError(Resources.invalidPosZDouble))
+
+    def passOrElse[E](value: Double)(f: Double => E): Validation[E] =
+      if (isValid(value)) Pass else Fail(f(value))
+
+    def goodOrElse[B](value: Double)(f: Double => B): PosZFiniteDouble Or B =
+      if (isValid(value)) Good(value) else Bad(f(value))
+
+    def rightOrElse[L](value: Double)(f: Double => L): Either[L, PosZFiniteDouble] =
+      if (isValid(value)) Right(ensuringValid(value)) else Left(f(value))
+
     /** The largest finite non-negative Double value. */
     val MaxValue: PosZFiniteDouble = Double.MaxValue
 
-    /** The smallest non-negative finite Double value. */
+    /** The smallest non-negative finite Double value (zero). */
     val MinValue: PosZFiniteDouble = 0.0
 
     /** The smallest positive finite Double value. */
@@ -500,6 +597,39 @@ object PosDoubles {
     extension (p: PosZFiniteDouble) {
       /** Return the underlying Double value. */
       def value: Double = p
+
+      /** Return this value (unary +). */
+      def unary_+ : PosZFiniteDouble = p
+
+      /** Negate this value, returning a NegZFiniteDouble. */
+      def unary_- : NegZFiniteDouble = NegZFiniteDouble.ensuringValid(-p)
+
+      /** Returns the larger of this and that. */
+      def max(that: PosZFiniteDouble): PosZFiniteDouble = math.max(p, that)
+
+      /** Returns the smaller of this and that. */
+      def min(that: PosZFiniteDouble): PosZFiniteDouble = math.min(p, that)
+
+      /** Indicates whether this value is a whole number. */
+      def isWhole: Boolean = {
+        val longValue = p.toLong
+        longValue.toDouble == p || longValue == Long.MaxValue && p < Double.PositiveInfinity || longValue == Long.MinValue && p > Double.NegativeInfinity
+      }
+
+      /** Rounds this value to the nearest whole number as a PosZLong. */
+      def round: PosZLong = PosZLong.ensuringValid(math.round(p))
+
+      /** Returns the smallest PosZFiniteDouble >= this that is a mathematical integer. */
+      def ceil: PosZFiniteDouble = PosZFiniteDouble.ensuringValid(math.ceil(p))
+
+      /** Returns the greatest PosZFiniteDouble <= this that is a mathematical integer. */
+      def floor: PosZFiniteDouble = PosZFiniteDouble.ensuringValid(math.floor(p))
+
+      /** Converts this angle in degrees to radians. */
+      def toRadians: Double = math.toRadians(p)
+
+      /** Converts this angle in radians to degrees. */
+      def toDegrees: Double = math.toDegrees(p)
 
       /** Applies the passed function and ensures the result is a valid PosZFiniteDouble. */
       def ensuringValid(f: Double => Double): PosZFiniteDouble = {

--- a/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/PosDoubles.scala
+++ b/dotty/scalactic/src/main/scala/org/scalactic/opaquetypes/PosDoubles.scala
@@ -23,6 +23,7 @@ import org.scalactic.{Or, Good, Bad}
 
 import PosLongs.PosZLong
 import NonZeroDoubles.NonZeroDouble
+import NegDoubles.NegFiniteDouble
 
 object PosDoubles {
 
@@ -507,6 +508,197 @@ object PosDoubles {
         else throw new AssertionError(s"${candidateResult.toString()}, the result of applying the passed function to ${p.toString()}, was not a valid PosZFiniteDouble")
       }
     }
+  }
+
+  opaque type PosFiniteDouble = Double
+
+  object PosFiniteDouble {
+
+    /** Convert a [[PosFiniteDouble]] to a plain Double (unwrap). */
+    given Conversion[PosFiniteDouble, Double] with {
+      def apply(x: PosFiniteDouble): Double = x.toDouble
+    }
+
+    /** Convert a compile-time Int literal or runtime Int to a [[PosFiniteDouble]]. */
+    given Conversion[Int, PosFiniteDouble] with {
+      inline def apply[I <: Int & Singleton](inline x: I): PosFiniteDouble =
+        inline constValueOpt[I] match {
+          case Some(v: Int) =>
+            inline if v <= 0 then
+              error("PosFiniteDouble cannot be instantiated with a zero or negative integer literal")
+            else
+              v.toDouble.asInstanceOf[PosFiniteDouble]
+          case None =>
+            error("PosFiniteDouble conversion requires a integer literal")
+        }
+      def apply(x: Int): PosFiniteDouble = x.toDouble
+    }
+
+    /** Convert a compile-time Float literal or runtime Float to a [[PosFiniteDouble]]. */
+    given Conversion[Float, PosFiniteDouble] with {
+      inline def apply[F <: Float & Singleton](inline x: F): PosFiniteDouble =
+        inline constValueOpt[F] match {
+          case Some(v: Float) =>
+            inline if v <= 0.0f || v == Float.PositiveInfinity || v == Float.NegativeInfinity then
+              error("PosFiniteDouble cannot be instantiated with a zero, negative, or infinite float literal")
+            else
+              v.toDouble.asInstanceOf[PosFiniteDouble]
+          case None =>
+            error("PosFiniteDouble conversion requires a float literal")
+        }
+      def apply(x: Float): PosFiniteDouble = x.toDouble
+    }
+
+    /** Convert a compile-time Double literal or runtime Double to a [[PosFiniteDouble]]. */
+    given Conversion[Double, PosFiniteDouble] with {
+      inline def apply[D <: Double & Singleton](inline x: D): PosFiniteDouble =
+        inline constValueOpt[D] match {
+          case Some(v: Double) =>
+            inline if v <= 0.0 || v == Double.PositiveInfinity || v == Double.NegativeInfinity then
+              error("PosFiniteDouble cannot be instantiated with a zero, negative, or infinite double literal")
+            else
+              v.asInstanceOf[PosFiniteDouble]
+          case None =>
+            error("PosFiniteDouble conversion requires a double literal")
+        }
+      def apply(x: Double): PosFiniteDouble = x
+    }
+
+    /** Compile-time factory for creating a [[PosFiniteDouble]] from a double literal. */
+    inline def apply[D <: Double & Singleton](inline d: D): PosFiniteDouble =
+      inline constValueOpt[D] match {
+        case Some(v: Double) =>
+          inline if v <= 0.0 || v == Double.PositiveInfinity || v == Double.NegativeInfinity then
+            error("PosFiniteDouble cannot be instantiated with a non-positive or infinite double literal")
+          else
+            v.asInstanceOf[PosFiniteDouble]
+        case None =>
+          error("PosFiniteDouble.apply requires a integer, long, float or double literal")
+      }
+
+    /** Compile-time factory for creating a [[PosFiniteDouble]] from a float literal. */
+    inline def apply[F <: Float & Singleton](inline f: F): PosFiniteDouble =
+      inline constValueOpt[F] match {
+        case Some(v: Float) =>
+          inline if v <= 0.0f || v == Float.PositiveInfinity || v == Float.NegativeInfinity then
+            error("PosFiniteDouble cannot be instantiated with a non-positive or infinite float literal")
+          else
+            v.toDouble.asInstanceOf[PosFiniteDouble]
+        case None =>
+          error("PosFiniteDouble.apply requires a integer, long, float or double literal")
+      }
+
+    /** Compile-time factory for creating a [[PosFiniteDouble]] from a long literal. */
+    inline def apply[L <: Long & Singleton](inline l: L): PosFiniteDouble =
+      inline constValueOpt[L] match {
+        case Some(v: Long) =>
+          inline if v <= 0L then
+            error("PosFiniteDouble cannot be instantiated with a non-positive long literal")
+          else
+            v.toDouble.asInstanceOf[PosFiniteDouble]
+        case None =>
+          error("PosFiniteDouble.apply requires a integer, long, float or double literal")
+      }
+
+    /** Compile-time factory for creating a [[PosFiniteDouble]] from an integer literal. */
+    inline def apply[I <: Int & Singleton](inline i: I): PosFiniteDouble =
+      inline constValueOpt[I] match {
+        case Some(v: Int) =>
+          inline if v <= 0 then
+            error("PosFiniteDouble cannot be instantiated with a non-positive integer literal")
+          else
+            v.toDouble.asInstanceOf[PosFiniteDouble]
+        case None =>
+          error("PosFiniteDouble.apply requires a integer, long, float or double literal")
+      }
+
+    /** Return true when the provided Double is a valid [[PosFiniteDouble]] value (> 0 and finite). */
+    def isValid(value: Double): Boolean = value > 0.0 && value != Double.PositiveInfinity && value != Double.NegativeInfinity
+
+    /** Construct a [[PosFiniteDouble]] from a runtime Double if it is positive and finite. */
+    def from(value: Double): Option[PosFiniteDouble] =
+      if (isValid(value)) Some(value) else None
+
+    /** Construct a [[PosFiniteDouble]] from a runtime Double if valid, else return the default. */
+    def fromOrElse(value: Double, default: => PosFiniteDouble): PosFiniteDouble =
+      if (isValid(value)) value else default
+
+    /** Ensure the runtime Double is positive and finite. */
+    def ensuringValid(value: Double): PosFiniteDouble =
+      if (isValid(value)) value
+      else throw new AssertionError(Resources.invalidPosDouble)
+
+    /** Try constructing a [[PosFiniteDouble]], returning Failure(AssertionError) if invalid. */
+    def tryingValid(value: Double): Try[PosFiniteDouble] =
+      if (isValid(value)) Success(value)
+      else Failure(new AssertionError(Resources.invalidPosDouble))
+
+    /** Ordering instance for PosFiniteDouble that orders by numeric value. */
+    given Ordering[PosFiniteDouble] with {
+      def compare(x: PosFiniteDouble, y: PosFiniteDouble): Int = java.lang.Double.compare(x, y)
+    }
+
+    extension (p: PosFiniteDouble) {
+      /** Return the underlying Double value. */
+      def value: Double = p
+
+      /** Indicates whether this PosFiniteDouble is finite and has no fraction part. */
+      def isWhole: Boolean = {
+        val longValue = p.toLong
+        longValue.toDouble == p || longValue == Long.MaxValue && p < Double.PositiveInfinity || longValue == Long.MinValue && p > Double.NegativeInfinity
+      }
+
+      /** Rounds this PosFiniteDouble to the nearest whole number as a PosZLong. */
+      def round: PosZLong = PosZLong.ensuringValid(math.round(value))
+
+      /** Returns the smallest PosFiniteDouble that is >= this value and is a mathematical integer. */
+      def ceil: PosFiniteDouble = PosFiniteDouble.ensuringValid(math.ceil(value))
+
+      /** Returns the greatest PosZFiniteDouble that is <= this value and is a mathematical integer. */
+      def floor: PosZFiniteDouble = PosZFiniteDouble.ensuringValid(math.floor(value))
+
+      /** Converts an angle measured in degrees to an approximately equivalent angle measured in radians. */
+      def toRadians: Double = math.toRadians(value)
+
+      /** Returns the larger of this value and other. */
+      def max(other: PosFiniteDouble): PosFiniteDouble =
+        if (p >= other) p else other
+
+      /** Returns the smaller of this value and other. */
+      def min(other: PosFiniteDouble): PosFiniteDouble =
+        if (p <= other) p else other
+
+      /** Returns the negated value as a [[NegFiniteDouble]]. */
+      def unary_- : NegFiniteDouble = NegFiniteDouble.ensuringValid(-p)
+
+      /** Applies the passed Double => Double function and ensures the result is a PosFiniteDouble. */
+      def ensuringValid(f: Double => Double): PosFiniteDouble = {
+        val candidateResult: Double = f(p)
+        if (PosFiniteDouble.isValid(candidateResult)) PosFiniteDouble.ensuringValid(candidateResult)
+        else throw new AssertionError(s"${candidateResult.toString()}, the result of applying the passed function to ${p.toString()}, was not a valid PosFiniteDouble")
+      }
+    }
+
+    /** Validate and return Pass/Fail for PosFiniteDouble constraints. */
+    def passOrElse[E](value: Double)(f: Double => E): Validation[E] =
+      if (isValid(value)) Pass else Fail(f(value))
+
+    /** Validate and return Good/Bad for PosFiniteDouble constraints. */
+    def goodOrElse[B](value: Double)(f: Double => B): PosFiniteDouble Or B =
+      if (isValid(value)) Good(value) else Bad(f(value))
+
+    /** Validate and return Right/Left for PosFiniteDouble constraints. */
+    def rightOrElse[L](value: Double)(f: Double => L): Either[L, PosFiniteDouble] =
+      if (isValid(value)) Right(ensuringValid(value)) else Left(f(value))
+
+    /** The largest finite positive Double value. */
+    val MaxValue: PosFiniteDouble = Double.MaxValue
+
+    /** The smallest finite positive Double value. */
+    val MinValue: PosFiniteDouble = Double.MinPositiveValue
+
+    /** The smallest positive finite Double value. */
+    val MinPositiveValue: PosFiniteDouble = Double.MinPositiveValue
   }
 
   opaque type PosDouble <: PosZDouble = Double

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -2587,6 +2587,78 @@ object Generator {
   //DOTTY-ONLY   }
   //DOTTY-ONLY given given_Generator_opaquetypes_PosDouble: Generator[org.scalactic.opaquetypes.PosDoubles.PosDouble] = opaquetypesPosDoubleGenerator
 
+  //DOTTY-ONLY /* Generator that produces opaquetypes.PosDoubles.PosFiniteDouble independently of anyvals. */
+  //DOTTY-ONLY val opaquetypesPosFiniteDoubleGenerator: Generator[org.scalactic.opaquetypes.PosDoubles.PosFiniteDouble] =
+  //DOTTY-ONLY   new Generator[org.scalactic.opaquetypes.PosDoubles.PosFiniteDouble] {
+  //DOTTY-ONLY
+  //DOTTY-ONLY   import org.scalactic.opaquetypes.PosDoubles.PosFiniteDouble
+  //DOTTY-ONLY
+  //DOTTY-ONLY     case class NextRoseTree(value: PosFiniteDouble, sizeParam: SizeParam, isValidFun: (PosFiniteDouble, SizeParam) => Boolean) extends RoseTree[PosFiniteDouble] {
+  //DOTTY-ONLY       def shrinks: LazyListOrStream[RoseTree[PosFiniteDouble]] = {
+  //DOTTY-ONLY         def resLazyListOrStream(theValue: PosFiniteDouble): LazyListOrStream[RoseTree[PosFiniteDouble]] = {
+  //DOTTY-ONLY           val dv: Double = theValue.value
+  //DOTTY-ONLY           if (dv == 1.0) LazyListOrStream.empty
+  //DOTTY-ONLY           else if (dv < 1.0) {
+  //DOTTY-ONLY             if (isValidFun(PosFiniteDouble.ensuringValid(1.0), sizeParam))
+  //DOTTY-ONLY               Rose(PosFiniteDouble.ensuringValid(1.0)) #:: LazyListOrStream.empty
+  //DOTTY-ONLY             else
+  //DOTTY-ONLY               LazyListOrStream.empty
+  //DOTTY-ONLY           }
+  //DOTTY-ONLY           else {
+  //DOTTY-ONLY             val nearest = PosFiniteDouble.ensuringValid(math.floor(dv))
+  //DOTTY-ONLY             if (isValidFun(nearest, sizeParam)) Rose(nearest) #:: LazyListOrStream.empty
+  //DOTTY-ONLY             else {
+  //DOTTY-ONLY               val sqrt: Double = math.sqrt(dv)
+  //DOTTY-ONLY               val whole = PosFiniteDouble.ensuringValid(math.floor(sqrt))
+  //DOTTY-ONLY               if (isValidFun(whole, sizeParam)) Rose(whole) #:: LazyListOrStream.empty
+  //DOTTY-ONLY               else LazyListOrStream.empty
+  //DOTTY-ONLY             }
+  //DOTTY-ONLY           }
+  //DOTTY-ONLY         }
+  //DOTTY-ONLY         resLazyListOrStream(value)
+  //DOTTY-ONLY       }
+  //DOTTY-ONLY     }
+  //DOTTY-ONLY
+  //DOTTY-ONLY     private val edges: List[PosFiniteDouble] = List(PosFiniteDouble.MinValue, PosFiniteDouble.ensuringValid(1.0), PosFiniteDouble.MaxValue)
+  //DOTTY-ONLY
+  //DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosFiniteDouble], Randomizer) = {
+  //DOTTY-ONLY       val (allEdges, nextRnd) = Randomizer.shuffle(edges, rnd)
+  //DOTTY-ONLY       (allEdges.take(maxLength), nextRnd)
+  //DOTTY-ONLY     }
+  //DOTTY-ONLY
+  //DOTTY-ONLY     override def roseTreeOfEdge(edge: PosFiniteDouble, sizeParam: SizeParam, isValidFun: (PosFiniteDouble, SizeParam) => Boolean): RoseTree[PosFiniteDouble] =
+  //DOTTY-ONLY       NextRoseTree(edge, sizeParam, isValidFun)
+  //DOTTY-ONLY
+  //DOTTY-ONLY     def nextImpl(szp: SizeParam, isValidFun: (PosFiniteDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosFiniteDouble], Randomizer) = {
+  //DOTTY-ONLY       val (anyPosFiniteDouble, rnd2) = rnd.nextPosFiniteDouble
+  //DOTTY-ONLY       val p = PosFiniteDouble.ensuringValid(anyPosFiniteDouble.value)
+  //DOTTY-ONLY       (NextRoseTree(p, szp, isValidFun), rnd2)
+  //DOTTY-ONLY     }
+  //DOTTY-ONLY
+  //DOTTY-ONLY     override def canonicals: LazyListOrStream[RoseTree[PosFiniteDouble]] = {
+  //DOTTY-ONLY       case class CanonicalRoseTree(value: PosFiniteDouble) extends RoseTree[PosFiniteDouble] {
+  //DOTTY-ONLY         def shrinks: LazyListOrStream[RoseTree[PosFiniteDouble]] = {
+  //DOTTY-ONLY           def resLazyListOrStream(theValue: PosFiniteDouble): LazyListOrStream[RoseTree[PosFiniteDouble]] = {
+  //DOTTY-ONLY             if (theValue.value == 1.0) LazyListOrStream.empty
+  //DOTTY-ONLY             else {
+  //DOTTY-ONLY               val minusOne: PosFiniteDouble = PosFiniteDouble.ensuringValid(theValue.value - 1.0)
+  //DOTTY-ONLY               if (minusOne.value == 1.0) Rose(minusOne) #:: LazyListOrStream.empty
+  //DOTTY-ONLY               else Rose(minusOne) #:: resLazyListOrStream(minusOne)
+  //DOTTY-ONLY             }
+  //DOTTY-ONLY           }
+  //DOTTY-ONLY           resLazyListOrStream(value)
+  //DOTTY-ONLY         }
+  //DOTTY-ONLY       }
+  //DOTTY-ONLY       LazyListOrStream(PosFiniteDouble.ensuringValid(1.0)).map(v => CanonicalRoseTree(v))
+  //DOTTY-ONLY     }
+  //DOTTY-ONLY
+  //DOTTY-ONLY     override def toString = "Generator[org.scalactic.opaquetypes.PosDoubles.PosFiniteDouble]"
+  //DOTTY-ONLY
+  //DOTTY-ONLY     override def shrinksForValue(valueToShrink: PosFiniteDouble): Option[LazyListOrStream[RoseTree[PosFiniteDouble]]] =
+  //DOTTY-ONLY       Some(NextRoseTree(valueToShrink, SizeParam(PosZInt.ensuringValid(1), PosZInt.ensuringValid(0), PosZInt.ensuringValid(1)), isValid).shrinks)
+  //DOTTY-ONLY   }
+  //DOTTY-ONLY given given_Generator_opaquetypes_PosFiniteDouble: Generator[org.scalactic.opaquetypes.PosDoubles.PosFiniteDouble] = opaquetypesPosFiniteDoubleGenerator
+
   /**
     * A [[Generator]] that produces positive Doubles, excluding zero and infinity.
     */


### PR DESCRIPTION
- Ported over PosFiniteDoubleSpec.scala from anyvals, then added required code to get tests to pass.