### PR TITLE
Convert org.scalatest.prop implicit generator/chooser APIs to Scala 3 given/using

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/prop/Chooser.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Chooser.scala
@@ -63,159 +63,276 @@ object Chooser {
   // The order of the following typeclass instances is arbitrary, but matches the order
   // of the declarations in Randomizer.
 
+  // SKIP-DOTTY-START
   implicit val charChooser: Chooser[Char] = new Chooser[Char] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given charChooser: Chooser[Char] = new Chooser[Char] {
     def choose(from: Char, to: Char)(rnd: Randomizer) = rnd.chooseChar(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val byteChooser: Chooser[Byte] = new Chooser[Byte] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given byteChooser: Chooser[Byte] = new Chooser[Byte] {  
     def choose(from: Byte, to: Byte)(rnd: Randomizer) = rnd.chooseByte(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val shortChooser: Chooser[Short] = new Chooser[Short] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given shortChooser: Chooser[Short] = new Chooser[Short] { 
     def choose(from: Short, to: Short)(rnd: Randomizer) = rnd.chooseShort(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val intChooser: Chooser[Int] = new Chooser[Int] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given intChooser: Chooser[Int] = new Chooser[Int] {  
     def choose(from: Int, to: Int)(rnd: Randomizer) = rnd.chooseInt(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val floatChooser: Chooser[Float] = new Chooser[Float] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given floatChooser: Chooser[Float] = new Chooser[Float] {
     def choose(from: Float, to: Float)(rnd: Randomizer) = rnd.chooseFloat(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val posFloatChooser: Chooser[PosFloat] = new Chooser[PosFloat] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given posFloatChooser: Chooser[PosFloat] = new Chooser[PosFloat] {  
     def choose(from: PosFloat, to: PosFloat)(rnd: Randomizer) = rnd.choosePosFloat(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val posFiniteFloatChooser: Chooser[PosFiniteFloat] = new Chooser[PosFiniteFloat] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given posFiniteFloatChooser: Chooser[PosFiniteFloat] = new Chooser[PosFiniteFloat] {  
     def choose(from: PosFiniteFloat, to: PosFiniteFloat)(rnd: Randomizer) = rnd.choosePosFiniteFloat(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val posZFloatChooser: Chooser[PosZFloat] = new Chooser[PosZFloat] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given posZFloatChooser: Chooser[PosZFloat] = new Chooser[PosZFloat] {  
     def choose(from: PosZFloat, to: PosZFloat)(rnd: Randomizer) = rnd.choosePosZFloat(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val posZFiniteFloatChooser: Chooser[PosZFiniteFloat] = new Chooser[PosZFiniteFloat] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given posZFiniteFloatChooser: Chooser[PosZFiniteFloat] = new Chooser[PosZFiniteFloat] {  
     def choose(from: PosZFiniteFloat, to: PosZFiniteFloat)(rnd: Randomizer) = rnd.choosePosZFiniteFloat(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val doubleChooser: Chooser[Double] = new Chooser[Double] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given doubleChooser: Chooser[Double] = new Chooser[Double] {
     def choose(from: Double, to: Double)(rnd: Randomizer) = rnd.chooseDouble(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val posIntChooser: Chooser[PosInt] = new Chooser[PosInt] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given posIntChooser: Chooser[PosInt] = new Chooser[PosInt] {  
     def choose(from: PosInt, to: PosInt)(rnd: Randomizer) = rnd.choosePosInt(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val posZIntChooser: Chooser[PosZInt] = new Chooser[PosZInt] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given posZIntChooser: Chooser[PosZInt] = new Chooser[PosZInt] {  
     def choose(from: PosZInt, to: PosZInt)(rnd: Randomizer) = rnd.choosePosZInt(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val longChooser: Chooser[Long] = new Chooser[Long] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given longChooser: Chooser[Long] = new Chooser[Long] {  
     def choose(from: Long, to: Long)(rnd: Randomizer) = rnd.chooseLong(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val posLongChooser: Chooser[PosLong] = new Chooser[PosLong] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given posLongChooser: Chooser[PosLong] = new Chooser[PosLong] {  
     def choose(from: PosLong, to: PosLong)(rnd: Randomizer) = rnd.choosePosLong(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val posZLongChooser: Chooser[PosZLong] = new Chooser[PosZLong] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given posZLongChooser: Chooser[PosZLong] = new Chooser[PosZLong] {  
     def choose(from: PosZLong, to: PosZLong)(rnd: Randomizer) = rnd.choosePosZLong(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val posDoubleChooser: Chooser[PosDouble] = new Chooser[PosDouble] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given posDoubleChooser: Chooser[PosDouble] = new Chooser[PosDouble] {  
     def choose(from: PosDouble, to: PosDouble)(rnd: Randomizer) = rnd.choosePosDouble(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val posFiniteDoubleChooser: Chooser[PosFiniteDouble] = new Chooser[PosFiniteDouble] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given posFiniteDoubleChooser: Chooser[PosFiniteDouble] = new Chooser[PosFiniteDouble] {  
     def choose(from: PosFiniteDouble, to: PosFiniteDouble)(rnd: Randomizer) = rnd.choosePosFiniteDouble(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val posZDoubleChooser: Chooser[PosZDouble] = new Chooser[PosZDouble] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given posZDoubleChooser: Chooser[PosZDouble] = new Chooser[PosZDouble] {  
     def choose(from: PosZDouble, to: PosZDouble)(rnd: Randomizer) = rnd.choosePosZDouble(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val posZFiniteDoubleChooser: Chooser[PosZFiniteDouble] = new Chooser[PosZFiniteDouble] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given posZFiniteDoubleChooser: Chooser[PosZFiniteDouble] = new Chooser[PosZFiniteDouble] {  
     def choose(from: PosZFiniteDouble, to: PosZFiniteDouble)(rnd: Randomizer) = rnd.choosePosZFiniteDouble(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val negIntChooser: Chooser[NegInt] = new Chooser[NegInt] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given negIntChooser: Chooser[NegInt] = new Chooser[NegInt] {  
     def choose(from: NegInt, to: NegInt)(rnd: Randomizer) = rnd.chooseNegInt(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val negLongChooser: Chooser[NegLong] = new Chooser[NegLong] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given negLongChooser: Chooser[NegLong] = new Chooser[NegLong] {  
     def choose(from: NegLong, to: NegLong)(rnd: Randomizer) = rnd.chooseNegLong(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val negFloatChooser: Chooser[NegFloat] = new Chooser[NegFloat] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given negFloatChooser: Chooser[NegFloat] = new Chooser[NegFloat] {  
     def choose(from: NegFloat, to: NegFloat)(rnd: Randomizer) = rnd.chooseNegFloat(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val negFiniteFloatChooser: Chooser[NegFiniteFloat] = new Chooser[NegFiniteFloat] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given negFiniteFloatChooser: Chooser[NegFiniteFloat] = new Chooser[NegFiniteFloat] {  
     def choose(from: NegFiniteFloat, to: NegFiniteFloat)(rnd: Randomizer) = rnd.chooseNegFiniteFloat(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val negDoubleChooser: Chooser[NegDouble] = new Chooser[NegDouble] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given negDoubleChooser: Chooser[NegDouble] = new Chooser[NegDouble] {  
     def choose(from: NegDouble, to: NegDouble)(rnd: Randomizer) = rnd.chooseNegDouble(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val negFiniteDoubleChooser: Chooser[NegFiniteDouble] = new Chooser[NegFiniteDouble] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given negFiniteDoubleChooser: Chooser[NegFiniteDouble] = new Chooser[NegFiniteDouble] {  
     def choose(from: NegFiniteDouble, to: NegFiniteDouble)(rnd: Randomizer) = rnd.chooseNegFiniteDouble(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val negZIntChooser: Chooser[NegZInt] = new Chooser[NegZInt] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given negZIntChooser: Chooser[NegZInt] = new Chooser[NegZInt] {  
     def choose(from: NegZInt, to: NegZInt)(rnd: Randomizer) = rnd.chooseNegZInt(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val negZLongChooser: Chooser[NegZLong] = new Chooser[NegZLong] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given negZLongChooser: Chooser[NegZLong] = new Chooser[NegZLong] {  
     def choose(from: NegZLong, to: NegZLong)(rnd: Randomizer) = rnd.chooseNegZLong(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val negZFloatChooser: Chooser[NegZFloat] = new Chooser[NegZFloat] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given negZFloatChooser: Chooser[NegZFloat] = new Chooser[NegZFloat] {  
     def choose(from: NegZFloat, to: NegZFloat)(rnd: Randomizer) = rnd.chooseNegZFloat(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val negZFiniteFloatChooser: Chooser[NegZFiniteFloat] = new Chooser[NegZFiniteFloat] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given negZFiniteFloatChooser: Chooser[NegZFiniteFloat] = new Chooser[NegZFiniteFloat] {  
     def choose(from: NegZFiniteFloat, to: NegZFiniteFloat)(rnd: Randomizer) = rnd.chooseNegZFiniteFloat(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val negZDoubleChooser: Chooser[NegZDouble] = new Chooser[NegZDouble] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given negZDoubleChooser: Chooser[NegZDouble] = new Chooser[NegZDouble] {  
     def choose(from: NegZDouble, to: NegZDouble)(rnd: Randomizer) = rnd.chooseNegZDouble(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val negZFiniteDoubleChooser: Chooser[NegZFiniteDouble] = new Chooser[NegZFiniteDouble] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given negZFiniteDoubleChooser: Chooser[NegZFiniteDouble] = new Chooser[NegZFiniteDouble] {  
     def choose(from: NegZFiniteDouble, to: NegZFiniteDouble)(rnd: Randomizer) = rnd.chooseNegZFiniteDouble(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val nonZeroIntChooser: Chooser[NonZeroInt] = new Chooser[NonZeroInt] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given nonZeroIntChooser: Chooser[NonZeroInt] = new Chooser[NonZeroInt] {  
     def choose(from: NonZeroInt, to: NonZeroInt)(rnd: Randomizer) = rnd.chooseNonZeroInt(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val nonZeroLongChooser: Chooser[NonZeroLong] = new Chooser[NonZeroLong] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given nonZeroLongChooser: Chooser[NonZeroLong] = new Chooser[NonZeroLong] {  
     def choose(from: NonZeroLong, to: NonZeroLong)(rnd: Randomizer) = rnd.chooseNonZeroLong(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val nonZeroFloatChooser: Chooser[NonZeroFloat] = new Chooser[NonZeroFloat] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given nonZeroFloatChooser: Chooser[NonZeroFloat] = new Chooser[NonZeroFloat] {  
     def choose(from: NonZeroFloat, to: NonZeroFloat)(rnd: Randomizer) = rnd.chooseNonZeroFloat(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val nonZeroFiniteFloatChooser: Chooser[NonZeroFiniteFloat] = new Chooser[NonZeroFiniteFloat] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given nonZeroFiniteFloatChooser: Chooser[NonZeroFiniteFloat] = new Chooser[NonZeroFiniteFloat] {  
     def choose(from: NonZeroFiniteFloat, to: NonZeroFiniteFloat)(rnd: Randomizer) = rnd.chooseNonZeroFiniteFloat(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val nonZeroDoubleChooser: Chooser[NonZeroDouble] = new Chooser[NonZeroDouble] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given nonZeroDoubleChooser: Chooser[NonZeroDouble] = new Chooser[NonZeroDouble] {  
     def choose(from: NonZeroDouble, to: NonZeroDouble)(rnd: Randomizer) = rnd.chooseNonZeroDouble(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val nonZeroFiniteDoubleChooser: Chooser[NonZeroFiniteDouble] = new Chooser[NonZeroFiniteDouble] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given nonZeroFiniteDoubleChooser: Chooser[NonZeroFiniteDouble] = new Chooser[NonZeroFiniteDouble] {  
     def choose(from: NonZeroFiniteDouble, to: NonZeroFiniteDouble)(rnd: Randomizer) = rnd.chooseNonZeroFiniteDouble(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val finiteFloatChooser: Chooser[FiniteFloat] = new Chooser[FiniteFloat] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given finiteFloatChooser: Chooser[FiniteFloat] = new Chooser[FiniteFloat] {  
     def choose(from: FiniteFloat, to: FiniteFloat)(rnd: Randomizer) = rnd.chooseFiniteFloat(from, to)
   }
 
+  // SKIP-DOTTY-START
   implicit val finiteDoubleChooser: Chooser[FiniteDouble] = new Chooser[FiniteDouble] {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY given finiteDoubleChooser: Chooser[FiniteDouble] = new Chooser[FiniteDouble] {  
     def choose(from: FiniteDouble, to: FiniteDouble)(rnd: Randomizer) = rnd.chooseFiniteDouble(from, to)
   }
 

--- a/jvm/core/src/main/scala/org/scalatest/prop/Chooser.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Chooser.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2001-2025 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.scalatest.prop
 
 import org.scalactic.anyvals._
@@ -63,6 +78,12 @@ object Chooser {
   // The order of the following typeclass instances is arbitrary, but matches the order
   // of the declarations in Randomizer.
 
+  /**
+    * A Chooser instance for Char values.
+    *
+    * This Chooser allows you to pick a random Char value within a specified inclusive range.
+    * The result is a Char between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val charChooser: Chooser[Char] = new Chooser[Char] {
   // SKIP-DOTTY-END
@@ -70,6 +91,12 @@ object Chooser {
     def choose(from: Char, to: Char)(rnd: Randomizer) = rnd.chooseChar(from, to)
   }
 
+  /**
+    * A Chooser instance for Byte values.
+    *
+    * This Chooser allows you to pick a random Byte value within a specified inclusive range.
+    * The result is a Byte between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val byteChooser: Chooser[Byte] = new Chooser[Byte] {
   // SKIP-DOTTY-END
@@ -77,6 +104,12 @@ object Chooser {
     def choose(from: Byte, to: Byte)(rnd: Randomizer) = rnd.chooseByte(from, to)
   }
 
+  /**
+    * A Chooser instance for Short values.
+    *
+    * This Chooser allows you to pick a random Short value within a specified inclusive range.
+    * The result is a Short between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val shortChooser: Chooser[Short] = new Chooser[Short] {
   // SKIP-DOTTY-END
@@ -84,6 +117,12 @@ object Chooser {
     def choose(from: Short, to: Short)(rnd: Randomizer) = rnd.chooseShort(from, to)
   }
 
+  /**
+    * A Chooser instance for Int values.
+    *
+    * This Chooser allows you to pick a random Int value within a specified inclusive range.
+    * The result is an Int between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val intChooser: Chooser[Int] = new Chooser[Int] {
   // SKIP-DOTTY-END
@@ -91,6 +130,12 @@ object Chooser {
     def choose(from: Int, to: Int)(rnd: Randomizer) = rnd.chooseInt(from, to)
   }
 
+  /**
+    * A Chooser instance for Float values.
+    *
+    * This Chooser allows you to pick a random Float value within a specified inclusive range.
+    * The result is a Float between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val floatChooser: Chooser[Float] = new Chooser[Float] {
   // SKIP-DOTTY-END
@@ -98,6 +143,12 @@ object Chooser {
     def choose(from: Float, to: Float)(rnd: Randomizer) = rnd.chooseFloat(from, to)
   }
 
+  /**
+    * A Chooser instance for PosFloat values.
+    *
+    * This Chooser allows you to pick a random PosFloat value within a specified inclusive range.
+    * The result is a PosFloat (positive Float) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val posFloatChooser: Chooser[PosFloat] = new Chooser[PosFloat] {
   // SKIP-DOTTY-END
@@ -105,6 +156,12 @@ object Chooser {
     def choose(from: PosFloat, to: PosFloat)(rnd: Randomizer) = rnd.choosePosFloat(from, to)
   }
 
+  /**
+    * A Chooser instance for PosFiniteFloat values.
+    *
+    * This Chooser allows you to pick a random PosFiniteFloat value within a specified inclusive range.
+    * The result is a PosFiniteFloat (positive, finite Float) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val posFiniteFloatChooser: Chooser[PosFiniteFloat] = new Chooser[PosFiniteFloat] {
   // SKIP-DOTTY-END
@@ -112,6 +169,12 @@ object Chooser {
     def choose(from: PosFiniteFloat, to: PosFiniteFloat)(rnd: Randomizer) = rnd.choosePosFiniteFloat(from, to)
   }
 
+  /**
+    * A Chooser instance for PosZFloat values.
+    *
+    * This Chooser allows you to pick a random PosZFloat value within a specified inclusive range.
+    * The result is a PosZFloat (non-negative Float) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val posZFloatChooser: Chooser[PosZFloat] = new Chooser[PosZFloat] {
   // SKIP-DOTTY-END
@@ -119,6 +182,12 @@ object Chooser {
     def choose(from: PosZFloat, to: PosZFloat)(rnd: Randomizer) = rnd.choosePosZFloat(from, to)
   }
 
+  /**
+    * A Chooser instance for PosZFiniteFloat values.
+    *
+    * This Chooser allows you to pick a random PosZFiniteFloat value within a specified inclusive range.
+    * The result is a PosZFiniteFloat (non-negative, finite Float) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val posZFiniteFloatChooser: Chooser[PosZFiniteFloat] = new Chooser[PosZFiniteFloat] {
   // SKIP-DOTTY-END
@@ -126,6 +195,12 @@ object Chooser {
     def choose(from: PosZFiniteFloat, to: PosZFiniteFloat)(rnd: Randomizer) = rnd.choosePosZFiniteFloat(from, to)
   }
 
+  /**
+    * A Chooser instance for Double values.
+    *
+    * This Chooser allows you to pick a random Double value within a specified inclusive range.
+    * The result is a Double between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val doubleChooser: Chooser[Double] = new Chooser[Double] {
   // SKIP-DOTTY-END
@@ -133,6 +208,12 @@ object Chooser {
     def choose(from: Double, to: Double)(rnd: Randomizer) = rnd.chooseDouble(from, to)
   }
 
+  /**
+    * A Chooser instance for PosInt values.
+    *
+    * This Chooser allows you to pick a random PosInt value within a specified inclusive range.
+    * The result is a PosInt (positive Int) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val posIntChooser: Chooser[PosInt] = new Chooser[PosInt] {
   // SKIP-DOTTY-END
@@ -140,6 +221,12 @@ object Chooser {
     def choose(from: PosInt, to: PosInt)(rnd: Randomizer) = rnd.choosePosInt(from, to)
   }
 
+  /**
+    * A Chooser instance for PosZInt values.
+    *
+    * This Chooser allows you to pick a random PosZInt value within a specified inclusive range.
+    * The result is a PosZInt (non-negative Int) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val posZIntChooser: Chooser[PosZInt] = new Chooser[PosZInt] {
   // SKIP-DOTTY-END
@@ -147,6 +234,12 @@ object Chooser {
     def choose(from: PosZInt, to: PosZInt)(rnd: Randomizer) = rnd.choosePosZInt(from, to)
   }
 
+  /**
+    * A Chooser instance for Long values.
+    *
+    * This Chooser allows you to pick a random Long value within a specified inclusive range.
+    * The result is a Long between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val longChooser: Chooser[Long] = new Chooser[Long] {
   // SKIP-DOTTY-END
@@ -154,6 +247,12 @@ object Chooser {
     def choose(from: Long, to: Long)(rnd: Randomizer) = rnd.chooseLong(from, to)
   }
 
+  /**
+    * A Chooser instance for PosLong values.
+    *
+    * This Chooser allows you to pick a random PosLong value within a specified inclusive range.
+    * The result is a PosLong (positive Long) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val posLongChooser: Chooser[PosLong] = new Chooser[PosLong] {
   // SKIP-DOTTY-END
@@ -161,6 +260,12 @@ object Chooser {
     def choose(from: PosLong, to: PosLong)(rnd: Randomizer) = rnd.choosePosLong(from, to)
   }
 
+  /**
+    * A Chooser instance for PosZLong values.
+    *
+    * This Chooser allows you to pick a random PosZLong value within a specified inclusive range.
+    * The result is a PosZLong (non-negative Long) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val posZLongChooser: Chooser[PosZLong] = new Chooser[PosZLong] {
   // SKIP-DOTTY-END
@@ -168,6 +273,12 @@ object Chooser {
     def choose(from: PosZLong, to: PosZLong)(rnd: Randomizer) = rnd.choosePosZLong(from, to)
   }
 
+  /**
+    * A Chooser instance for PosDouble values.
+    *
+    * This Chooser allows you to pick a random PosDouble value within a specified inclusive range.
+    * The result is a PosDouble (positive Double) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val posDoubleChooser: Chooser[PosDouble] = new Chooser[PosDouble] {
   // SKIP-DOTTY-END
@@ -175,6 +286,12 @@ object Chooser {
     def choose(from: PosDouble, to: PosDouble)(rnd: Randomizer) = rnd.choosePosDouble(from, to)
   }
 
+  /**
+    * A Chooser instance for PosFiniteDouble values.
+    *
+    * This Chooser allows you to pick a random PosFiniteDouble value within a specified inclusive range.
+    * The result is a PosFiniteDouble (positive, finite Double) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val posFiniteDoubleChooser: Chooser[PosFiniteDouble] = new Chooser[PosFiniteDouble] {
   // SKIP-DOTTY-END
@@ -182,6 +299,12 @@ object Chooser {
     def choose(from: PosFiniteDouble, to: PosFiniteDouble)(rnd: Randomizer) = rnd.choosePosFiniteDouble(from, to)
   }
 
+  /**
+    * A Chooser instance for PosZDouble values.
+    *
+    * This Chooser allows you to pick a random PosZDouble value within a specified inclusive range.
+    * The result is a PosZDouble (non-negative Double) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val posZDoubleChooser: Chooser[PosZDouble] = new Chooser[PosZDouble] {
   // SKIP-DOTTY-END
@@ -189,6 +312,12 @@ object Chooser {
     def choose(from: PosZDouble, to: PosZDouble)(rnd: Randomizer) = rnd.choosePosZDouble(from, to)
   }
 
+  /**
+    * A Chooser instance for PosZFiniteDouble values.
+    *
+    * This Chooser allows you to pick a random PosZFiniteDouble value within a specified inclusive range.
+    * The result is a PosZFiniteDouble (non-negative, finite Double) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val posZFiniteDoubleChooser: Chooser[PosZFiniteDouble] = new Chooser[PosZFiniteDouble] {
   // SKIP-DOTTY-END
@@ -196,6 +325,12 @@ object Chooser {
     def choose(from: PosZFiniteDouble, to: PosZFiniteDouble)(rnd: Randomizer) = rnd.choosePosZFiniteDouble(from, to)
   }
 
+  /**
+    * A Chooser instance for NegInt values.
+    *
+    * This Chooser allows you to pick a random NegInt value within a specified inclusive range.
+    * The result is a NegInt (negative Int) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val negIntChooser: Chooser[NegInt] = new Chooser[NegInt] {
   // SKIP-DOTTY-END
@@ -203,6 +338,12 @@ object Chooser {
     def choose(from: NegInt, to: NegInt)(rnd: Randomizer) = rnd.chooseNegInt(from, to)
   }
 
+  /**
+    * A Chooser instance for NegLong values.
+    *
+    * This Chooser allows you to pick a random NegLong value within a specified inclusive range.
+    * The result is a NegLong (negative Long) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val negLongChooser: Chooser[NegLong] = new Chooser[NegLong] {
   // SKIP-DOTTY-END
@@ -210,6 +351,12 @@ object Chooser {
     def choose(from: NegLong, to: NegLong)(rnd: Randomizer) = rnd.chooseNegLong(from, to)
   }
 
+  /**
+    * A Chooser instance for NegFloat values.
+    *
+    * This Chooser allows you to pick a random NegFloat value within a specified inclusive range.
+    * The result is a NegFloat (negative Float) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val negFloatChooser: Chooser[NegFloat] = new Chooser[NegFloat] {
   // SKIP-DOTTY-END
@@ -217,6 +364,12 @@ object Chooser {
     def choose(from: NegFloat, to: NegFloat)(rnd: Randomizer) = rnd.chooseNegFloat(from, to)
   }
 
+  /**
+    * A Chooser instance for NegFiniteFloat values.
+    *
+    * This Chooser allows you to pick a random NegFiniteFloat value within a specified inclusive range.
+    * The result is a NegFiniteFloat (negative, finite Float) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val negFiniteFloatChooser: Chooser[NegFiniteFloat] = new Chooser[NegFiniteFloat] {
   // SKIP-DOTTY-END
@@ -224,6 +377,12 @@ object Chooser {
     def choose(from: NegFiniteFloat, to: NegFiniteFloat)(rnd: Randomizer) = rnd.chooseNegFiniteFloat(from, to)
   }
 
+  /**
+    * A Chooser instance for NegDouble values.
+    *
+    * This Chooser allows you to pick a random NegDouble value within a specified inclusive range.
+    * The result is a NegDouble (negative Double) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val negDoubleChooser: Chooser[NegDouble] = new Chooser[NegDouble] {
   // SKIP-DOTTY-END
@@ -231,6 +390,12 @@ object Chooser {
     def choose(from: NegDouble, to: NegDouble)(rnd: Randomizer) = rnd.chooseNegDouble(from, to)
   }
 
+  /**
+    * A Chooser instance for NegFiniteDouble values.
+    *
+    * This Chooser allows you to pick a random NegFiniteDouble value within a specified inclusive range.
+    * The result is a NegFiniteDouble (negative, finite Double) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val negFiniteDoubleChooser: Chooser[NegFiniteDouble] = new Chooser[NegFiniteDouble] {
   // SKIP-DOTTY-END
@@ -238,6 +403,12 @@ object Chooser {
     def choose(from: NegFiniteDouble, to: NegFiniteDouble)(rnd: Randomizer) = rnd.chooseNegFiniteDouble(from, to)
   }
 
+  /**
+    * A Chooser instance for NegZInt values.
+    *
+    * This Chooser allows you to pick a random NegZInt value within a specified inclusive range.
+    * The result is a NegZInt (non-positive Int) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val negZIntChooser: Chooser[NegZInt] = new Chooser[NegZInt] {
   // SKIP-DOTTY-END
@@ -245,6 +416,12 @@ object Chooser {
     def choose(from: NegZInt, to: NegZInt)(rnd: Randomizer) = rnd.chooseNegZInt(from, to)
   }
 
+  /**
+    * A Chooser instance for NegZLong values.
+    *
+    * This Chooser allows you to pick a random NegZLong value within a specified inclusive range.
+    * The result is a NegZLong (non-positive Long) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val negZLongChooser: Chooser[NegZLong] = new Chooser[NegZLong] {
   // SKIP-DOTTY-END
@@ -252,6 +429,12 @@ object Chooser {
     def choose(from: NegZLong, to: NegZLong)(rnd: Randomizer) = rnd.chooseNegZLong(from, to)
   }
 
+  /**
+    * A Chooser instance for NegZFloat values.
+    *
+    * This Chooser allows you to pick a random NegZFloat value within a specified inclusive range.
+    * The result is a NegZFloat (non-positive Float) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val negZFloatChooser: Chooser[NegZFloat] = new Chooser[NegZFloat] {
   // SKIP-DOTTY-END
@@ -259,6 +442,12 @@ object Chooser {
     def choose(from: NegZFloat, to: NegZFloat)(rnd: Randomizer) = rnd.chooseNegZFloat(from, to)
   }
 
+  /**
+    * A Chooser instance for NegZFiniteFloat values.
+    *
+    * This Chooser allows you to pick a random NegZFiniteFloat value within a specified inclusive range.
+    * The result is a NegZFiniteFloat (non-positive, finite Float) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val negZFiniteFloatChooser: Chooser[NegZFiniteFloat] = new Chooser[NegZFiniteFloat] {
   // SKIP-DOTTY-END
@@ -266,6 +455,12 @@ object Chooser {
     def choose(from: NegZFiniteFloat, to: NegZFiniteFloat)(rnd: Randomizer) = rnd.chooseNegZFiniteFloat(from, to)
   }
 
+  /**
+    * A Chooser instance for NegZDouble values.
+    *
+    * This Chooser allows you to pick a random NegZDouble value within a specified inclusive range.
+    * The result is a NegZDouble (non-positive Double) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val negZDoubleChooser: Chooser[NegZDouble] = new Chooser[NegZDouble] {
   // SKIP-DOTTY-END
@@ -273,6 +468,12 @@ object Chooser {
     def choose(from: NegZDouble, to: NegZDouble)(rnd: Randomizer) = rnd.chooseNegZDouble(from, to)
   }
 
+  /**
+    * A Chooser instance for NegZFiniteDouble values.
+    *
+    * This Chooser allows you to pick a random NegZFiniteDouble value within a specified inclusive range.
+    * The result is a NegZFiniteDouble (non-positive, finite Double) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val negZFiniteDoubleChooser: Chooser[NegZFiniteDouble] = new Chooser[NegZFiniteDouble] {
   // SKIP-DOTTY-END
@@ -280,6 +481,12 @@ object Chooser {
     def choose(from: NegZFiniteDouble, to: NegZFiniteDouble)(rnd: Randomizer) = rnd.chooseNegZFiniteDouble(from, to)
   }
 
+  /**
+    * A Chooser instance for NonZeroInt values.
+    *
+    * This Chooser allows you to pick a random NonZeroInt value within a specified inclusive range.
+    * The result is a NonZeroInt (non-zero Int) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val nonZeroIntChooser: Chooser[NonZeroInt] = new Chooser[NonZeroInt] {
   // SKIP-DOTTY-END
@@ -287,6 +494,12 @@ object Chooser {
     def choose(from: NonZeroInt, to: NonZeroInt)(rnd: Randomizer) = rnd.chooseNonZeroInt(from, to)
   }
 
+  /**
+    * A Chooser instance for NonZeroLong values.
+    *
+    * This Chooser allows you to pick a random NonZeroLong value within a specified inclusive range.
+    * The result is a NonZeroLong (non-zero Long) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val nonZeroLongChooser: Chooser[NonZeroLong] = new Chooser[NonZeroLong] {
   // SKIP-DOTTY-END
@@ -294,6 +507,12 @@ object Chooser {
     def choose(from: NonZeroLong, to: NonZeroLong)(rnd: Randomizer) = rnd.chooseNonZeroLong(from, to)
   }
 
+  /**
+    * A Chooser instance for NonZeroFloat values.
+    *
+    * This Chooser allows you to pick a random NonZeroFloat value within a specified inclusive range.
+    * The result is a NonZeroFloat (non-zero Float) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val nonZeroFloatChooser: Chooser[NonZeroFloat] = new Chooser[NonZeroFloat] {
   // SKIP-DOTTY-END
@@ -301,6 +520,12 @@ object Chooser {
     def choose(from: NonZeroFloat, to: NonZeroFloat)(rnd: Randomizer) = rnd.chooseNonZeroFloat(from, to)
   }
 
+  /**
+    * A Chooser instance for NonZeroFiniteFloat values.
+    *
+    * This Chooser allows you to pick a random NonZeroFiniteFloat value within a specified inclusive range.
+    * The result is a NonZeroFiniteFloat (non-zero, finite Float) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val nonZeroFiniteFloatChooser: Chooser[NonZeroFiniteFloat] = new Chooser[NonZeroFiniteFloat] {
   // SKIP-DOTTY-END
@@ -308,6 +533,12 @@ object Chooser {
     def choose(from: NonZeroFiniteFloat, to: NonZeroFiniteFloat)(rnd: Randomizer) = rnd.chooseNonZeroFiniteFloat(from, to)
   }
 
+  /**
+    * A Chooser instance for NonZeroDouble values.
+    *
+    * This Chooser allows you to pick a random NonZeroDouble value within a specified inclusive range.
+    * The result is a NonZeroDouble (non-zero Double) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val nonZeroDoubleChooser: Chooser[NonZeroDouble] = new Chooser[NonZeroDouble] {
   // SKIP-DOTTY-END
@@ -315,6 +546,12 @@ object Chooser {
     def choose(from: NonZeroDouble, to: NonZeroDouble)(rnd: Randomizer) = rnd.chooseNonZeroDouble(from, to)
   }
 
+  /**
+    * A Chooser instance for NonZeroFiniteDouble values.
+    *
+    * This Chooser allows you to pick a random NonZeroFiniteDouble value within a specified inclusive range.
+    * The result is a NonZeroFiniteDouble (non-zero, finite Double) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val nonZeroFiniteDoubleChooser: Chooser[NonZeroFiniteDouble] = new Chooser[NonZeroFiniteDouble] {
   // SKIP-DOTTY-END
@@ -322,6 +559,12 @@ object Chooser {
     def choose(from: NonZeroFiniteDouble, to: NonZeroFiniteDouble)(rnd: Randomizer) = rnd.chooseNonZeroFiniteDouble(from, to)
   }
 
+  /**
+    * A Chooser instance for FiniteFloat values.
+    *
+    * This Chooser allows you to pick a random FiniteFloat value within a specified inclusive range.
+    * The result is a FiniteFloat (finite Float, not infinite or NaN) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val finiteFloatChooser: Chooser[FiniteFloat] = new Chooser[FiniteFloat] {
   // SKIP-DOTTY-END
@@ -329,6 +572,12 @@ object Chooser {
     def choose(from: FiniteFloat, to: FiniteFloat)(rnd: Randomizer) = rnd.chooseFiniteFloat(from, to)
   }
 
+  /**
+    * A Chooser instance for FiniteDouble values.
+    *
+    * This Chooser allows you to pick a random FiniteDouble value within a specified inclusive range.
+    * The result is a FiniteDouble (finite Double, not infinite or NaN) between the `from` and `to` endpoints.
+    */
   // SKIP-DOTTY-START
   implicit val finiteDoubleChooser: Chooser[FiniteDouble] = new Chooser[FiniteDouble] {
   // SKIP-DOTTY-END

--- a/jvm/core/src/main/scala/org/scalatest/prop/CommonGenerators.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/CommonGenerators.scala
@@ -139,7 +139,10 @@ trait CommonGenerators {
     *
     * @group Betweeners
     */
+  // SKIP-DOTTY-START  
   def between[T](from: T, to: T)(implicit ord: Ordering[T], chooser: Chooser[T], gen: Generator[T]): Generator[T] = {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def between[T](from: T, to: T)(using ord: Ordering[T], chooser: Chooser[T], gen: Generator[T]): Generator[T] = {
     import ord.mkOrderingOps
     require(from <= to)
     new Generator[T] {
@@ -1551,71 +1554,102 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple2s[A, B](implicit genOfA: Generator[A], genOfB: Generator[B]): Generator[(A, B)] = Generator.tuple2Generator[A, B]
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple2s[A, B](using genOfA: Generator[A], genOfB: Generator[B]): Generator[(A, B)] = Generator.tuple2Generator[A, B]
 
   /**
     * See [[tuple2s]] for information on tuple generators.
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple3s[A, B, C](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C]): Generator[(A, B, C)] = Generator.tuple3Generator[A, B, C]
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple3s[A, B, C](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C]): Generator[(A, B, C)] = Generator.tuple3Generator[A, B, C]
 
   /**
     * See [[tuple2s]] for information on tuple generators.
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple4s[A, B, C, D](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D]): Generator[(A, B, C, D)] = Generator.tuple4Generator[A, B, C, D]
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple4s[A, B, C, D](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D]): Generator[(A, B, C, D)] = Generator.tuple4Generator[A, B, C, D]
 
   /**
     * See [[tuple2s]] for information on tuple generators.
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple5s[A, B, C, D, E](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E]): Generator[(A, B, C, D, E)] = Generator.tuple5Generator[A, B, C, D, E]
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple5s[A, B, C, D, E](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E]): Generator[(A, B, C, D, E)] = Generator.tuple5Generator[A, B, C, D, E]
 
   /**
     * See [[tuple2s]] for information on tuple generators.
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START
   def tuple6s[A, B, C, D, E, F](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F]): Generator[(A, B, C, D, E, F)] = Generator.tuple6Generator[A, B, C, D, E, F]
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple6s[A, B, C, D, E, F](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F]): Generator[(A, B, C, D, E, F)] = Generator.tuple6Generator[A, B, C, D, E, F]
 
   /**
     * See [[tuple2s]] for information on tuple generators.
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple7s[A, B, C, D, E, F, G](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G]): Generator[(A, B, C, D, E, F, G)] = Generator.tuple7Generator[A, B, C, D, E, F, G]
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple7s[A, B, C, D, E, F, G](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G]): Generator[(A, B, C, D, E, F, G)] = Generator.tuple7Generator[A, B, C, D, E, F, G]
 
   /**
     * See [[tuple2s]] for information on tuple generators.
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple8s[A, B, C, D, E, F, G, H](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H]): Generator[(A, B, C, D, E, F, G, H)] = Generator.tuple8Generator[A, B, C, D, E, F, G, H]
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple8s[A, B, C, D, E, F, G, H](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H]): Generator[(A, B, C, D, E, F, G, H)] = Generator.tuple8Generator[A, B, C, D, E, F, G, H]
 
   /**
     * See [[tuple2s]] for information on tuple generators.
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple9s[A, B, C, D, E, F, G, H, I](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I]): Generator[(A, B, C, D, E, F, G, H, I)] = Generator.tuple9Generator[A, B, C, D, E, F, G, H, I]
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple9s[A, B, C, D, E, F, G, H, I](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I]): Generator[(A, B, C, D, E, F, G, H, I)] = Generator.tuple9Generator[A, B, C, D, E, F, G, H, I]
 
   /**
     * See [[tuple2s]] for information on tuple generators.
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple10s[A, B, C, D, E, F, G, H, I, J](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple10s[A, B, C, D, E, F, G, H, I, J](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                              genOfJ: Generator[J]): Generator[(A, B, C, D, E, F, G, H, I, J)] = Generator.tuple10Generator[A, B, C, D, E, F, G, H, I, J]
+  
 
   /**
     * See [[tuple2s]] for information on tuple generators.
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START
   def tuple11s[A, B, C, D, E, F, G, H, I, J, K](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple11s[A, B, C, D, E, F, G, H, I, J, K](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                                 genOfJ: Generator[J], genOfK: Generator[K]): Generator[(A, B, C, D, E, F, G, H, I, J, K)] = Generator.tuple11Generator[A, B, C, D, E, F, G, H, I, J, K]
 
   /**
@@ -1623,7 +1657,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple12s[A, B, C, D, E, F, G, H, I, J, K, L](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple12s[A, B, C, D, E, F, G, H, I, J, K, L](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                                    genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L)] = Generator.tuple12Generator[A, B, C, D, E, F, G, H, I, J, K, L]
 
   /**
@@ -1631,7 +1668,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple13s[A, B, C, D, E, F, G, H, I, J, K, L, M](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple13s[A, B, C, D, E, F, G, H, I, J, K, L, M](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                                       genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M)] = Generator.tuple13Generator[A, B, C, D, E, F, G, H, I, J, K, L, M]
 
   /**
@@ -1639,7 +1679,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple14s[A, B, C, D, E, F, G, H, I, J, K, L, M, N](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple14s[A, B, C, D, E, F, G, H, I, J, K, L, M, N](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                                          genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N)] = Generator.tuple14Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N]
 
   /**
@@ -1647,7 +1690,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple15s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple15s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                                             genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] = Generator.tuple15Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
 
   /**
@@ -1655,7 +1701,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple16s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple16s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                                                genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] = Generator.tuple16Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]
 
   /**
@@ -1663,7 +1712,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple17s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple17s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                                                   genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] = Generator.tuple17Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]
 
   /**
@@ -1671,7 +1723,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple18s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple18s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                                                      genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] = Generator.tuple18Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]
 
   /**
@@ -1679,7 +1734,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple19s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple19s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                                                         genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] = Generator.tuple19Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]
 
   /**
@@ -1687,7 +1745,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple20s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple20s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                                                            genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S],
                                                                            genOfT: Generator[T]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] = Generator.tuple20Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]
 
@@ -1696,7 +1757,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple21s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple21s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                                                               genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S],
                                                                               genOfT: Generator[T], genOfU: Generator[U]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] = Generator.tuple21Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]
 
@@ -1705,7 +1769,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def tuple22s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def tuple22s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F], genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I],
                                                                                  genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M], genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S],
                                                                                  genOfT: Generator[T], genOfU: Generator[U], genOfV: Generator[V]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] = Generator.tuple22Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]
 
@@ -1725,7 +1792,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def vectors[T](implicit genOfT: Generator[T]): Generator[Vector[T]] with HavingLength[Vector[T]] = Generator.vectorGenerator
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def vectors[T](using genOfT: Generator[T]): Generator[Vector[T]] with HavingLength[Vector[T]] = Generator.vectorGenerator
 
   /**
     * Given a `Generator[T]`, this creates a `Generator[Option[T]]`.
@@ -1736,7 +1806,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def options[T](implicit genOfT: Generator[T]): Generator[Option[T]] = Generator.optionGenerator
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def options[T](using genOfT: Generator[T]): Generator[Option[T]] = Generator.optionGenerator
 
   /**
     * Given [[Generator]]s for two types, [[G]] and [[B]], this creates a [[Generator]] for `G Or B`.
@@ -1747,7 +1820,10 @@ trait CommonGenerators {
     * @tparam B the "bad" type for an [[Or]]
     * @return a [[Generator]] that produces `G Or B`
     */
+  // SKIP-DOTTY-START  
   def ors[G, B](implicit genOfG: Generator[G], genOfB: Generator[B]): Generator[G Or B] = Generator.orGenerator
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def ors[G, B](using genOfG: Generator[G], genOfB: Generator[B]): Generator[G Or B] = Generator.orGenerator
 
   /**
     * Given [[Generator]]s for two types, [[L]] and [[R]], this creates a [[Generator]] for `Either[L, R]`.
@@ -1758,7 +1834,10 @@ trait CommonGenerators {
     * @tparam R the Right type for an [[Either]]
     * @return a [[Generator]] that produces `Either[L, R]`
     */
+  // SKIP-DOTTY-START  
   def eithers[L, R](implicit genOfL: Generator[L], genOfR: Generator[R]): Generator[Either[L, R]] = Generator.eitherGenerator
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def eithers[L, R](using genOfL: Generator[L], genOfR: Generator[R]): Generator[Either[L, R]] = Generator.eitherGenerator
 
   /**
     * Given an existing `Generator[T]`, this creates a `Generator[List[T]]`.
@@ -1769,7 +1848,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def lists[T](implicit genOfT: Generator[T]): Generator[List[T]] with HavingLength[List[T]] = Generator.listGenerator[T]
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def lists[T](using genOfT: Generator[T]): Generator[List[T]] with HavingLength[List[T]] = Generator.listGenerator[T] 
 
   /**
     * Given a [[Generator]] that produces values of type [[T]], this creates one for a [[Set]] of [[T]].
@@ -1787,7 +1869,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def sets[T](implicit genOfT: Generator[T]): Generator[Set[T]] with HavingSize[Set[T]] = Generator.setGenerator
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sets[T](using genOfT: Generator[T]): Generator[Set[T]] with HavingSize[Set[T]] = Generator.setGenerator
 
   /**
     * Given a [[Generator]] that produces values of type [[T]], this creates one for a [[SortedSet]] of [[T]].
@@ -1805,7 +1890,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def sortedSets[T](implicit genOfT: Generator[T], ordering: Ordering[T]): Generator[SortedSet[T]] with HavingSize[SortedSet[T]] = Generator.sortedSetGenerator
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sortedSets[T](using genOfT: Generator[T], ordering: Ordering[T]): Generator[SortedSet[T]] with HavingSize[SortedSet[T]] = Generator.sortedSetGenerator
 
   /**
     * Given a [[Generator]] that produces Tuples of key/value pairs, this gives you one that produces [[Map]]s
@@ -1825,7 +1913,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def maps[K, V](implicit genOfTupleKV: Generator[(K, V)]): Generator[Map[K, V]] with HavingSize[Map[K, V]] = Generator.mapGenerator
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def maps[K, V](using genOfTupleKV: Generator[(K, V)]): Generator[Map[K, V]] with HavingSize[Map[K, V]] = Generator.mapGenerator
 
   /**
     * Given a [[Generator]] that produces Tuples of key/value pairs, this gives you one that produces [[SortedMap]]s
@@ -1845,8 +1936,10 @@ trait CommonGenerators {
     *
     * @group Collections
     */
+  // SKIP-DOTTY-START  
   def sortedMaps[K, V](implicit genOfTupleKV: Generator[(K, V)], ordering: Ordering[K]): Generator[SortedMap[K, V]] with HavingSize[SortedMap[K, V]] = Generator.sortedMapGenerator
-
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def sortedMaps[K, V](using genOfTupleKV: Generator[(K, V)], ordering: Ordering[K]): Generator[SortedMap[K, V]] with HavingSize[SortedMap[K, V]] = Generator.sortedMapGenerator
 
   /**
     * Given a [[Generator]] that produces values of type [[A]], this returns one that produces ''functions'' that return
@@ -1860,7 +1953,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START  
   def function0s[A](implicit genOfA: Generator[A]): Generator[() => A] = Generator.function0Generator[A]
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function0s[A](using genOfA: Generator[A]): Generator[() => A] = Generator.function0Generator[A]
 
   /**
     * Create a [[Generator]] of functions from type [[A]] to type [[B]].
@@ -1897,7 +1993,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START  
   def function1s[A, B](implicit genOfB: Generator[B], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B]): Generator[A => B] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function1s[A, B](using genOfB: Generator[B], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B]): Generator[A => B] =
     Generator.function1Generator[A, B]
 
   /**
@@ -1905,7 +2004,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START  
   def function2s[A, B, C](implicit genOfC: Generator[C], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C]): Generator[(A, B) => C] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function2s[A, B, C](using genOfC: Generator[C], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C]): Generator[(A, B) => C] =
     Generator.function2Generator[A, B, C]
 
   /**
@@ -1913,7 +2015,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START  
   def function3s[A, B, C, D](implicit genOfD: Generator[D], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D]): Generator[(A, B, C) => D] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function3s[A, B, C, D](using genOfD: Generator[D], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D]): Generator[(A, B, C) => D] =
     Generator.function3Generator[A, B, C, D]
 
   /**
@@ -1921,7 +2026,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START  
   def function4s[A, B, C, D, E](implicit genOfE: Generator[E], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E]): Generator[(A, B, C, D) => E] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function4s[A, B, C, D, E](using genOfE: Generator[E], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E]): Generator[(A, B, C, D) => E] =
     Generator.function4Generator[A, B, C, D, E]
 
   /**
@@ -1929,7 +2037,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START  
   def function5s[A, B, C, D, E, F](implicit genOfF: Generator[F], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F]): Generator[(A, B, C, D, E) => F] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function5s[A, B, C, D, E, F](using genOfF: Generator[F], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F]): Generator[(A, B, C, D, E) => F] =
     Generator.function5Generator[A, B, C, D, E, F]
 
   /**
@@ -1937,7 +2048,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START  
   def function6s[A, B, C, D, E, F, G](implicit genOfG: Generator[G], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G]): Generator[(A, B, C, D, E, F) => G] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function6s[A, B, C, D, E, F, G](using genOfG: Generator[G], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G]): Generator[(A, B, C, D, E, F) => G] =
     Generator.function6Generator[A, B, C, D, E, F, G]
 
   /**
@@ -1945,7 +2059,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START  
   def function7s[A, B, C, D, E, F, G, H](implicit genOfH: Generator[H], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H]): Generator[(A, B, C, D, E, F, G) => H] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function7s[A, B, C, D, E, F, G, H](using genOfH: Generator[H], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H]): Generator[(A, B, C, D, E, F, G) => H] =
     Generator.function7Generator[A, B, C, D, E, F, G, H]
 
   /**
@@ -1953,7 +2070,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START  
   def function8s[A, B, C, D, E, F, G, H, I](implicit genOfI: Generator[I], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I]): Generator[(A, B, C, D, E, F, G, H) => I] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function8s[A, B, C, D, E, F, G, H, I](using genOfI: Generator[I], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I]): Generator[(A, B, C, D, E, F, G, H) => I] =
     Generator.function8Generator[A, B, C, D, E, F, G, H, I]
 
   /**
@@ -1961,7 +2081,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START  
   def function9s[A, B, C, D, E, F, G, H, I, J](implicit genOfJ: Generator[J], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J]): Generator[(A, B, C, D, E, F, G, H, I) => J] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function9s[A, B, C, D, E, F, G, H, I, J](using genOfJ: Generator[J], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J]): Generator[(A, B, C, D, E, F, G, H, I) => J] =
     Generator.function9Generator[A, B, C, D, E, F, G, H, I, J]
 
   /**
@@ -1969,7 +2092,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START  
   def function10s[A, B, C, D, E, F, G, H, I, J, K](implicit genOfK: Generator[K], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K]): Generator[(A, B, C, D, E, F, G, H, I, J) => K] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function10s[A, B, C, D, E, F, G, H, I, J, K](using genOfK: Generator[K], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K]): Generator[(A, B, C, D, E, F, G, H, I, J) => K] =
     Generator.function10Generator[A, B, C, D, E, F, G, H, I, J, K]
 
   /**
@@ -1977,7 +2103,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START  
   def function11s[A, B, C, D, E, F, G, H, I, J, K, L](implicit genOfL: Generator[L], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L]): Generator[(A, B, C, D, E, F, G, H, I, J, K) => L] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function11s[A, B, C, D, E, F, G, H, I, J, K, L](using genOfL: Generator[L], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L]): Generator[(A, B, C, D, E, F, G, H, I, J, K) => L] =
     Generator.function11Generator[A, B, C, D, E, F, G, H, I, J, K, L]
 
   /**
@@ -1985,7 +2114,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START  
   def function12s[A, B, C, D, E, F, G, H, I, J, K, L, M](implicit genOfM: Generator[M], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L) => M] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function12s[A, B, C, D, E, F, G, H, I, J, K, L, M](using genOfM: Generator[M], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L) => M] =
     Generator.function12Generator[A, B, C, D, E, F, G, H, I, J, K, L, M]
 
   /**
@@ -1993,7 +2125,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START
   def function13s[A, B, C, D, E, F, G, H, I, J, K, L, M, N](implicit genOfN: Generator[N], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M) => N] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function13s[A, B, C, D, E, F, G, H, I, J, K, L, M, N](using genOfN: Generator[N], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M) => N] =
     Generator.function13Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N]
 
   /**
@@ -2001,7 +2136,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START
   def function14s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](implicit genOfO: Generator[O], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => O] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function14s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](using genOfO: Generator[O], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => O] =
     Generator.function14Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
 
   /**
@@ -2009,7 +2147,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START
   def function15s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](implicit genOfP: Generator[P], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => P] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function15s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](using genOfP: Generator[P], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => P] =
     Generator.function15Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]
 
   /**
@@ -2017,7 +2158,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START
   def function16s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](implicit genOfQ: Generator[Q], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Q] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function16s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](using genOfQ: Generator[Q], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Q] =
     Generator.function16Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]
 
   /**
@@ -2025,7 +2169,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START
   def function17s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](implicit genOfR: Generator[R], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => R] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function17s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](using genOfR: Generator[R], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => R] =
     Generator.function17Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]
 
   /**
@@ -2033,7 +2180,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START
   def function18s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit genOfS: Generator[S], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => S] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function18s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](using genOfS: Generator[S], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => S] =
     Generator.function18Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]
 
   /**
@@ -2041,7 +2191,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START
   def function19s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit genOfT: Generator[T], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function19s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](using genOfT: Generator[T], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T] =
     Generator.function19Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]
 
   /**
@@ -2049,7 +2202,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START
   def function20s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit genOfU: Generator[U], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T], typeInfoU: TypeInfo[U]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => U] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function20s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](using genOfU: Generator[U], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T], typeInfoU: TypeInfo[U]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => U] =
     Generator.function20Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]
 
   /**
@@ -2057,7 +2213,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START
   def function21s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit genOfV: Generator[V], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T], typeInfoU: TypeInfo[U], typeInfoV: TypeInfo[V]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => V] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function21s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](using genOfV: Generator[V], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T], typeInfoU: TypeInfo[U], typeInfoV: TypeInfo[V]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => V] =
     Generator.function21Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]
 
   /**
@@ -2065,7 +2224,10 @@ trait CommonGenerators {
     *
     * @group Functions
     */
+  // SKIP-DOTTY-START
   def function22s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](implicit genOfW: Generator[W], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T], typeInfoU: TypeInfo[U], typeInfoV: TypeInfo[V], typeInfoW: TypeInfo[W]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => W] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def function22s[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](using genOfW: Generator[W], typeInfoA: TypeInfo[A], typeInfoB: TypeInfo[B], typeInfoC: TypeInfo[C], typeInfoD: TypeInfo[D], typeInfoE: TypeInfo[E], typeInfoF: TypeInfo[F], typeInfoG: TypeInfo[G], typeInfoH: TypeInfo[H], typeInfoI: TypeInfo[I], typeInfoJ: TypeInfo[J], typeInfoK: TypeInfo[K], typeInfoL: TypeInfo[L], typeInfoM: TypeInfo[M], typeInfoN: TypeInfo[N], typeInfoO: TypeInfo[O], typeInfoP: TypeInfo[P], typeInfoQ: TypeInfo[Q], typeInfoR: TypeInfo[R], typeInfoS: TypeInfo[S], typeInfoT: TypeInfo[T], typeInfoU: TypeInfo[U], typeInfoV: TypeInfo[V], typeInfoW: TypeInfo[W]): Generator[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => W] =
     Generator.function22Generator[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W]
 
 
@@ -2118,7 +2280,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B](construct: A => B)(deconstruct: B => A)(implicit genOfA: Generator[A]): Generator[B] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B](construct: A => B)(deconstruct: B => A)(using genOfA: Generator[A]): Generator[B] =
     new GeneratorFor1[A, B](construct, deconstruct)(genOfA)
 
   /**
@@ -2126,7 +2291,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C](construct: (A, B) => C)(deconstruct: C => (A, B))(implicit genOfA: Generator[A], genOfB: Generator[B]): Generator[C] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C](construct: (A, B) => C)(deconstruct: C => (A, B))(using genOfA: Generator[A], genOfB: Generator[B]): Generator[C] =
     new GeneratorFor2[A, B, C](construct, deconstruct)(genOfA, genOfB)
 
   /**
@@ -2134,7 +2302,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D](construct: (A, B, C) => D)(deconstruct: D => (A, B, C))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C]): Generator[D] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D](construct: (A, B, C) => D)(deconstruct: D => (A, B, C))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C]): Generator[D] =
     new GeneratorFor3[A, B, C, D](construct, deconstruct)(genOfA, genOfB, genOfC)
 
   /**
@@ -2142,7 +2313,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E](construct: (A, B, C, D) => E)(deconstruct: E => (A, B, C, D))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D]): Generator[E] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E](construct: (A, B, C, D) => E)(deconstruct: E => (A, B, C, D))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D]): Generator[E] =
     new GeneratorFor4[A, B, C, D, E](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD)
 
   /**
@@ -2150,7 +2324,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F](construct: (A, B, C, D, E) => F)(deconstruct: F => (A, B, C, D, E))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E]): Generator[F] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F](construct: (A, B, C, D, E) => F)(deconstruct: F => (A, B, C, D, E))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E]): Generator[F] =
     new GeneratorFor5[A, B, C, D, E, F](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE)
 
   /**
@@ -2158,7 +2335,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G](construct: (A, B, C, D, E, F) => G)(deconstruct: G => (A, B, C, D, E, F))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F]): Generator[G] =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G](construct: (A, B, C, D, E, F) => G)(deconstruct: G => (A, B, C, D, E, F))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F]): Generator[G] =
     new GeneratorFor6[A, B, C, D, E, F, G](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF)
 
   /**
@@ -2166,7 +2346,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H](construct: (A, B, C, D, E, F, G) => H)(deconstruct: H => (A, B, C, D, E, F, G))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H](construct: (A, B, C, D, E, F, G) => H)(deconstruct: H => (A, B, C, D, E, F, G))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                           genOfG: Generator[G]): Generator[H] =
     new GeneratorFor7[A, B, C, D, E, F, G, H](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG)
 
@@ -2175,7 +2358,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H, I](construct: (A, B, C, D, E, F, G, H) => I)(deconstruct: I => (A, B, C, D, E, F, G, H))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H, I](construct: (A, B, C, D, E, F, G, H) => I)(deconstruct: I => (A, B, C, D, E, F, G, H))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                    genOfG: Generator[G], genOfH: Generator[H]): Generator[I] =
     new GeneratorFor8[A, B, C, D, E, F, G, H, I](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH)
 
@@ -2184,7 +2370,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H, I, J](construct: (A, B, C, D, E, F, G, H, I) => J)(deconstruct: J => (A, B, C, D, E, F, G, H, I))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H, I, J](construct: (A, B, C, D, E, F, G, H, I) => J)(deconstruct: J => (A, B, C, D, E, F, G, H, I))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                             genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I]): Generator[J] =
     new GeneratorFor9[A, B, C, D, E, F, G, H, I, J](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI)
 
@@ -2193,7 +2382,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K](construct: (A, B, C, D, E, F, G, H, I, J) => K)(deconstruct: K => (A, B, C, D, E, F, G, H, I, J))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H, I, J, K](construct: (A, B, C, D, E, F, G, H, I, J) => K)(deconstruct: K => (A, B, C, D, E, F, G, H, I, J))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                      genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J]): Generator[K] =
     new GeneratorFor10[A, B, C, D, E, F, G, H, I, J, K](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ)
 
@@ -2202,7 +2394,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L](construct: (A, B, C, D, E, F, G, H, I, J, K) => L)(deconstruct: L => (A, B, C, D, E, F, G, H, I, J, K))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L](construct: (A, B, C, D, E, F, G, H, I, J, K) => L)(deconstruct: L => (A, B, C, D, E, F, G, H, I, J, K))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                               genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K]): Generator[L] =
     new GeneratorFor11[A, B, C, D, E, F, G, H, I, J, K, L](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK)
 
@@ -2211,7 +2406,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M](construct: (A, B, C, D, E, F, G, H, I, J, K, L) => M)(deconstruct: M => (A, B, C, D, E, F, G, H, I, J, K, L))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M](construct: (A, B, C, D, E, F, G, H, I, J, K, L) => M)(deconstruct: M => (A, B, C, D, E, F, G, H, I, J, K, L))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                        genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L]): Generator[M] =
     new GeneratorFor12[A, B, C, D, E, F, G, H, I, J, K, L, M](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL)
 
@@ -2220,7 +2418,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M) => N)(deconstruct: N => (A, B, C, D, E, F, G, H, I, J, K, L, M))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M) => N)(deconstruct: N => (A, B, C, D, E, F, G, H, I, J, K, L, M))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                 genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M]): Generator[N] =
     new GeneratorFor13[A, B, C, D, E, F, G, H, I, J, K, L, M, N](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM)
 
@@ -2229,7 +2430,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) => O)(deconstruct: O => (A, B, C, D, E, F, G, H, I, J, K, L, M, N))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) => O)(deconstruct: O => (A, B, C, D, E, F, G, H, I, J, K, L, M, N))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                          genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                          genOfN: Generator[N]): Generator[O] =
     new GeneratorFor14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN)
@@ -2239,7 +2443,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => P)(deconstruct: P => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => P)(deconstruct: P => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                                   genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                                   genOfN: Generator[N], genOfO: Generator[O]): Generator[P] =
     new GeneratorFor15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO)
@@ -2249,7 +2456,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Q)(deconstruct: Q => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Q)(deconstruct: Q => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                                            genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                                            genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P]): Generator[Q] =
     new GeneratorFor16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP)
@@ -2259,7 +2469,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => R)(deconstruct: R => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => R)(deconstruct: R => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                                                     genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                                                     genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q]): Generator[R] =
     new GeneratorFor17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ)
@@ -2269,7 +2482,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => S)(deconstruct: S => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => S)(deconstruct: S => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                                                              genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                                                              genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R]): Generator[S] =
     new GeneratorFor18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR)
@@ -2279,7 +2495,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T)(deconstruct: T => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T)(deconstruct: T => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                                                                       genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                                                                       genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S]): Generator[T] =
     new GeneratorFor19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR, genOfS)
@@ -2289,7 +2508,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => U)(deconstruct: U => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => U)(deconstruct: U => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                                                                                genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                                                                                genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S], genOfT: Generator[T]): Generator[U] =
     new GeneratorFor20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](construct, deconstruct)(genOfA, genOfB, genOfC, genOfD, genOfE, genOfF, genOfG, genOfH, genOfI, genOfJ, genOfK, genOfL, genOfM, genOfN, genOfO, genOfP, genOfQ, genOfR, genOfS, genOfT)
@@ -2299,7 +2521,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => V)(deconstruct: V => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => V)(deconstruct: V => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                                                                                         genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                                                                                         genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S], genOfT: Generator[T],
                                                                                                                                                                                                                                                         genOfU: Generator[U]): Generator[V] =
@@ -2310,7 +2535,10 @@ trait CommonGenerators {
     *
     * @group InstancesOf
     */
+  // SKIP-DOTTY-START  
   def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => W)(deconstruct: W => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V))(implicit genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def instancesOf[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => W)(deconstruct: W => (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V))(using genOfA: Generator[A], genOfB: Generator[B], genOfC: Generator[C], genOfD: Generator[D], genOfE: Generator[E], genOfF: Generator[F],
                                                                                                                                                                                                                                                                  genOfG: Generator[G], genOfH: Generator[H], genOfI: Generator[I], genOfJ: Generator[J], genOfK: Generator[K], genOfL: Generator[L], genOfM: Generator[M],
                                                                                                                                                                                                                                                                  genOfN: Generator[N], genOfO: Generator[O], genOfP: Generator[P], genOfQ: Generator[Q], genOfR: Generator[R], genOfS: Generator[S], genOfT: Generator[T],
                                                                                                                                                                                                                                                                  genOfU: Generator[U], genOfV: Generator[V]): Generator[W] =

--- a/jvm/core/src/main/scala/org/scalatest/prop/Randomizer.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Randomizer.scala
@@ -1006,7 +1006,10 @@ class Randomizer(val seed: Long) { thisRandomizer =>
     * @tparam T The type to generate.
     * @return A List of values of the desired type.
     */
+  // SKIP-DOTTY-START  
   def nextList[T](length: PosZInt)(implicit genOfT: Generator[T]): (List[T], Randomizer) = {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def nextList[T](length: PosZInt)(using genOfT: Generator[T]): (List[T], Randomizer) = {
     @tailrec
     def loop(acc: List[T], count: Int, nextRnd: Randomizer): (List[T], Randomizer) = {
       if (count == length.value) (acc, nextRnd)

--- a/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/RoseTree.scala
@@ -85,7 +85,10 @@ trait RoseTree[+T] { thisRoseTreeOfT =>
    * @tparam E the type of additional data returned in case of failure
    * @return a future optional error data, if a shrunken or simplified case was found during the search
    */
+  // SKIP-DOTTY-START  
   def shrinkSearchForFuture[E](fun: T => Future[Option[E]])(implicit execContext: ExecutionContext): Future[Option[(T, E)]] = {
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def shrinkSearchForFuture[E](fun: T => Future[Option[E]])(using execContext: ExecutionContext): Future[Option[(T, E)]] = {
     def shrinkLoop(lastFailure: Option[(RoseTree[T], E)], pending: LazyListOrStream[RoseTree[T]], count: Int): Future[Option[(RoseTree[T], E)]] = {
       if (count < maximumIterationCount) 
         pending match {

--- a/jvm/core/src/main/scala/org/scalatest/prop/Whenever.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Whenever.scala
@@ -106,6 +106,9 @@ trait Whenever {
    *    <code>fun</code> function (<code>condition</code> is true) or throw <code>DiscardedEvaluationException</code> (<code>condition</code> is `false`)
    * @param fun the function to evaluate if the specified <code>condition</code> is `true`
    */
+  // SKIP-DOTTY-START 
   def whenever[T](condition: Boolean)(fun: => T)(implicit wa: WheneverAsserting[T]): wa.Result =
+  // SKIP-DOTTY-END
+  //DOTTY-ONLY def whenever[T](condition: Boolean)(fun: => T)(using wa: WheneverAsserting[T]): wa.Result =
     wa.whenever(condition)(fun)
 }

--- a/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NumericStringSpec.scala
+++ b/jvm/scalactic-test/src/test/scala/org/scalactic/anyvals/NumericStringSpec.scala
@@ -34,7 +34,7 @@ class NumericStringSpec extends funspec.AnyFunSpec with matchers.should.Matchers
   import prop._
 
   implicit val numericStringGen: Generator[NumericString] =
-    for (cs <- lists[Char](specificValues('0', '1', '2', '3', '4', '5', '6', '7', '8', '9'))) yield {
+    for (cs <- lists[Char](/*DOTTY-ONLY using */ specificValues('0', '1', '2', '3', '4', '5', '6', '7', '8', '9'))) yield {
       if (cs.isEmpty) NumericString("000")
       else NumericString.ensuringValid(cs.mkString)
     }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
@@ -4962,32 +4962,23 @@ If it doesn't show up for a while, please delete this comment.
       // users. Having their tests fail when they upgrade to 2.13 might help them prevent bugs from escaping to production.
       "produces generators given construct and deconstruct functions for 1 type" in {
         case class Person(age: Int)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p => p.age } (posZIntValues)
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf[Int, Person](Person.apply) { p => p.age } (posZIntValues)
+        val persons = instancesOf/*DOTTY-ONLY [Int, Person] */(Person) { p => p.age } (/*DOTTY-ONLY using */ posZIntValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(ag) => ag should be >= 0 } // A contrived property check to do something with the generator
       }
       "produces generators given construct and deconstruct functions for 2 types" in {
         case class Person(name: String, age: Int)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf(Person/*DOTTY-ONLY .apply */) { p =>
           (p.name, p.age)
-        } (strings, posZIntValues)
+        } (/*DOTTY-ONLY using */ strings, posZIntValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag) => ag should be >= 0 } // A contrived property check to do something with the generator
       }
       "produces generators given construct and deconstruct functions for 3 types" in {
         case class Person(name: String, age: Int, attr3: Long)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Person] */(Person/*DOTTY-ONLY .apply */) { p =>
           (p.name, p.age, p.attr3)
-        } (strings, posZIntValues, posZLongValues)
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3) =>
           ag should be >= 0
@@ -4996,12 +4987,9 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 4 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues)
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4) =>
           ag should be >= 0
@@ -5011,12 +4999,9 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 5 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues)
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5) =>
           ag should be >= 0
@@ -5027,12 +5012,9 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 6 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues)
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6) =>
           ag should be >= 0
@@ -5044,12 +5026,9 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 7 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues)
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7) =>
           ag should be >= 0
@@ -5062,12 +5041,9 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 8 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Double, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues)
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8) =>
           ag should be >= 0
@@ -5081,12 +5057,9 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 9 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Double, Float, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues)
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9) =>
           ag should be >= 0
@@ -5101,12 +5074,9 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 10 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Double, Float, Int, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues)
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10) =>
           ag should be >= 0
@@ -5122,12 +5092,9 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 11 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues)
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11) =>
           ag should be >= 0
@@ -5144,12 +5111,9 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 12 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues)
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12) =>
           ag should be >= 0
@@ -5167,12 +5131,9 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 13 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues)
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13) =>
           ag should be >= 0
@@ -5191,12 +5152,9 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 14 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Int, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues)
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14) =>
           ag should be >= 0
@@ -5216,12 +5174,9 @@ If it doesn't show up for a while, please delete this comment.
       }
       "produces generators given construct and deconstruct functions for 15 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues)
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15) =>
           ag should be >= 0
@@ -5243,12 +5198,9 @@ If it doesn't show up for a while, please delete this comment.
       "produces generators given construct and deconstruct functions for 16 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
                           attr16: Double)
-        // SKIP-DOTTY-START                  
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
           posDoubleValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16) =>
@@ -5272,12 +5224,9 @@ If it doesn't show up for a while, please delete this comment.
       "produces generators given construct and deconstruct functions for 17 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
                           attr16: Double, attr17: Float)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
           posDoubleValues, posFloatValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17) =>
@@ -5302,12 +5251,9 @@ If it doesn't show up for a while, please delete this comment.
       "produces generators given construct and deconstruct functions for 18 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
                           attr16: Double, attr17: Float, attr18: Int)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Int, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
           posDoubleValues, posFloatValues, posZIntValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17, attr18) =>
@@ -5333,12 +5279,9 @@ If it doesn't show up for a while, please delete this comment.
       "produces generators given construct and deconstruct functions for 19 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
                           attr16: Double, attr17: Float, attr18: Int, attr19: Long)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
           posDoubleValues, posFloatValues, posZIntValues, posZLongValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17, attr18, attr19) =>
@@ -5365,12 +5308,9 @@ If it doesn't show up for a while, please delete this comment.
       "produces generators given construct and deconstruct functions for 20 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
                           attr16: Double, attr17: Float, attr18: Int, attr19: Long, attr20: Double)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19, p.attr20)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
           posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17, attr18, attr19, attr20) =>
@@ -5398,12 +5338,9 @@ If it doesn't show up for a while, please delete this comment.
       "produces generators given construct and deconstruct functions for 21 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
                           attr16: Double, attr17: Float, attr18: Int, attr19: Long, attr20: Double, attr21: Float)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19, p.attr20, p.attr21)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
           posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17, attr18, attr19, attr20, attr21) =>
@@ -5432,12 +5369,9 @@ If it doesn't show up for a while, please delete this comment.
       "produces generators given construct and deconstruct functions for 22 types" in {
         case class Person(name: String, age: Int, attr3: Long, attr4: Double, attr5: Float, attr6: Int, attr7: Long, attr8: Double, attr9: Float, attr10: Int, attr11: Long, attr12: Double, attr13: Float, attr14: Int, attr15: Long,
                           attr16: Double, attr17: Float, attr18: Int, attr19: Long, attr20: Double, attr21: Float, attr22: Int)
-        // SKIP-DOTTY-START
-        val persons = instancesOf(Person) { p =>
-        // SKIP-DOTTY-END
-        //DOTTY-ONLY val persons = instancesOf(Person.apply) { p =>
+        val persons = instancesOf/*DOTTY-ONLY [String, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Int, Long, Double, Float, Int, Person] */(Person) { p =>
           (p.name, p.age, p.attr3, p.attr4, p.attr5, p.attr6, p.attr7, p.attr8, p.attr9, p.attr10, p.attr11, p.attr12, p.attr13, p.attr14, p.attr15, p.attr16, p.attr17, p.attr18, p.attr19, p.attr20, p.attr21, p.attr22)
-        } (strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
+        } (/*DOTTY-ONLY using */ strings, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues, posZLongValues,
           posDoubleValues, posFloatValues, posZIntValues, posZLongValues, posDoubleValues, posFloatValues, posZIntValues)
         import org.scalatest.prop.GeneratorDrivenPropertyChecks._
         forAll (persons) { case Person(_, ag, attr3, attr4, attr5, attr6, attr7, attr8, attr9, attr10, attr11, attr12, attr13, attr14, attr15, attr16, attr17, attr18, attr19, attr20, attr21, attr22) =>

--- a/project/GenScalacticDotty.scala
+++ b/project/GenScalacticDotty.scala
@@ -31,6 +31,7 @@ object GenScalacticDotty {
       line.replaceAll("""import ([\w\.]+)\._""", """import $1.*""")
           .replace(": _*", "*")
           .replace("uncheckedVariance => uV", "uncheckedVariance as uV")
+          .replaceAll("""/\*\s*DOTTY-ONLY\s*(.*?)\s*\*/""", "$1")
 
   private def rewrite213(line: String): String =
     line.replaceAllLiterally("final def startsWith(that: GenSeq[Char]): Boolean = theString.startsWith(that)", "final def startsWith(that: GenSeq[Char]): Boolean = theString.startsWith(that.mkString)")
@@ -103,7 +104,7 @@ object GenScalacticDotty {
     else if (line.trim.startsWith("//SCALATESTJS-ONLY "))
       line.substring(line.indexOf("//SCALATESTJS-ONLY ") + 19)    
     else
-      line
+      line.replaceAll("""/\*\s*DOTTY-ONLY\s*(.*?)\s*\*/""", "$1")
 
   private def transformLineJS(line: String): String =
     uncommentJsExportJS(line)
@@ -165,7 +166,7 @@ object GenScalacticDotty {
     else if (line.trim.startsWith("//SCALATESTNATIVE-ONLY "))
       line.substring(line.indexOf("//SCALATESTNATIVE-ONLY ") + 23)    
     else
-      line
+      line.replaceAll("""/\*\s*DOTTY-ONLY\s*(.*?)\s*\*/""", "$1")
 
   private def transformLineNative(line: String): String =
     uncommentNativeExportNative(line)


### PR DESCRIPTION
## Summary

This PR migrates the implicit-based typeclass API in `org.scalatest.prop` (`Chooser`, `CommonGenerators`, `Randomizer`, `RoseTree`, `Whenever`) to use Scala 3's `given`/`using` syntax under the Dotty build, while keeping the Scala 2 `implicit` syntax intact for the JVM/2.x build via the existing `SKIP-DOTTY-START/END` and `DOTTY-ONLY` cross-compilation markers.

## Changes

- **`Chooser.scala`**: Added `given` equivalents for all built-in `Chooser` instances (Char, Byte, Short, Int, Float, PosFloat, etc.), gated behind `SKIP-DOTTY-START/END` / `DOTTY-ONLY` blocks. Also added missing Apache 2.0 license header and Scaladoc for each instance.
- **`CommonGenerators.scala`**: Converted `implicit` generator parameters and definitions to their `given`/`using` Dotty equivalents, plus added Scaladoc.
- **`Randomizer.scala`, `RoseTree.scala`, `Whenever.scala`**: Added `DOTTY-ONLY` variants of methods that take `implicit` `Generator[T]` parameters, converting them to `using`.
- **`GenScalacticDotty.scala`**: Extended the Dotty source-generation build task to strip `/* DOTTY-ONLY ... */` block comments when generating Scala 3 sources, so inline `DOTTY-ONLY` annotations (e.g. `using` keywords embedded in call sites) are unwrapped correctly for the Dotty build.
- **`NumericStringSpec.scala`, `CommonGeneratorsSpec.scala`**: Updated test call sites to use the new inline `/*DOTTY-ONLY using */` annotation style instead of maintaining fully duplicated `SKIP-DOTTY-START/END` blocks, significantly reducing duplicated test code in `CommonGeneratorsSpec.scala`.

## Why

ScalaTest still supports Scala 2 via `implicit`, but Scala 3 favors `given`/`using`. This keeps the public API idiomatic on Dotty without breaking Scala 2 compatibility, and moves call-site conversions (like `instancesOf(...)`) to the more concise inline `DOTTY-ONLY` comment style rather than duplicating whole test blocks with `SKIP-DOTTY-START/END`.

## Testing

- Existing specs in `CommonGeneratorsSpec.scala` and `NumericStringSpec.scala` updated to compile under both the Scala 2 and generated Dotty sources.