### PR TITLE
Use Scala Native `test-interface-sbt-defs` instead of `test-interface`

### DIFF
--- a/project/DottyBuild.scala
+++ b/project/DottyBuild.scala
@@ -373,7 +373,7 @@ trait DottyBuild { this: BuildCommons =>
                                        |import org.scalactic._
                                        |import Matchers._""".stripMargin,
       libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.4.0",
-      libraryDependencies += ("org.scala-native" %%% "test-interface" % nativeVersion),
+      libraryDependencies += ("org.scala-native" %%% "test-interface-sbt-defs" % nativeVersion),
       packageManagedSources,
       Compile / sourceGenerators += Def.task {
         GenScalaTestDotty.genScalaNative((Compile / sourceManaged).value / "scala", version.value, scalaVersion.value) ++
@@ -1180,7 +1180,7 @@ trait DottyBuild { this: BuildCommons =>
         organization := "org.scalatest",
         moduleName := "scalatest-app",
         //libraryDependencies ++= nativeCrossBuildLibraryDependencies.value,
-        libraryDependencies += ("org.scala-native" %%% "test-interface" % nativeVersion),
+        libraryDependencies += ("org.scala-native" %%% "test-interface-sbt-defs" % nativeVersion),
         // include the scalacticDottyNative classes and resources in the jar
         Compile / packageBin / mappings ++= (scalacticDottyNative / Compile / packageBin / mappings).value,
         // include the scalacticDottyNative sources in the source jar

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -156,7 +156,7 @@ trait NativeBuild { this: BuildCommons =>
         organization := "org.scalatest",
         moduleName := "scalatest-app",
         libraryDependencies ++= nativeCrossBuildLibraryDependencies.value,
-        libraryDependencies += "org.scala-native" %%% "test-interface" % nativeVersion,
+        libraryDependencies += "org.scala-native" %%% "test-interface-sbt-defs" % nativeVersion,
         // include the scalactic classes and resources in the jar
         Compile / packageBin / mappings ++= (scalacticNative / Compile / packageBin / mappings).value,
         // include the scalactic sources in the source jar
@@ -250,7 +250,7 @@ trait NativeBuild { this: BuildCommons =>
       organization := "org.scalatest",
       moduleName := "scalatest-core",
       libraryDependencies ++= nativeCrossBuildLibraryDependencies.value,
-      libraryDependencies += "org.scala-native" %%% "test-interface" % nativeVersion,
+      libraryDependencies += "org.scala-native" %%% "test-interface-sbt-defs" % nativeVersion,
       Compile / sourceGenerators += {
         Def.task {
           GenScalaTestNative.genHtml((Compile / resourceManaged).value, version.value, scalaVersion.value)


### PR DESCRIPTION
See https://github.com/scala-native/scala-native/issues/4844

Testing libraries and frameworks should depend on Scala Native's `test-interface-sbt-defs`, not `test-interface`.
 - `test-interface-sbt-defs` defines a common interface for unit tests. It follows `early-semver` versioning.
 - `test-interface` is a server implementation that must match the version of the Scala Native plugin. It follows `strict` versioning.

This was picked up by SBT [1.12.10](https://eed3si9n.com/sbt-1.12.10), which added eviction checks for test dependencies.

## How to reproduce

Create an SBT project with the following:

```scala
// project/build.properties
sbt.version = 1.12.11
```

```scala
// project/plugins.sbt
addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.11")
```

```scala
// build.sbt
scalaVersion := "3.3.7"
enablePlugins(ScalaNativePlugin)

ThisBuild / evictionWarningOptions := (ThisBuild / evictionWarningOptions).value
  .withConfigurations(List(Compile, Test))

libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.20" % Test
```

The `sbt update` command gives:

```
[error] (update) found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error]
[error] 	* org.scala-native:test-interface_native0.5_3:0.5.11 (strict) is selected over 0.5.10 for test
[error] 	    +- default:scala-native-seed-project_native0.5_3:0.1.0-SNAPSHOT (depends on 0.5.11)
[error] 	    +- org.scalatest:scalatest-core_native0.5_3:3.2.20    (depends on 0.5.10)
```
