### PR TITLE
Matchers Using Using

### DIFF
--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/Matcher.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/Matcher.scala
@@ -718,7 +718,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def inOrderOnly(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory1[T, Sequencing] =
-      outerInstance.and(MatcherWords.contain.inOrderOnly(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      outerInstance.and(MatcherWords.contain.inOrderOnly(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:
@@ -729,7 +729,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def allOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory1[T, Aggregating] =
-      outerInstance.and(MatcherWords.contain.allOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      outerInstance.and(MatcherWords.contain.allOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:
@@ -751,7 +751,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def inOrder(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory1[T, Sequencing] =
-      outerInstance.and(MatcherWords.contain.inOrder(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      outerInstance.and(MatcherWords.contain.inOrder(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:
@@ -773,7 +773,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def oneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory1[T, Containing] =
-      outerInstance.and(MatcherWords.contain.oneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      outerInstance.and(MatcherWords.contain.oneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:
@@ -795,7 +795,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def atLeastOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory1[T, Aggregating] =
-      outerInstance.and(MatcherWords.contain.atLeastOneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      outerInstance.and(MatcherWords.contain.atLeastOneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:
@@ -817,7 +817,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def only(right: Any*): MatcherFactory1[T, Aggregating] =
-      outerInstance.and(MatcherWords.contain.only(right.toList: _*)(prettifier, pos))
+      outerInstance.and(MatcherWords.contain.only(right.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:
@@ -828,7 +828,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def noneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory1[T, Containing] =
-      outerInstance.and(MatcherWords.contain.noneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      outerInstance.and(MatcherWords.contain.noneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:
@@ -850,7 +850,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def atMostOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory1[T, Aggregating] =
-      outerInstance.and(MatcherWords.contain.atMostOneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      outerInstance.and(MatcherWords.contain.atMostOneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:
@@ -2003,7 +2003,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def allOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory1[T, Aggregating] =
-      outerInstance.or(MatcherWords.contain.allOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      outerInstance.or(MatcherWords.contain.allOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:
@@ -2025,7 +2025,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def inOrder(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory1[T, Sequencing] =
-      outerInstance.or(MatcherWords.contain.inOrder(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      outerInstance.or(MatcherWords.contain.inOrder(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:
@@ -2047,7 +2047,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def oneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory1[T, Containing] =
-      outerInstance.or(MatcherWords.contain.oneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      outerInstance.or(MatcherWords.contain.oneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:
@@ -2069,7 +2069,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def atLeastOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory1[T, Aggregating] =
-      outerInstance.or(MatcherWords.contain.atLeastOneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      outerInstance.or(MatcherWords.contain.atLeastOneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:
@@ -2091,7 +2091,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def only(right: Any*): MatcherFactory1[T, Aggregating] =
-      outerInstance.or(MatcherWords.contain.only(right.toList: _*)(prettifier, pos))
+      outerInstance.or(MatcherWords.contain.only(right.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:
@@ -2102,7 +2102,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def inOrderOnly(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory1[T, Sequencing] =
-      outerInstance.or(MatcherWords.contain.inOrderOnly(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      outerInstance.or(MatcherWords.contain.inOrderOnly(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:
@@ -2113,7 +2113,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def noneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory1[T, Containing] =
-      outerInstance.or(MatcherWords.contain.noneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      outerInstance.or(MatcherWords.contain.noneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:
@@ -2135,7 +2135,7 @@ trait Matcher[-T] extends Function1[T, MatchResult] { outerInstance =>
      * </pre>
      **/
     infix def atMostOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory1[T, Aggregating] =
-      outerInstance.or(MatcherWords.contain.atMostOneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      outerInstance.or(MatcherWords.contain.atMostOneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax:

--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/BeWord.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/BeWord.scala
@@ -90,7 +90,7 @@ final class BeWord {
    *                       ^
    * </pre>
    **/
-  def <[T : Ordering](right: T): Matcher[T] =
+  infix def <[T : Ordering](right: T): Matcher[T] =
     new Matcher[T] {
       def apply(left: T): MatchResult = {
         val ordering = implicitly[Ordering[T]]
@@ -129,7 +129,7 @@ final class BeWord {
    *                       ^
    * </pre>
    **/
-  def >[T : Ordering](right: T): Matcher[T] =
+  infix def >[T : Ordering](right: T): Matcher[T] =
     new Matcher[T] {
       def apply(left: T): MatchResult = {
         val ordering = implicitly[Ordering[T]]
@@ -168,7 +168,7 @@ final class BeWord {
    *                       ^
    * </pre>
    **/
-  def <=[T : Ordering](right: T): Matcher[T] =
+  infix def <=[T : Ordering](right: T): Matcher[T] =
     new Matcher[T] {
       def apply(left: T): MatchResult = {
         val ordering = implicitly[Ordering[T]]
@@ -207,7 +207,7 @@ final class BeWord {
    *                       ^
    * </pre>
    **/
-  def >=[T : Ordering](right: T): Matcher[T] =
+  infix def >=[T : Ordering](right: T): Matcher[T] =
     new Matcher[T] {
       def apply(left: T): MatchResult = {
         val ordering = implicitly[Ordering[T]]
@@ -234,7 +234,7 @@ final class BeWord {
    * </p>
    */
   @deprecated("The deprecation period for the be === syntax has expired. Please use should equal, should ===, shouldEqual, should be, or shouldBe instead.")
-  def ===(right: Any)(implicit pos: source.Position): Matcher[Any] = {
+  infix def ===(right: Any)(using pos: source.Position): Matcher[Any] = {
     throw new NotAllowedException(FailureMessages.beTripleEqualsNotAllowed, pos)
   }
 
@@ -247,7 +247,7 @@ final class BeWord {
    *                          ^
    * </pre>
    **/
-  infix def a(right: Symbol)(implicit prettifier: Prettifier, pos: source.Position): Matcher[AnyRef] =
+  infix def a(right: Symbol)(using prettifier: Prettifier, pos: source.Position): Matcher[AnyRef] =
     new Matcher[AnyRef] {
       def apply(left: AnyRef): MatchResult = matchSymbolToPredicateMethod(left, right, true, true, prettifier, pos)
       override def toString: String = "be a " + prettifier(right)
@@ -300,7 +300,7 @@ final class BeWord {
    *                        ^
    * </pre>
    **/
-  infix def an(right: Symbol)(implicit prettifier: Prettifier, pos: source.Position): Matcher[AnyRef] =
+  infix def an(right: Symbol)(using prettifier: Prettifier, pos: source.Position): Matcher[AnyRef] =
     new Matcher[AnyRef] {
       def apply(left: AnyRef): MatchResult = matchSymbolToPredicateMethod(left, right, true, false, prettifier, pos)
       override def toString: String = "be an " + Prettifier.default(right)
@@ -458,7 +458,7 @@ final class BeWord {
    *               ^
    * </pre>
    **/
-  def apply(right: Symbol)(implicit prettifier: Prettifier, pos: source.Position): Matcher[AnyRef] =
+  infix def apply(right: Symbol)(using prettifier: Prettifier, pos: source.Position): Matcher[AnyRef] =
     new Matcher[AnyRef] {
       def apply(left: AnyRef): MatchResult = matchSymbolToPredicateMethod(left, right, false, false, prettifier, pos)
       override def toString: String = "be (" + Prettifier.default(right) + ")"
@@ -474,7 +474,7 @@ final class BeWord {
    *               ^
    * </pre>
    **/
-  def apply[T](right: BeMatcher[T]): Matcher[T] =
+  infix def apply[T](right: BeMatcher[T]): Matcher[T] =
     new Matcher[T] {
       def apply(left: T): MatchResult = right(left)
       override def toString: String = "be (" + Prettifier.default(right) + ")"
@@ -488,7 +488,7 @@ final class BeWord {
    *                ^
    * </pre>
    **/
-  def apply[T](bePropertyMatcher: BePropertyMatcher[T]): Matcher[T] =
+  infix def apply[T](bePropertyMatcher: BePropertyMatcher[T]): Matcher[T] =
     new Matcher[T] {
       def apply(left: T): MatchResult = {
         val result = bePropertyMatcher(left)
@@ -518,7 +518,7 @@ final class BeWord {
    *               ^
    * </pre>
    **/
-  def apply(right: Any): Matcher[Any] =
+  infix def apply(right: Any): Matcher[Any] =
     new Matcher[Any] {
       def apply(left: Any): MatchResult = {
         new EqualMatchResult(
@@ -540,7 +540,7 @@ final class BeWord {
    *                          ^
    * </pre>
    **/
-  def apply(right: SortedWord): MatcherFactory1[Any, Sortable] =
+  infix def apply(right: SortedWord): MatcherFactory1[Any, Sortable] =
     new MatcherFactory1[Any, Sortable] {
       def matcher[T <: Any : Sortable]: Matcher[T] =
         new Matcher[T] {
@@ -596,7 +596,7 @@ final class BeWord {
    *                  ^
    * </pre>
    **/
-  def apply[A, U <: PartialFunction[A, _]](resultOfDefinedAt: ResultOfDefinedAt[A]): Matcher[U] =
+  infix def apply[A, U <: PartialFunction[A, _]](resultOfDefinedAt: ResultOfDefinedAt[A]): Matcher[U] =
     new Matcher[U] {
       def apply(left: U): MatchResult =
         MatchResult(
@@ -618,7 +618,7 @@ final class BeWord {
    *               ^
    * </pre>
    **/
-  inline def apply(aType: ResultOfATypeInvocation[_]): Matcher[Any] =
+  infix inline def apply(aType: ResultOfATypeInvocation[_]): Matcher[Any] =
     ${ TypeMatcherMacro.aTypeMatcherImpl('{aType}) }
 
   /**
@@ -629,7 +629,7 @@ final class BeWord {
    *               ^
    * </pre>
    **/
-  inline def apply(anType: ResultOfAnTypeInvocation[_]): Matcher[Any] =
+  infix inline def apply(anType: ResultOfAnTypeInvocation[_]): Matcher[Any] =
     ${ TypeMatcherMacro.anTypeMatcherImpl('{anType}) }
 
   /**
@@ -640,7 +640,7 @@ final class BeWord {
    *                ^
    * </pre>
    **/
-  def apply(readable: ReadableWord): MatcherFactory1[Any, Readability] =
+  infix def apply(readable: ReadableWord): MatcherFactory1[Any, Readability] =
     new MatcherFactory1[Any, Readability] {
       def matcher[T <: Any : Readability]: Matcher[T] =
         new Matcher[T] {
@@ -666,7 +666,7 @@ final class BeWord {
    *                 ^
    * </pre>
    **/
-  def apply(writable: WritableWord): MatcherFactory1[Any, Writability] =
+  infix def apply(writable: WritableWord): MatcherFactory1[Any, Writability] =
     new MatcherFactory1[Any, Writability] {
       def matcher[T <: Any : Writability]: Matcher[T] =
         new Matcher[T] {
@@ -692,7 +692,7 @@ final class BeWord {
    *                 ^
    * </pre>
    **/
-  def apply(empty: EmptyWord): MatcherFactory1[Any, Emptiness] =
+  infix def apply(empty: EmptyWord): MatcherFactory1[Any, Emptiness] =
     new MatcherFactory1[Any, Emptiness] {
       def matcher[T <: Any : Emptiness]: Matcher[T] =
         new Matcher[T] {
@@ -718,7 +718,7 @@ final class BeWord {
    *                 ^
    * </pre>
    **/
-  def apply(defined: DefinedWord): MatcherFactory1[Any, Definition] =
+  infix def apply(defined: DefinedWord): MatcherFactory1[Any, Definition] =
     new MatcherFactory1[Any, Definition] {
       def matcher[T <: Any : Definition]: Matcher[T] =
         new Matcher[T] {

--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/MatchPatternWord.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/MatchPatternWord.scala
@@ -35,7 +35,7 @@ final class MatchPatternWord {
    *               ^
    * </pre>
    */
-  inline def apply(inline right: PartialFunction[Matchable, _]) =
+  infix inline def apply(inline right: PartialFunction[Matchable, _]) =
     ${ org.scalatest.matchers.MatchPatternMacro.matchPatternMatcher('{right}) }
 
   /**

--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/NotWord.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/NotWord.scala
@@ -54,7 +54,7 @@ final class NotWord {
    *                     ^
    * </pre>
    **/
-  def apply[S](matcher: Matcher[S]): Matcher[S] =
+  infix def apply[S](matcher: Matcher[S]): Matcher[S] =
     new Matcher[S] {
       def apply(left: S): MatchResult = matcher(left).negated
       override def toString: String = "not (" + Prettifier.default(matcher) + ")"
@@ -70,7 +70,7 @@ final class NotWord {
    *                      ^
    * </pre>
    **/
-  def apply[S, TYPECLASS[_]](matcherGen1: MatcherFactory1[S, TYPECLASS]): MatcherFactory1[S, TYPECLASS] = {
+  infix def apply[S, TYPECLASS[_]](matcherGen1: MatcherFactory1[S, TYPECLASS]): MatcherFactory1[S, TYPECLASS] = {
     new MatcherFactory1[S, TYPECLASS] {
       def matcher[V <: S : TYPECLASS]: Matcher[V] = {
         val innerMatcher: Matcher[V] = matcherGen1.matcher
@@ -83,7 +83,7 @@ final class NotWord {
     }
   }
 
-  def apply[S, TYPECLASS1[_], TYPECLASS2[_]](matcherGen2: MatcherFactory2[S, TYPECLASS1, TYPECLASS2]): MatcherFactory2[S, TYPECLASS1, TYPECLASS2] = {
+  infix def apply[S, TYPECLASS1[_], TYPECLASS2[_]](matcherGen2: MatcherFactory2[S, TYPECLASS1, TYPECLASS2]): MatcherFactory2[S, TYPECLASS1, TYPECLASS2] = {
     new MatcherFactory2[S, TYPECLASS1, TYPECLASS2] {
       def matcher[V <: S : TYPECLASS1 : TYPECLASS2]: Matcher[V] = {
         val innerMatcher: Matcher[V] = matcherGen2.matcher
@@ -123,7 +123,7 @@ final class NotWord {
    * num should not be (odd)
    * </pre>
    */
-  def apply[S](beMatcher: BeMatcher[S]): BeMatcher[S] =
+  infix def apply[S](beMatcher: BeMatcher[S]): BeMatcher[S] =
     new BeMatcher[S] {
       def apply(left: S): MatchResult = beMatcher(left).negated
       override def toString: String = "not (" + Prettifier.default(beMatcher) + ")"
@@ -137,7 +137,7 @@ final class NotWord {
    *             ^
    * </pre>
    **/
-  def apply(existWord: ExistWord): ResultOfNotExist =
+  infix def apply(existWord: ExistWord): ResultOfNotExist =
     new ResultOfNotExist(this)
 
   /*
@@ -420,7 +420,7 @@ final class NotWord {
    * </p>
    */
   @deprecated("The deprecation period for the be === syntax has expired. Please use should equal, should ===, shouldEqual, should be, or shouldBe instead.")
-  infix def be(tripleEqualsInvocation: TripleEqualsInvocation[_])(implicit pos: source.Position): Matcher[Any] = {
+  infix def be(tripleEqualsInvocation: TripleEqualsInvocation[_])(using pos: source.Position): Matcher[Any] = {
     throw new NotAllowedException(FailureMessages.beTripleEqualsNotAllowed, pos)
   }
 
@@ -433,7 +433,7 @@ final class NotWord {
    *                    ^
    * </pre>
    **/
-  infix def be[T <: AnyRef](symbol: Symbol)(implicit prettifier: Prettifier, pos: source.Position): Matcher[T] = {
+  infix def be[T <: AnyRef](symbol: Symbol)(using prettifier: Prettifier, pos: source.Position): Matcher[T] = {
     new Matcher[T] {
       def apply(left: T): MatchResult = {
         val positiveMatchResult = matchSymbolToPredicateMethod(left, symbol, false, false, prettifier, pos)
@@ -483,7 +483,7 @@ final class NotWord {
    *                           ^
    * </pre>
    **/
-  infix def be[T <: AnyRef](resultOfAWordApplication: ResultOfAWordToSymbolApplication)(implicit prettifier: Prettifier, pos: source.Position): Matcher[T] = {
+  infix def be[T <: AnyRef](resultOfAWordApplication: ResultOfAWordToSymbolApplication)(using prettifier: Prettifier, pos: source.Position): Matcher[T] = {
     new Matcher[T] {
       def apply(left: T): MatchResult = {
         val positiveMatchResult = matchSymbolToPredicateMethod(left, resultOfAWordApplication.symbol, true, true, prettifier, pos)
@@ -557,7 +557,7 @@ final class NotWord {
    *                            ^
    * </pre>
    **/
-  infix def be[T <: AnyRef](resultOfAnWordApplication: ResultOfAnWordToSymbolApplication)(implicit prettifier: Prettifier, pos: source.Position): Matcher[T] = {
+  infix def be[T <: AnyRef](resultOfAnWordApplication: ResultOfAnWordToSymbolApplication)(using prettifier: Prettifier, pos: source.Position): Matcher[T] = {
     new Matcher[T] {
       def apply(left: T): MatchResult = {
         val positiveMatchResult = matchSymbolToPredicateMethod(left, resultOfAnWordApplication.symbol, true, false, prettifier, pos)
@@ -1033,9 +1033,9 @@ final class NotWord {
    *                         ^
    * </pre>
    **/
-  infix def contain[T](oneOf: ResultOfOneOfApplication)(implicit prettifier: Prettifier): MatcherFactory1[Any, Containing] = {
+  infix def contain[T](oneOf: ResultOfOneOfApplication)(using prettifier: Prettifier): MatcherFactory1[Any, Containing] = {
     new MatcherFactory1[Any, Containing] {
-      def matcher[T](implicit containing: Containing[T]): Matcher[T] = {
+      def matcher[T](using containing: Containing[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1065,7 +1065,7 @@ final class NotWord {
    **/
   infix def contain[T](oneElementOf: ResultOfOneElementOfApplication): MatcherFactory1[Any, Containing] = {
     new MatcherFactory1[Any, Containing] {
-      def matcher[T](implicit containing: Containing[T]): Matcher[T] = {
+      def matcher[T](using containing: Containing[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1093,9 +1093,9 @@ final class NotWord {
    *                         ^
    * </pre>
    **/
-  infix def contain[T](atLeastOneOf: ResultOfAtLeastOneOfApplication)(implicit prettifier: Prettifier): MatcherFactory1[Any, Aggregating] = {
+  infix def contain[T](atLeastOneOf: ResultOfAtLeastOneOfApplication)(using prettifier: Prettifier): MatcherFactory1[Any, Aggregating] = {
     new MatcherFactory1[Any, Aggregating] {
-      def matcher[T](implicit aggregating: Aggregating[T]): Matcher[T] = {
+      def matcher[T](using aggregating: Aggregating[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1125,7 +1125,7 @@ final class NotWord {
    **/
   infix def contain[T](atLeastOneElementOf: ResultOfAtLeastOneElementOfApplication): MatcherFactory1[Any, Aggregating] = {
     new MatcherFactory1[Any, Aggregating] {
-      def matcher[T](implicit aggregating: Aggregating[T]): Matcher[T] = {
+      def matcher[T](using aggregating: Aggregating[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1153,9 +1153,9 @@ final class NotWord {
    *                         ^
    * </pre>
    **/
-  infix def contain[T](noneOf: ResultOfNoneOfApplication)(implicit prettifier: Prettifier): MatcherFactory1[Any, Containing] = {
+  infix def contain[T](noneOf: ResultOfNoneOfApplication)(using prettifier: Prettifier): MatcherFactory1[Any, Containing] = {
     new MatcherFactory1[Any, Containing] {
-      def matcher[T](implicit containing: Containing[T]): Matcher[T] = {
+      def matcher[T](using containing: Containing[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1185,7 +1185,7 @@ final class NotWord {
    **/
   infix def contain[T](noElementsOf: ResultOfNoElementsOfApplication): MatcherFactory1[Any, Containing] = {
     new MatcherFactory1[Any, Containing] {
-      def matcher[T](implicit containing: Containing[T]): Matcher[T] = {
+      def matcher[T](using containing: Containing[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1215,7 +1215,7 @@ final class NotWord {
    **/
   infix def contain[T](theSameElementAs: ResultOfTheSameElementsAsApplication): MatcherFactory1[Any, Aggregating] = {
     new MatcherFactory1[Any, Aggregating] {
-      def matcher[T](implicit aggregating: Aggregating[T]): Matcher[T] = {
+      def matcher[T](using aggregating: Aggregating[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1245,7 +1245,7 @@ final class NotWord {
    **/
   infix def contain[T](theSameElementInOrderAs: ResultOfTheSameElementsInOrderAsApplication): MatcherFactory1[Any, Sequencing] = {
     new MatcherFactory1[Any, Sequencing] {
-      def matcher[T](implicit sequencing: Sequencing[T]): Matcher[T] = {
+      def matcher[T](using sequencing: Sequencing[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1273,9 +1273,9 @@ final class NotWord {
    *                                 ^
    * </pre>
    **/
-  infix def contain[T](only: ResultOfOnlyApplication)(implicit prettifier: Prettifier): MatcherFactory1[Any, Aggregating] = {
+  infix def contain[T](only: ResultOfOnlyApplication)(using prettifier: Prettifier): MatcherFactory1[Any, Aggregating] = {
     new MatcherFactory1[Any, Aggregating] {
-      def matcher[T](implicit aggregating: Aggregating[T]): Matcher[T] = {
+      def matcher[T](using aggregating: Aggregating[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1305,9 +1305,9 @@ final class NotWord {
    *                                 ^
    * </pre>
    **/
-  infix def contain[T](inOrderOnly: ResultOfInOrderOnlyApplication)(implicit prettifier: Prettifier): MatcherFactory1[Any, Sequencing] = {
+  infix def contain[T](inOrderOnly: ResultOfInOrderOnlyApplication)(using prettifier: Prettifier): MatcherFactory1[Any, Sequencing] = {
     new MatcherFactory1[Any, Sequencing] {
-      def matcher[T](implicit sequencing: Sequencing[T]): Matcher[T] = {
+      def matcher[T](using sequencing: Sequencing[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1335,9 +1335,9 @@ final class NotWord {
    *                                 ^
    * </pre>
    **/
-  infix def contain[T](allOf: ResultOfAllOfApplication)(implicit prettifier: Prettifier): MatcherFactory1[Any, Aggregating] = {
+  infix def contain[T](allOf: ResultOfAllOfApplication)(using prettifier: Prettifier): MatcherFactory1[Any, Aggregating] = {
     new MatcherFactory1[Any, Aggregating] {
-      def matcher[T](implicit aggregating: Aggregating[T]): Matcher[T] = {
+      def matcher[T](using aggregating: Aggregating[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1367,7 +1367,7 @@ final class NotWord {
    **/
   infix def contain(allElementsOf: ResultOfAllElementsOfApplication): MatcherFactory1[Any, Aggregating] = {
     new MatcherFactory1[Any, Aggregating] {
-      def matcher[T](implicit aggregating: Aggregating[T]): Matcher[T] = {
+      def matcher[T](using aggregating: Aggregating[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1395,9 +1395,9 @@ final class NotWord {
    *                                 ^
    * </pre>
    **/
-  infix def contain[T](inOrder: ResultOfInOrderApplication)(implicit prettifier: Prettifier): MatcherFactory1[Any, Sequencing] = {
+  infix def contain[T](inOrder: ResultOfInOrderApplication)(using prettifier: Prettifier): MatcherFactory1[Any, Sequencing] = {
     new MatcherFactory1[Any, Sequencing] {
-      def matcher[T](implicit sequencing: Sequencing[T]): Matcher[T] = {
+      def matcher[T](using sequencing: Sequencing[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1427,7 +1427,7 @@ final class NotWord {
    **/
   infix def contain(inOrderElementsOf: ResultOfInOrderElementsOfApplication): MatcherFactory1[Any, Sequencing] = {
     new MatcherFactory1[Any, Sequencing] {
-      def matcher[T](implicit sequencing: Sequencing[T]): Matcher[T] = {
+      def matcher[T](using sequencing: Sequencing[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1455,9 +1455,9 @@ final class NotWord {
    *                         ^
    * </pre>
    **/
-  infix def contain[T](atMostOneOf: ResultOfAtMostOneOfApplication)(implicit prettifier: Prettifier): MatcherFactory1[Any, Aggregating] = {
+  infix def contain[T](atMostOneOf: ResultOfAtMostOneOfApplication)(using prettifier: Prettifier): MatcherFactory1[Any, Aggregating] = {
     new MatcherFactory1[Any, Aggregating] {
-      def matcher[T](implicit aggregating: Aggregating[T]): Matcher[T] = {
+      def matcher[T](using aggregating: Aggregating[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1487,7 +1487,7 @@ final class NotWord {
    **/
   infix def contain(atMostOneElementOf: ResultOfAtMostOneElementOfApplication): MatcherFactory1[Any, Aggregating] = {
     new MatcherFactory1[Any, Aggregating] {
-      def matcher[T](implicit aggregating: Aggregating[T]): Matcher[T] = {
+      def matcher[T](using aggregating: Aggregating[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
 
@@ -1517,7 +1517,7 @@ final class NotWord {
    **/
   infix def contain(resultOfKeyWordApplication: ResultOfKeyWordApplication): MatcherFactory1[Any, KeyMapping] = {
     new MatcherFactory1[Any, KeyMapping] {
-      def matcher[T](implicit keyMapping: KeyMapping[T]): Matcher[T] = {
+      def matcher[T](using keyMapping: KeyMapping[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
             val expectedKey = resultOfKeyWordApplication.expectedKey
@@ -1545,7 +1545,7 @@ final class NotWord {
    **/
   infix def contain(resultOfValueWordApplication: ResultOfValueWordApplication): MatcherFactory1[Any, ValueMapping] = {
     new MatcherFactory1[Any, ValueMapping] {
-      def matcher[T](implicit valueMapping: ValueMapping[T]): Matcher[T] = {
+      def matcher[T](using valueMapping: ValueMapping[T]): Matcher[T] = {
         new Matcher[T] {
           def apply(left: T): MatchResult = {
             val expectedValue = resultOfValueWordApplication.expectedValue

--- a/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfNotWordForAny.scala
+++ b/dotty/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfNotWordForAny.scala
@@ -64,7 +64,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                   ^
    * </pre>
    **/
-  infix def equal(right: Any)(implicit equality: Equality[T]): Assertion = {
+  infix def equal(right: Any)(using equality: Equality[T]): Assertion = {
     if (equality.areEqual(left, right) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.didNotEqual(prettifier, left, right) else FailureMessages.equaled(prettifier, left, right), None, pos)
     else
@@ -263,7 +263,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                       ^
    * </pre>
    **/
-  infix def be[U](resultOfDefinedAt: ResultOfDefinedAt[U])(implicit ev: T <:< PartialFunction[U, _]): Assertion = {
+  infix def be[U](resultOfDefinedAt: ResultOfDefinedAt[U])(using ev: T <:< PartialFunction[U, _]): Assertion = {
     if (left.isDefinedAt(resultOfDefinedAt.right) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.wasNotDefinedAt(prettifier, left, resultOfDefinedAt.right) else FailureMessages.wasDefinedAt(prettifier, left, resultOfDefinedAt.right), None, pos)
     else
@@ -304,7 +304,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    * Enables parentheses to be placed around <code>length (N)</code> in expressions of the
    * form: <code>should not have (length (N))</code>.
    */
-  infix def have(resultOfLengthWordApplication: ResultOfLengthWordApplication)(implicit len: Length[T]): Assertion = {
+  infix def have(resultOfLengthWordApplication: ResultOfLengthWordApplication)(using len: Length[T]): Assertion = {
     val right = resultOfLengthWordApplication.expectedLength
     val leftLength = len.lengthOf(left)
     if ((leftLength == right) != shouldBeTrue)
@@ -317,7 +317,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    * Enables parentheses to be placed around <code>size (N)</code> in expressions of the
    * form: <code>should not have (size (N))</code>.
    */
-  infix def have(resultOfSizeWordApplication: ResultOfSizeWordApplication)(implicit sz: Size[T]): Assertion = {
+  infix def have(resultOfSizeWordApplication: ResultOfSizeWordApplication)(using sz: Size[T]): Assertion = {
     val right = resultOfSizeWordApplication.expectedSize
     val leftSize = sz.sizeOf(left)
     if ((leftSize == right) != shouldBeTrue)
@@ -438,7 +438,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
     }
   }
 
-  infix def have(resultOfMessageWordApplication: ResultOfMessageWordApplication)(implicit messaging: Messaging[T]): Assertion = {
+  infix def have(resultOfMessageWordApplication: ResultOfMessageWordApplication)(using messaging: Messaging[T]): Assertion = {
     val right = resultOfMessageWordApplication.expectedMessage
     val actualMessage = messaging.messageOf(left)
     if ((actualMessage == right) != shouldBeTrue)
@@ -455,7 +455,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                   ^
    * </pre>
    **/
-  infix def contain(nullValue: Null)(implicit containing: Containing[T]): Assertion = {
+  infix def contain(nullValue: Null)(using containing: Containing[T]): Assertion = {
     if (containing.contains(left, null) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.didNotContainNull(prettifier, left) else FailureMessages.containedNull(prettifier, left), None, pos)
     else
@@ -470,7 +470,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                   ^
    * </pre>
    **/
-  infix def contain(expectedElement: Any)(implicit containing: Containing[T]): Assertion = {
+  infix def contain(expectedElement: Any)(using containing: Containing[T]): Assertion = {
     val right = expectedElement
     if (containing.contains(left, right) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.didNotContainExpectedElement(prettifier, left, right) else FailureMessages.containedExpectedElement(prettifier, left, right), None, pos)
@@ -486,7 +486,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                ^
    * </pre>
    **/
-  infix def be(o: Null)(implicit ev: T <:< AnyRef): Assertion = {
+  infix def be(o: Null)(using ev: T <:< AnyRef): Assertion = {
     if ((left == null) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.wasNotNull(prettifier, left) else FailureMessages.wasNull, None, pos)
     else
@@ -502,7 +502,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                  ^
    * </pre>
    **/
-  infix def be(symbol: Symbol)(implicit toAnyRef: T <:< AnyRef, prettifier: Prettifier, pos: source.Position): Assertion = {
+  infix def be(symbol: Symbol)(using toAnyRef: T <:< AnyRef, prettifier: Prettifier, pos: source.Position): Assertion = {
     val matcherResult = matchSymbolToPredicateMethod(toAnyRef(left), symbol, false, false, prettifier, pos)
     if (matcherResult.matches != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) matcherResult.failureMessage(prettifier) else matcherResult.negatedFailureMessage(prettifier), None, pos)
@@ -520,7 +520,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                      ^
    * </pre>
    **/
-  infix def be(bePropertyMatcher: BePropertyMatcher[T])(implicit ev: T <:< AnyRef): Assertion = {
+  infix def be(bePropertyMatcher: BePropertyMatcher[T])(using ev: T <:< AnyRef): Assertion = {
     val result = bePropertyMatcher(left)
     if (result.matches != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.wasNot(prettifier, left, UnquotedString(result.propertyName)) else FailureMessages.was(prettifier, left, UnquotedString(result.propertyName)), None, pos)
@@ -537,7 +537,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                        ^
    * </pre>
    **/
-  infix def be(resultOfAWordApplication: ResultOfAWordToSymbolApplication)(implicit toAnyRef: T <:< AnyRef, prettifier: Prettifier, pos: source.Position): Assertion = {
+  infix def be(resultOfAWordApplication: ResultOfAWordToSymbolApplication)(using toAnyRef: T <:< AnyRef, prettifier: Prettifier, pos: source.Position): Assertion = {
     val matcherResult = matchSymbolToPredicateMethod(toAnyRef(left), resultOfAWordApplication.symbol, true, true, prettifier, pos)
     if (matcherResult.matches != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) matcherResult.failureMessage(prettifier) else matcherResult.negatedFailureMessage(prettifier), None, pos)
@@ -555,7 +555,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                        ^
    * </pre>
    **/
-  infix def be[U >: T](resultOfAWordApplication: ResultOfAWordToBePropertyMatcherApplication[U])(implicit ev: T <:< AnyRef): Assertion = {
+  infix def be[U >: T](resultOfAWordApplication: ResultOfAWordToBePropertyMatcherApplication[U])(using ev: T <:< AnyRef): Assertion = {
     val result = resultOfAWordApplication.bePropertyMatcher(left)
     if (result.matches != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.wasNotA(prettifier, left, UnquotedString(result.propertyName)) else FailureMessages.wasA(prettifier, left, UnquotedString(result.propertyName)), None, pos)
@@ -572,7 +572,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                     ^
    * </pre>
    **/
-  infix def be(resultOfAnWordApplication: ResultOfAnWordToSymbolApplication)(implicit toAnyRef: T <:< AnyRef, prettifier: Prettifier, pos: source.Position): Assertion = {
+  infix def be(resultOfAnWordApplication: ResultOfAnWordToSymbolApplication)(using toAnyRef: T <:< AnyRef, prettifier: Prettifier, pos: source.Position): Assertion = {
     val matcherResult = matchSymbolToPredicateMethod(toAnyRef(left), resultOfAnWordApplication.symbol, true, false, prettifier, pos)
     if (matcherResult.matches != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) matcherResult.failureMessage(prettifier) else matcherResult.negatedFailureMessage(prettifier), None, pos)
@@ -590,7 +590,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                     ^
    * </pre>
    **/
-  infix def be[U >: T](resultOfAnWordApplication: ResultOfAnWordToBePropertyMatcherApplication[U])(implicit ev: T <:< AnyRef): Assertion = {
+  infix def be[U >: T](resultOfAnWordApplication: ResultOfAnWordToBePropertyMatcherApplication[U])(using ev: T <:< AnyRef): Assertion = {
     val result = resultOfAnWordApplication.bePropertyMatcher(left)
     if (result.matches != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.wasNotAn(prettifier, left, UnquotedString(result.propertyName)) else FailureMessages.wasAn(prettifier, left, UnquotedString(result.propertyName)), None, pos)
@@ -606,7 +606,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                        ^
    * </pre>
    **/
-  infix def be(resultOfSameInstanceAsApplication: ResultOfTheSameInstanceAsApplication)(implicit toAnyRef: T <:< AnyRef): Assertion = {
+  infix def be(resultOfSameInstanceAsApplication: ResultOfTheSameInstanceAsApplication)(using toAnyRef: T <:< AnyRef): Assertion = {
     if ((resultOfSameInstanceAsApplication.right eq toAnyRef(left)) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.wasNotSameInstanceAs(prettifier, left, resultOfSameInstanceAsApplication.right) else FailureMessages.wasSameInstanceAs(prettifier, left, resultOfSameInstanceAsApplication.right), None, pos)
     else
@@ -621,7 +621,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                  ^
    * </pre>
    **/
-  infix def be[U](sortedWord: SortedWord)(implicit sortable: Sortable[T]): Assertion = {
+  infix def be[U](sortedWord: SortedWord)(using sortable: Sortable[T]): Assertion = {
     if (sortable.isSorted(left) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.wasNotSorted(prettifier, left) else FailureMessages.wasSorted(prettifier, left), None, pos)
     else
@@ -636,7 +636,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                    ^
    * </pre>
    **/
-  infix def be[U](readableWord: ReadableWord)(implicit readability: Readability[T]): Assertion = {
+  infix def be[U](readableWord: ReadableWord)(using readability: Readability[T]): Assertion = {
     if (readability.isReadable(left) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.wasNotReadable(prettifier, left) else FailureMessages.wasReadable(prettifier, left), None, pos)
     else
@@ -651,7 +651,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                    ^
    * </pre>
    **/
-  infix def be[U](writableWord: WritableWord)(implicit writability: Writability[T]): Assertion = {
+  infix def be[U](writableWord: WritableWord)(using writability: Writability[T]): Assertion = {
     if (writability.isWritable(left) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.wasNotWritable(prettifier, left) else FailureMessages.wasWritable(prettifier, left), None, pos)
     else
@@ -666,7 +666,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                    ^
    * </pre>
    **/
-  infix def be[U](emptyWord: EmptyWord)(implicit emptiness: Emptiness[T]): Assertion = {
+  infix def be[U](emptyWord: EmptyWord)(using emptiness: Emptiness[T]): Assertion = {
     if (emptiness.isEmpty(left) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.wasNotEmpty(prettifier, left) else FailureMessages.wasEmpty(prettifier, left), None, pos)
     else
@@ -681,14 +681,14 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                      ^
    * </pre>
    **/
-  infix def be[U](definedWord: DefinedWord)(implicit definition: Definition[T]): Assertion = {
+  infix def be[U](definedWord: DefinedWord)(using definition: Definition[T]): Assertion = {
     if (definition.isDefined(left) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.wasNotDefined(prettifier, left) else FailureMessages.wasDefined(prettifier, left), None, pos)
     else
       indicateSuccess(shouldBeTrue, FailureMessages.wasDefined(prettifier, left), FailureMessages.wasNotDefined(prettifier, left))
   }
 
-  infix def contain(newOneOf: ResultOfOneOfApplication)(implicit containing: Containing[T]): Assertion = {
+  infix def contain(newOneOf: ResultOfOneOfApplication)(using containing: Containing[T]): Assertion = {
 
     val right = newOneOf.right
 
@@ -709,7 +709,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
       )
   }
 
-  infix def contain(oneElementOf: ResultOfOneElementOfApplication)(implicit evidence: Containing[T]): Assertion = {
+  infix def contain(oneElementOf: ResultOfOneElementOfApplication)(using evidence: Containing[T]): Assertion = {
 
     val right = oneElementOf.right
 
@@ -750,7 +750,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
       indicateSuccess(shouldBeTrue, FailureMessages.containedAtLeastOneElementOf(prettifier, left, right), FailureMessages.didNotContainAtLeastOneElementOf(prettifier, left, right))
   }
 
-  infix def contain(noneOf: ResultOfNoneOfApplication)(implicit containing: Containing[T]): Assertion = {
+  infix def contain(noneOf: ResultOfNoneOfApplication)(using containing: Containing[T]): Assertion = {
 
     val right = noneOf.right
 
@@ -771,7 +771,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
       )
   }
 
-  infix def contain(noElementsOf: ResultOfNoElementsOfApplication)(implicit containing: Containing[T]): Assertion = {
+  infix def contain(noElementsOf: ResultOfNoElementsOfApplication)(using containing: Containing[T]): Assertion = {
 
     val right = noElementsOf.right
 
@@ -791,7 +791,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
       indicateSuccess(shouldBeTrue, FailureMessages.containedSameElements(prettifier, left, right), FailureMessages.didNotContainSameElements(prettifier, left, right))
   }
 
-  infix def contain(theSameElementsInOrderAs: ResultOfTheSameElementsInOrderAsApplication)(implicit sequencing: Sequencing[T]): Assertion = {
+  infix def contain(theSameElementsInOrderAs: ResultOfTheSameElementsInOrderAsApplication)(using sequencing: Sequencing[T]): Assertion = {
 
     val right = theSameElementsInOrderAs.right
 
@@ -835,7 +835,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
       )
   }
 
-  infix def contain(only: ResultOfInOrderOnlyApplication)(implicit sequencing: Sequencing[T]): Assertion = {
+  infix def contain(only: ResultOfInOrderOnlyApplication)(using sequencing: Sequencing[T]): Assertion = {
     val right = only.right
     if (sequencing.containsInOrderOnly(left, right) != shouldBeTrue)
       indicateFailure(
@@ -883,7 +883,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
       indicateSuccess(shouldBeTrue, FailureMessages.containedAllElementsOf(prettifier, left, right), FailureMessages.didNotContainAllElementsOf(prettifier, left, right))
   }
 
-  infix def contain(only: ResultOfInOrderApplication)(implicit sequencing: Sequencing[T]): Assertion = {
+  infix def contain(only: ResultOfInOrderApplication)(using sequencing: Sequencing[T]): Assertion = {
 
     val right = only.right
     if (sequencing.containsInOrder(left, right) != shouldBeTrue)
@@ -903,7 +903,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
       )
   }
 
-  infix def contain(only: ResultOfInOrderElementsOfApplication)(implicit sequencing: Sequencing[T]): Assertion = {
+  infix def contain(only: ResultOfInOrderElementsOfApplication)(using sequencing: Sequencing[T]): Assertion = {
 
     val right = only.right
     if (sequencing.containsInOrder(left, right.distinct) != shouldBeTrue)
@@ -943,14 +943,14 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
       indicateSuccess(shouldBeTrue, FailureMessages.containedAtMostOneElementOf(prettifier, left, right), FailureMessages.didNotContainAtMostOneElementOf(prettifier, left, right))
   }
 
-  infix def contain(resultOfKeyWordApplication: ResultOfKeyWordApplication)(implicit keyMapping: KeyMapping[T]): Assertion = {
+  infix def contain(resultOfKeyWordApplication: ResultOfKeyWordApplication)(using keyMapping: KeyMapping[T]): Assertion = {
     val right = resultOfKeyWordApplication.expectedKey
     if (keyMapping.containsKey(left, right) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.didNotContainKey(prettifier, left, right) else FailureMessages.containedKey(prettifier, left, right), None, pos)
     else
       indicateSuccess(shouldBeTrue, FailureMessages.containedKey(prettifier, left, right), FailureMessages.didNotContainKey(prettifier, left, right))
   }
-  infix def contain(resultOfValueWordApplication: ResultOfValueWordApplication)(implicit valueMapping: ValueMapping[T]): Assertion = {
+  infix def contain(resultOfValueWordApplication: ResultOfValueWordApplication)(using valueMapping: ValueMapping[T]): Assertion = {
     val right = resultOfValueWordApplication.expectedValue
     if (valueMapping.containsValue(left, right) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.didNotContainValue(prettifier, left, right) else FailureMessages.containedValue(prettifier, left, right), None, pos)
@@ -971,7 +971,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    * or a <code>scala.util.matching.Regex</code>.
    * </p>
    */
-  infix def fullyMatch(resultOfRegexWordApplication: ResultOfRegexWordApplication)(implicit ev: T <:< String): Assertion = {
+  infix def fullyMatch(resultOfRegexWordApplication: ResultOfRegexWordApplication)(using ev: T <:< String): Assertion = {
     val result = fullyMatchRegexWithGroups(left, resultOfRegexWordApplication.regex, resultOfRegexWordApplication.groups)
     if (result.matches != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) result.failureMessage(prettifier) else result.negatedFailureMessage(prettifier), None, pos)
@@ -992,7 +992,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    * or a <code>scala.util.matching.Regex</code>.
    * </p>
    */
-  infix def include(resultOfRegexWordApplication: ResultOfRegexWordApplication)(implicit ev: T <:< String): Assertion = {
+  infix def include(resultOfRegexWordApplication: ResultOfRegexWordApplication)(using ev: T <:< String): Assertion = {
     val result = includeRegexWithGroups(left, resultOfRegexWordApplication.regex, resultOfRegexWordApplication.groups)
     if (result.matches != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) result.failureMessage(prettifier) else result.negatedFailureMessage(prettifier), None, pos)
@@ -1008,7 +1008,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                   ^
    * </pre>
    **/
-  infix def include(expectedSubstring: String)(implicit ev: T <:< String): Assertion = {
+  infix def include(expectedSubstring: String)(using ev: T <:< String): Assertion = {
     if ((left.indexOf(expectedSubstring) >= 0) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.didNotIncludeSubstring(prettifier, left, expectedSubstring) else FailureMessages.includedSubstring(prettifier, left, expectedSubstring), None, pos)
     else
@@ -1028,7 +1028,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    * or a <code>scala.util.matching.Regex</code>.
    * </p>
    */
-  infix def startWith(resultOfRegexWordApplication: ResultOfRegexWordApplication)(implicit ev: T <:< String): Assertion = {
+  infix def startWith(resultOfRegexWordApplication: ResultOfRegexWordApplication)(using ev: T <:< String): Assertion = {
     val result = startWithRegexWithGroups(left, resultOfRegexWordApplication.regex, resultOfRegexWordApplication.groups)
     if (result.matches != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) result.failureMessage(prettifier) else result.negatedFailureMessage(prettifier), None, pos)
@@ -1044,7 +1044,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                    ^
    * </pre>
    **/
-  infix def startWith(expectedSubstring: String)(implicit ev: T <:< String): Assertion = {
+  infix def startWith(expectedSubstring: String)(using ev: T <:< String): Assertion = {
     if ((left.indexOf(expectedSubstring) == 0) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.didNotStartWith(prettifier, left, expectedSubstring) else FailureMessages.startedWith(prettifier, left, expectedSubstring), None, pos)
     else
@@ -1059,7 +1059,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                     ^
    * </pre>
    **/
-  infix def endWith(resultOfRegexWordApplication: ResultOfRegexWordApplication)(implicit ev: T <:< String): Assertion = {
+  infix def endWith(resultOfRegexWordApplication: ResultOfRegexWordApplication)(using ev: T <:< String): Assertion = {
     val result = endWithRegexWithGroups(left, resultOfRegexWordApplication.regex, resultOfRegexWordApplication.groups)
     if (result.matches != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) result.failureMessage(prettifier) else result.negatedFailureMessage(prettifier), None, pos)
@@ -1075,7 +1075,7 @@ final class ResultOfNotWordForAny[T](val left: T, val shouldBeTrue: Boolean, val
    *                    ^
    * </pre>
    **/
-  infix def endWith(expectedSubstring: String)(implicit ev: T <:< String): Assertion = {
+  infix def endWith(expectedSubstring: String)(using ev: T <:< String): Assertion = {
     if ((left endsWith expectedSubstring) != shouldBeTrue)
       indicateFailure(if (shouldBeTrue) FailureMessages.didNotEndWith(prettifier, left, expectedSubstring) else FailureMessages.endedWith(prettifier, left, expectedSubstring), None, pos)
     else

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ContainWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ContainWord.scala
@@ -45,7 +45,7 @@ final class ContainWord {
    *                     ^
    * </pre>
    **/
-  def apply(nullValue: Null): MatcherFactory1[Any, Containing] =
+  /* DOTTY-ONLY infix */ def apply(nullValue: Null): MatcherFactory1[Any, Containing] =
     new MatcherFactory1[Any, Containing] {
       def matcher[U <: Any : Containing]: Matcher[U] =
         new Matcher[U] {
@@ -71,7 +71,7 @@ final class ContainWord {
    *                             ^
    * </pre>
    **/ 
-  def apply(expectedElement: Any): MatcherFactory1[Any, Containing] =
+  /* DOTTY-ONLY infix */ def apply(expectedElement: Any): MatcherFactory1[Any, Containing] =
     new MatcherFactory1[Any, Containing] {
       def matcher[U <: Any : Containing]: Matcher[U] = 
         new Matcher[U] {
@@ -90,7 +90,7 @@ final class ContainWord {
       override def toString: String = "contain (" + Prettifier.default(expectedElement) + ")"
     }
 
-  def apply(expectedElement: String): MatcherFactory1[Any, Containing] =
+  /* DOTTY-ONLY infix */ def apply(expectedElement: String): MatcherFactory1[Any, Containing] =
     new MatcherFactory1[Any, Containing] {
       def matcher[U <: Any : Containing]: Matcher[U] = 
         new Matcher[U] {
@@ -136,10 +136,7 @@ final class ContainWord {
    * This will enable the matcher returned by this method to be used against any <code>Map</code> that has
    * the inferred key type.
    */
-  //DOTTY-ONLY infix def key[K](expectedKey: Any): MatcherFactory1[Any, KeyMapping] = 
-  // SKIP-DOTTY-START 
-  def key[K](expectedKey: Any): MatcherFactory1[Any, KeyMapping] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def key[K](expectedKey: Any): MatcherFactory1[Any, KeyMapping] =
     new MatcherFactory1[Any, KeyMapping] {
       def matcher[U <: Any : KeyMapping]: Matcher[U] = 
         new Matcher[U] {
@@ -186,10 +183,7 @@ final class ContainWord {
    * the inferred value type.
    *
    */
-  //DOTTY-ONLY infix def value[K](expectedValue: Any): MatcherFactory1[Any, ValueMapping] =
-  // SKIP-DOTTY-START 
-  def value[K](expectedValue: Any): MatcherFactory1[Any, ValueMapping] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def value[K](expectedValue: Any): MatcherFactory1[Any, ValueMapping] =
     new MatcherFactory1[Any, ValueMapping] {
       def matcher[U <: Any : ValueMapping]: Matcher[U] = 
         new Matcher[U] {
@@ -216,10 +210,7 @@ final class ContainWord {
    *                                ^
    * </pre>
    **/
-  //DOTTY-ONLY infix private[scalatest] def a[T](aMatcher: AMatcher[T]): Matcher[Iterable[T]] =
-  // SKIP-DOTTY-START 
-  private[scalatest] def a[T](aMatcher: AMatcher[T]): Matcher[Iterable[T]] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ private[scalatest] def a[T](aMatcher: AMatcher[T]): Matcher[Iterable[T]] =
     new Matcher[Iterable[T]] {
       def apply(left: Iterable[T]): MatchResult = {
         val matched = left.find(aMatcher(_).matches)
@@ -242,10 +233,7 @@ final class ContainWord {
    *                                ^
    * </pre>
    **/
-  //DOTTY-ONLY infix private[scalatest] def an[T](anMatcher: AnMatcher[T]): Matcher[Iterable[T]] =
-  // SKIP-DOTTY-START 
-  private[scalatest] def an[T](anMatcher: AnMatcher[T]): Matcher[Iterable[T]] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ private[scalatest] def an[T](anMatcher: AnMatcher[T]): Matcher[Iterable[T]] =
     new Matcher[Iterable[T]] {
       def apply(left: Iterable[T]): MatchResult = {
         val matched = left.find(anMatcher(_).matches)
@@ -260,7 +248,7 @@ final class ContainWord {
       override def toString: String = "contain an " + Prettifier.default(anMatcher)
     }
 
-  //DOTTY-ONLY infix def oneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Containing] = {
+  //DOTTY-ONLY infix def oneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Containing] = {
   // SKIP-DOTTY-START
   def oneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Containing] = {
   // SKIP-DOTTY-END  
@@ -286,10 +274,7 @@ final class ContainWord {
     }
   }
 
-  //DOTTY-ONLY infix def oneElementOf(elements: Iterable[Any]): MatcherFactory1[Any, Containing] = {
-  // SKIP-DOTTY-START
-  def oneElementOf(elements: Iterable[Any]): MatcherFactory1[Any, Containing] = {
-  // SKIP-DOTTY-END  
+  /* DOTTY-ONLY infix */ def oneElementOf(elements: Iterable[Any]): MatcherFactory1[Any, Containing] = {
     val right = elements.toList
     new MatcherFactory1[Any, Containing] {
       def matcher[T](implicit containing: Containing[T]): Matcher[T] = {
@@ -310,7 +295,7 @@ final class ContainWord {
     }
   }
 
-  //DOTTY-ONLY infix def atLeastOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Aggregating] = {
+  //DOTTY-ONLY infix def atLeastOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Aggregating] = {
   // SKIP-DOTTY-START
   def atLeastOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Aggregating] = {
   // SKIP-DOTTY-END  
@@ -336,10 +321,7 @@ final class ContainWord {
     }
   }
 
-  //DOTTY-ONLY infix def atLeastOneElementOf(elements: Iterable[Any]): MatcherFactory1[Any, Aggregating] = {
-  // SKIP-DOTTY-START
-  def atLeastOneElementOf(elements: Iterable[Any]): MatcherFactory1[Any, Aggregating] = {
-  // SKIP-DOTTY-END  
+  /* DOTTY-ONLY infix */ def atLeastOneElementOf(elements: Iterable[Any]): MatcherFactory1[Any, Aggregating] = {
     val right = elements.toList
     new MatcherFactory1[Any, Aggregating] {
       def matcher[T](implicit aggregating: Aggregating[T]): Matcher[T] = {
@@ -360,7 +342,7 @@ final class ContainWord {
     }
   }
   
-  //DOTTY-ONLY infix def noneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Containing] = {
+  //DOTTY-ONLY infix def noneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Containing] = {
   // SKIP-DOTTY-START
   def noneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Containing] = {
   // SKIP-DOTTY-END  
@@ -456,7 +438,7 @@ final class ContainWord {
     }
   }
   
-  //DOTTY-ONLY infix def only(right: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Aggregating] = {
+  //DOTTY-ONLY infix def only(right: Any*)(using prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Aggregating] = {
   // SKIP-DOTTY-START
   def only(right: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Aggregating] = {
   // SKIP-DOTTY-END  
@@ -484,7 +466,7 @@ final class ContainWord {
     }
   }
 
-  //DOTTY-ONLY infix def inOrderOnly(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Sequencing] = {
+  //DOTTY-ONLY infix def inOrderOnly(firstEle: Any, secondEle: Any, remainingEles: Any*)(using prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Sequencing] = {
   // SKIP-DOTTY-START
   def inOrderOnly(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Sequencing] = {
   // SKIP-DOTTY-END  
@@ -510,7 +492,7 @@ final class ContainWord {
     }
   }
   
-  //DOTTY-ONLY infix def allOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Aggregating] = {
+  //DOTTY-ONLY infix def allOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Aggregating] = {
   // SKIP-DOTTY-START
   def allOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Aggregating] = {
   // SKIP-DOTTY-END
@@ -560,7 +542,7 @@ final class ContainWord {
     }
   }
   
-  //DOTTY-ONLY infix def inOrder(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Sequencing] = {
+  //DOTTY-ONLY infix def inOrder(firstEle: Any, secondEle: Any, remainingEles: Any*)(using prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Sequencing] = {
   // SKIP-DOTTY-START
   def inOrder(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Sequencing] = {
   // SKIP-DOTTY-END  
@@ -586,10 +568,7 @@ final class ContainWord {
     }
   }
 
-  //DOTTY-ONLY infix def inOrderElementsOf(elements: Iterable[Any]): MatcherFactory1[Any, Sequencing] = {
-  // SKIP-DOTTY-START
-  def inOrderElementsOf(elements: Iterable[Any]): MatcherFactory1[Any, Sequencing] = {
-  // SKIP-DOTTY-END  
+  /* DOTTY-ONLY infix */ def inOrderElementsOf(elements: Iterable[Any]): MatcherFactory1[Any, Sequencing] = {
     val right = elements.toList
     new MatcherFactory1[Any, Sequencing] {
       def matcher[T](implicit sequencing: Sequencing[T]): Matcher[T] = {
@@ -610,7 +589,7 @@ final class ContainWord {
     }
   }
   
-  //DOTTY-ONLY infix def atMostOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Aggregating] = {
+  //DOTTY-ONLY infix def atMostOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Aggregating] = {
   // SKIP-DOTTY-START
   def atMostOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit prettifier: Prettifier, pos: source.Position): MatcherFactory1[Any, Aggregating] = {
   // SKIP-DOTTY-END  
@@ -636,10 +615,7 @@ final class ContainWord {
     }
   }
 
-  //DOTTY-ONLY infix def atMostOneElementOf(elements: Iterable[Any]): MatcherFactory1[Any, Aggregating] = {
-  // SKIP-DOTTY-START
-  def atMostOneElementOf(elements: Iterable[Any]): MatcherFactory1[Any, Aggregating] = {
-  // SKIP-DOTTY-END  
+  /* DOTTY-ONLY infix */ def atMostOneElementOf(elements: Iterable[Any]): MatcherFactory1[Any, Aggregating] = {
     val right = elements.toList
     new MatcherFactory1[Any, Aggregating] {
       def matcher[T](implicit aggregating: Aggregating[T]): Matcher[T] = {

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/EndWithWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/EndWithWord.scala
@@ -39,7 +39,7 @@ final class EndWithWord {
    *                        ^
    * </pre>
    */ 
-  def apply(right: String): Matcher[String] =
+  /* DOTTY-ONLY infix */ def apply(right: String): Matcher[String] =
     new Matcher[String] {
       def apply(left: String): MatchResult =
         MatchResult(
@@ -60,11 +60,8 @@ final class EndWithWord {
    *                        ^
    * </pre>
    */
-  //DOTTY-ONLY infix def regex[T <: String](right: T): Matcher[T] = regex(right.r)
-  // SKIP-DOTTY-START 
-  def regex[T <: String](right: T): Matcher[T] = regex(right.r)
-  // SKIP-DOTTY-END
-  
+  /* DOTTY-ONLY infix */ def regex[T <: String](right: T): Matcher[T] = regex(right.r)
+
   /**
    * This method enables the following syntax:
    *
@@ -73,16 +70,12 @@ final class EndWithWord {
    *                             ^
    * </pre>
    */
-  //DOTTY-ONLY infix def regex(regexWithGroups: RegexWithGroups) = 
-  // SKIP-DOTTY-START 	
-  def regex(regexWithGroups: RegexWithGroups) = 
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def regex(regexWithGroups: RegexWithGroups) = 
     new Matcher[String] {
       def apply(left: String): MatchResult = 
         endWithRegexWithGroups(left, regexWithGroups.regex, regexWithGroups.groups)
       override def toString: String = "endWith regex " + Prettifier.default(regexWithGroups)
     }
-  // SKIP-DOTTY-END  
 
   /**
    * This method enables the following syntax:
@@ -93,10 +86,7 @@ final class EndWithWord {
    *                        ^
    * </pre>
    */
-  //DOTTY-ONLY infix def regex(rightRegex: Regex): Matcher[String] = 
-  // SKIP-DOTTY-START 
-  def regex(rightRegex: Regex): Matcher[String] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def regex(rightRegex: Regex): Matcher[String] =
     new Matcher[String] {
       def apply(left: String): MatchResult = {
         val allMatches = rightRegex.findAllIn(left)

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ExistWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ExistWord.scala
@@ -57,10 +57,7 @@ final class ExistWord {
    *                    ^
    * </pre>
    */
-  //DOTTY-ONLY infix def and[TYPECLASS1[_]](anotherMatcherFactory: MatcherFactory1[Any, TYPECLASS1]): MatcherFactory2[Any, Existence, TYPECLASS1] = 
-  // SKIP-DOTTY-START 
-  def and[TYPECLASS1[_]](anotherMatcherFactory: MatcherFactory1[Any, TYPECLASS1]): MatcherFactory2[Any, Existence, TYPECLASS1] = 
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def and[TYPECLASS1[_]](anotherMatcherFactory: MatcherFactory1[Any, TYPECLASS1]): MatcherFactory2[Any, Existence, TYPECLASS1] = 
     matcherFactory.and(anotherMatcherFactory)
   
   /**
@@ -71,10 +68,7 @@ final class ExistWord {
    *                    ^
    * </pre>
    */
-  //DOTTY-ONLY infix def and(anotherMatcher: Matcher[Any]): MatcherFactory1[Any, Existence] = 
-  // SKIP-DOTTY-START 
-  def and(anotherMatcher: Matcher[Any]): MatcherFactory1[Any, Existence] = 
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def and(anotherMatcher: Matcher[Any]): MatcherFactory1[Any, Existence] = 
     matcherFactory.and(anotherMatcher)  
     
   /**
@@ -85,10 +79,7 @@ final class ExistWord {
    *                    ^
    * </pre>
    */
-  //DOTTY-ONLY infix def or[TYPECLASS1[_]](anotherMatcherFactory: MatcherFactory1[Any, TYPECLASS1]): MatcherFactory2[Any, Existence, TYPECLASS1] =  
-  // SKIP-DOTTY-START 
-  def or[TYPECLASS1[_]](anotherMatcherFactory: MatcherFactory1[Any, TYPECLASS1]): MatcherFactory2[Any, Existence, TYPECLASS1] = 
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def or[TYPECLASS1[_]](anotherMatcherFactory: MatcherFactory1[Any, TYPECLASS1]): MatcherFactory2[Any, Existence, TYPECLASS1] = 
     matcherFactory.or(anotherMatcherFactory)
     
   /**
@@ -99,9 +90,6 @@ final class ExistWord {
    *                    ^
    * </pre>
    */
-  //DOTTY-ONLY infix def or(anotherMatcher: Matcher[Any]): MatcherFactory1[Any, Existence] = 
-  // SKIP-DOTTY-START 
-  def or(anotherMatcher: Matcher[Any]): MatcherFactory1[Any, Existence] = 
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def or(anotherMatcher: Matcher[Any]): MatcherFactory1[Any, Existence] = 
     matcherFactory.or(anotherMatcher)
 }

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/FullyMatchWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/FullyMatchWord.scala
@@ -39,10 +39,7 @@ final class FullyMatchWord {
    *                          ^
    * </pre>
    */
-  //DOTTY-ONLY infix def regex(rightRegexString: String): Matcher[String] =
-  // SKIP-DOTTY-START 
-  def regex(rightRegexString: String): Matcher[String] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def regex(rightRegexString: String): Matcher[String] =
     new Matcher[String] {
       def apply(left: String): MatchResult =
         MatchResult(
@@ -62,10 +59,7 @@ final class FullyMatchWord {
    *                          ^
    * </pre>
    */
-  //DOTTY-ONLY infix def regex(regexWithGroups: RegexWithGroups) = 
-  // SKIP-DOTTY-START 	
-  def regex(regexWithGroups: RegexWithGroups) = 
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def regex(regexWithGroups: RegexWithGroups) = 
     new Matcher[String] {
       def apply(left: String): MatchResult = 
         fullyMatchRegexWithGroups(left, regexWithGroups.regex, regexWithGroups.groups)
@@ -81,10 +75,7 @@ final class FullyMatchWord {
    *                          ^
    * </pre>
    */
-  //DOTTY-ONLY infix def regex(rightRegex: Regex): Matcher[String] =
-  // SKIP-DOTTY-START 
-  def regex(rightRegex: Regex): Matcher[String] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def regex(rightRegex: Regex): Matcher[String] =
     new Matcher[String] {
       def apply(left: String): MatchResult =
         MatchResult(

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/HaveWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/HaveWord.scala
@@ -39,10 +39,7 @@ final class HaveWord {
    *                  ^
    * </pre>
    */
-  //DOTTY-ONLY infix def length(expectedLength: Long): MatcherFactory1[Any, Length] =
-  // SKIP-DOTTY-START 
-  def length(expectedLength: Long): MatcherFactory1[Any, Length] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def length(expectedLength: Long): MatcherFactory1[Any, Length] =
     new MatcherFactory1[Any, Length] {
       def matcher[T <: Any : Length]: Matcher[T] = {
         val length = implicitly[Length[T]]
@@ -78,10 +75,7 @@ final class HaveWord {
    * In a future ScalaTest release, this may be tightened so that all is statically checked at compile time.
    * </p>
    */
-  //DOTTY-ONLY infix def size(expectedSize: Long): MatcherFactory1[Any, Size] =
-  // SKIP-DOTTY-START 
-  def size(expectedSize: Long): MatcherFactory1[Any, Size] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def size(expectedSize: Long): MatcherFactory1[Any, Size] =
     new MatcherFactory1[Any, Size] {
       def matcher[T <: Any : Size]: Matcher[T] = {
         val size = implicitly[Size[T]]
@@ -110,10 +104,7 @@ final class HaveWord {
    *                    ^
    * </pre>
    */
-  //DOTTY-ONLY infix def message(expectedMessage: String): MatcherFactory1[Any, Messaging] =
-  // SKIP-DOTTY-START 
-  def message(expectedMessage: String): MatcherFactory1[Any, Messaging] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def message(expectedMessage: String): MatcherFactory1[Any, Messaging] =
     new MatcherFactory1[Any, Messaging] {
       def matcher[T <: Any : Messaging]: Matcher[T] = {
         val messaging = implicitly[Messaging[T]]
@@ -137,12 +128,12 @@ final class HaveWord {
   /**
    * Enables parentheses to be placed around <code>length (N)</code> in expressions of the form: <code>should have (length (N))</code>.
    */ 
-  def apply[T](resultOfLengthWordApplication: ResultOfLengthWordApplication): MatcherFactory1[Any, Length] = length(resultOfLengthWordApplication.expectedLength)
+  /* DOTTY-ONLY infix */ def apply[T](resultOfLengthWordApplication: ResultOfLengthWordApplication): MatcherFactory1[Any, Length] = length(resultOfLengthWordApplication.expectedLength)
 
   /**
    * Enables parentheses to be placed around <code>size (N)</code> in expressions of the form: <code>should have (size (N))</code>.
    */ 
-  def apply[T](resultOfSizeWordApplication: ResultOfSizeWordApplication): MatcherFactory1[Any, Size] = size(resultOfSizeWordApplication.expectedSize)
+  /* DOTTY-ONLY infix */ def apply[T](resultOfSizeWordApplication: ResultOfSizeWordApplication): MatcherFactory1[Any, Size] = size(resultOfSizeWordApplication.expectedSize)
 
   /**
    * This method enables the following syntax:
@@ -152,7 +143,7 @@ final class HaveWord {
    *                  ^
    * </pre>
    */
-  def apply[T](firstPropertyMatcher: HavePropertyMatcher[T, _], propertyMatchers: HavePropertyMatcher[T, _]*): Matcher[T] =
+  /* DOTTY-ONLY infix */ def apply[T](firstPropertyMatcher: HavePropertyMatcher[T, _], propertyMatchers: HavePropertyMatcher[T, _]*): Matcher[T] =
 
     new Matcher[T] {
 

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/IncludeWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/IncludeWord.scala
@@ -38,7 +38,7 @@ final class IncludeWord {
    *                       ^
    * </pre>
    */ 
-  def apply(expectedSubstring: String): Matcher[String] =
+  /* DOTTY-ONLY infix */ def apply(expectedSubstring: String): Matcher[String] =
     new Matcher[String] {
       def apply(left: String): MatchResult =
         MatchResult(
@@ -59,10 +59,7 @@ final class IncludeWord {
    *                         ^
    * </pre>
    */
-  //DOTTY-ONLY infix def regex[T <: String](right: T): Matcher[T] = regex(right.r)
-  // SKIP-DOTTY-START 
-  def regex[T <: String](right: T): Matcher[T] = regex(right.r)
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def regex[T <: String](right: T): Matcher[T] = regex(right.r)
   
   /**
    * This method enables the following syntax:
@@ -72,10 +69,7 @@ final class IncludeWord {
    *                             ^
    * </pre>
    */
-  //DOTTY-ONLY infix def regex(regexWithGroups: RegexWithGroups) = 
-  // SKIP-DOTTY-START 	
-  def regex(regexWithGroups: RegexWithGroups) = 
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def regex(regexWithGroups: RegexWithGroups) = 
     new Matcher[String] {
       def apply(left: String): MatchResult = 
         includeRegexWithGroups(left, regexWithGroups.regex, regexWithGroups.groups)
@@ -91,10 +85,7 @@ final class IncludeWord {
    *                        ^
    * </pre>
    */
-  //DOTTY-ONLY infix def regex(expectedRegex: Regex): Matcher[String] =
-  // SKIP-DOTTY-START 
-  def regex(expectedRegex: Regex): Matcher[String] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def regex(expectedRegex: Regex): Matcher[String] =
     new Matcher[String] {
       def apply(left: String): MatchResult =
         MatchResult(

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/LengthWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/LengthWord.scala
@@ -31,7 +31,7 @@ final class LengthWord {
    *                             ^
    * </pre>
    */ 
-  def apply(expectedLength: Long): ResultOfLengthWordApplication = new ResultOfLengthWordApplication(expectedLength)
+  /* DOTTY-ONLY infix */ def apply(expectedLength: Long): ResultOfLengthWordApplication = new ResultOfLengthWordApplication(expectedLength)
   
   /**
    * Overrides toString to return "length"

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/MatcherWords.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/MatcherWords.scala
@@ -179,8 +179,11 @@ trait MatcherWords {
    * ^
    * </pre>
    **/
+  //DOTTY-ONLY def noException(implicit pos: source.Position) = new NoExceptionWord(pos)
+  // SKIP-DOTTY-START
   def noException(implicit pos: source.Position) = new NoExceptionWord(pos)
-  
+  // SKIP-DOTTY-END
+
   /**
    * This field enables the following syntax: 
    *
@@ -290,7 +293,10 @@ trait MatcherWords {
    * </p>
    *
    */
+  //DOTTY-ONLY def equal(right: Any): MatcherFactory1[Any, Equality] =
+  // SKIP-DOTTY-START 
   def equal(right: Any): MatcherFactory1[Any, Equality] =
+  // SKIP-DOTTY-END 
     new MatcherFactory1[Any, Equality] {
       def matcher[T <: Any : Equality]: Matcher[T] = {
         val equality = implicitly[Equality[T]]

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/NoExceptionWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/NoExceptionWord.scala
@@ -36,10 +36,7 @@ final class NoExceptionWord(pos: source.Position) {
    *             ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def should(beWord: BeWord): ResultOfBeWordForNoException =
-  // SKIP-DOTTY-START 
-  def should(beWord: BeWord): ResultOfBeWordForNoException = 
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def should(beWord: BeWord): ResultOfBeWordForNoException = 
     new ResultOfBeWordForNoException(pos)
   
   /**
@@ -50,10 +47,7 @@ final class NoExceptionWord(pos: source.Position) {
    *             ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def shouldBe(thrownBy: ResultOfThrownByApplication): org.scalatest.Assertion = {
-  // SKIP-DOTTY-START 
-  def shouldBe(thrownBy: ResultOfThrownByApplication): org.scalatest.Assertion = {
-  // SKIP-DOTTY-END  
+  /* DOTTY-ONLY infix */ def shouldBe(thrownBy: ResultOfThrownByApplication): org.scalatest.Assertion = {
     try {
       thrownBy.execute()
       indicateSuccess(Resources.noExceptionWasThrown)
@@ -74,10 +68,7 @@ final class NoExceptionWord(pos: source.Position) {
    *             ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def must(beWord: BeWord): ResultOfBeWordForNoException =
-  // SKIP-DOTTY-START 
-  def must(beWord: BeWord): ResultOfBeWordForNoException =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def must(beWord: BeWord): ResultOfBeWordForNoException =
     new ResultOfBeWordForNoException(pos)
 
   /**
@@ -88,10 +79,7 @@ final class NoExceptionWord(pos: source.Position) {
    *             ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def mustBe(thrownBy: ResultOfThrownByApplication): org.scalatest.Assertion = {
-  // SKIP-DOTTY-START 
-  def mustBe(thrownBy: ResultOfThrownByApplication): org.scalatest.Assertion = {
-  // SKIP-DOTTY-END  
+  /* DOTTY-ONLY infix */ def mustBe(thrownBy: ResultOfThrownByApplication): org.scalatest.Assertion = {
     try {
       thrownBy.execute()
       indicateSuccess(Resources.noExceptionWasThrown)

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfATypeInvocation.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfATypeInvocation.scala
@@ -45,7 +45,7 @@ final class ResultOfATypeInvocation[T](val clazzTag: ClassTag[T]) {
    *                      ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def should(beWord: BeWord)(implicit prettifier: Prettifier, pos: source.Position): ResultOfBeWordForAType[T] =
+  //DOTTY-ONLY infix def should(beWord: BeWord)(using prettifier: Prettifier, pos: source.Position): ResultOfBeWordForAType[T] =
   // SKIP-DOTTY-START 
   def should(beWord: BeWord)(implicit prettifier: Prettifier, pos: source.Position): ResultOfBeWordForAType[T] =
   // SKIP-DOTTY-END
@@ -61,10 +61,7 @@ final class ResultOfATypeInvocation[T](val clazzTag: ClassTag[T]) {
    *
    * This method is here to direct people trying to use the above syntax to use <code>noException</code> instead.
    */
-  //DOTTY-ONLY infix def should(notWord: NotWord): PleaseUseNoExceptionShouldSyntaxInstead =
-  // SKIP-DOTTY-START 
-  def should(notWord: NotWord): PleaseUseNoExceptionShouldSyntaxInstead =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def should(notWord: NotWord): PleaseUseNoExceptionShouldSyntaxInstead =
     new PleaseUseNoExceptionShouldSyntaxInstead
   
   /**
@@ -79,7 +76,7 @@ final class ResultOfATypeInvocation[T](val clazzTag: ClassTag[T]) {
   def shouldBe(thrownBy: ResultOfThrownByApplication)(implicit prettifier: Prettifier, pos: source.Position): org.scalatest.Assertion = 
     checkThrownBy(clazz, thrownBy, pos)
   // SKIP-DOTTY-END
-  //DOTTY-ONLY infix inline def shouldBe(thrownBy: ResultOfThrownByApplication)(implicit prettifier: Prettifier): org.scalatest.Assertion =   
+  //DOTTY-ONLY infix inline def shouldBe(thrownBy: ResultOfThrownByApplication)(using prettifier: Prettifier): org.scalatest.Assertion =   
   //DOTTY-ONLY   ${ org.scalatest.matchers.MatchersHelper.checkThrownByMacro('{clazz}, '{thrownBy}) }
 
   /**
@@ -94,7 +91,7 @@ final class ResultOfATypeInvocation[T](val clazzTag: ClassTag[T]) {
   def should(beThrownBy: ResultOfBeThrownBy)(implicit prettifier: Prettifier, pos: source.Position): org.scalatest.Assertion = 
     checkBeThrownBy(clazz, beThrownBy, pos)
   // SKIP-DOTTY-END  
-  //DOTTY-ONLY infix inline def should(beThrownBy: ResultOfBeThrownBy)(implicit prettifier: Prettifier): org.scalatest.Assertion = 
+  //DOTTY-ONLY infix inline def should(beThrownBy: ResultOfBeThrownBy)(using prettifier: Prettifier): org.scalatest.Assertion = 
   //DOTTY-ONLY   ${ org.scalatest.matchers.MatchersHelper.checkBeThrownByMacro('{clazz}, '{beThrownBy}) }
 
   /**
@@ -105,7 +102,7 @@ final class ResultOfATypeInvocation[T](val clazzTag: ClassTag[T]) {
    *                      ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def must(beWord: BeWord)(implicit prettifier: Prettifier, pos: source.Position): ResultOfBeWordForAType[T] =
+  //DOTTY-ONLY infix def must(beWord: BeWord)(using prettifier: Prettifier, pos: source.Position): ResultOfBeWordForAType[T] =
   // SKIP-DOTTY-START 
   def must(beWord: BeWord)(implicit prettifier: Prettifier, pos: source.Position): ResultOfBeWordForAType[T] =
   // SKIP-DOTTY-END
@@ -121,10 +118,7 @@ final class ResultOfATypeInvocation[T](val clazzTag: ClassTag[T]) {
    *
    * This method is here to direct people trying to use the above syntax to use <code>noException</code> instead.
    */
-  //DOTTY-ONLY infix def must(notWord: NotWord): PleaseUseNoExceptionShouldSyntaxInstead =
-  // SKIP-DOTTY-START 
-  def must(notWord: NotWord): PleaseUseNoExceptionShouldSyntaxInstead =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def must(notWord: NotWord): PleaseUseNoExceptionShouldSyntaxInstead =
     new PleaseUseNoExceptionShouldSyntaxInstead
 
   /**
@@ -139,7 +133,7 @@ final class ResultOfATypeInvocation[T](val clazzTag: ClassTag[T]) {
   def mustBe(thrownBy: ResultOfThrownByApplication)(implicit prettifier: Prettifier, pos: source.Position): org.scalatest.Assertion = 
     checkThrownBy(clazz, thrownBy, pos)
   // SKIP-DOTTY-END
-  //DOTTY-ONLY infix inline def mustBe(thrownBy: ResultOfThrownByApplication)(implicit prettifier: Prettifier): org.scalatest.Assertion = 
+  //DOTTY-ONLY infix inline def mustBe(thrownBy: ResultOfThrownByApplication)(using prettifier: Prettifier): org.scalatest.Assertion = 
   //DOTTY-ONLY   ${ org.scalatest.matchers.MatchersHelper.checkThrownByMacro('{clazz}, '{thrownBy}) }  
 
   /**
@@ -154,7 +148,7 @@ final class ResultOfATypeInvocation[T](val clazzTag: ClassTag[T]) {
   def must(beThrownBy: ResultOfBeThrownBy)(implicit prettifier: Prettifier, pos: source.Position): org.scalatest.Assertion = 
     checkBeThrownBy(clazz, beThrownBy, pos)
   // SKIP-DOTTY-END
-  //DOTTY-ONLY infix inline def must(beThrownBy: ResultOfBeThrownBy)(implicit prettifier: Prettifier): org.scalatest.Assertion = 
+  //DOTTY-ONLY infix inline def must(beThrownBy: ResultOfBeThrownBy)(using prettifier: Prettifier): org.scalatest.Assertion = 
   //DOTTY-ONLY   ${ org.scalatest.matchers.MatchersHelper.checkBeThrownByMacro('{clazz}, '{beThrownBy}) }
   
   override def toString: String = "a [" + clazz.getName + "]"

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAnTypeInvocation.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfAnTypeInvocation.scala
@@ -44,7 +44,7 @@ final class ResultOfAnTypeInvocation[T](val clazzTag: ClassTag[T]) {
    *                ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def should(beWord: BeWord)(implicit prettifier: Prettifier, pos: source.Position): ResultOfBeWordForAnType[T] =
+  //DOTTY-ONLY infix def should(beWord: BeWord)(using prettifier: Prettifier, pos: source.Position): ResultOfBeWordForAnType[T] =
   // SKIP-DOTTY-START 
   def should(beWord: BeWord)(implicit prettifier: Prettifier, pos: source.Position): ResultOfBeWordForAnType[T] =
   // SKIP-DOTTY-END
@@ -60,10 +60,7 @@ final class ResultOfAnTypeInvocation[T](val clazzTag: ClassTag[T]) {
    *
    * This method is here to direct people trying to use the above syntax to use <code>noException</code> instead.
    */
-  //DOTTY-ONLY infix def should(notWord: NotWord): PleaseUseNoExceptionShouldSyntaxInstead =
-  // SKIP-DOTTY-START 
-  def should(notWord: NotWord): PleaseUseNoExceptionShouldSyntaxInstead =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def should(notWord: NotWord): PleaseUseNoExceptionShouldSyntaxInstead =
     new PleaseUseNoExceptionShouldSyntaxInstead
   
   /**
@@ -78,7 +75,7 @@ final class ResultOfAnTypeInvocation[T](val clazzTag: ClassTag[T]) {
   def shouldBe(thrownBy: ResultOfThrownByApplication)(implicit prettifier: Prettifier, pos: source.Position): org.scalatest.Assertion = 
     checkThrownBy(clazz, thrownBy, pos)
   // SKIP-DOTTY-END
-  //DOTTY-ONLY infix inline def shouldBe(thrownBy: ResultOfThrownByApplication)(implicit prettifier: Prettifier): org.scalatest.Assertion =   
+  //DOTTY-ONLY infix inline def shouldBe(thrownBy: ResultOfThrownByApplication)(using prettifier: Prettifier): org.scalatest.Assertion =   
   //DOTTY-ONLY   ${ org.scalatest.matchers.MatchersHelper.checkThrownByMacro('{clazz}, '{thrownBy}) }  
 
   /**
@@ -93,7 +90,7 @@ final class ResultOfAnTypeInvocation[T](val clazzTag: ClassTag[T]) {
   def should(beThrownBy: ResultOfBeThrownBy)(implicit prettifier: Prettifier, pos: source.Position): org.scalatest.Assertion = 
     checkBeThrownBy(clazz, beThrownBy, pos)
   // SKIP-DOTTY-END
-  //DOTTY-ONLY infix inline def should(beThrownBy: ResultOfBeThrownBy)(implicit prettifier: Prettifier): org.scalatest.Assertion = 
+  //DOTTY-ONLY infix inline def should(beThrownBy: ResultOfBeThrownBy)(using prettifier: Prettifier): org.scalatest.Assertion = 
   //DOTTY-ONLY   ${ org.scalatest.matchers.MatchersHelper.checkBeThrownByMacro('{clazz}, '{beThrownBy}) }
 
   /**
@@ -104,7 +101,7 @@ final class ResultOfAnTypeInvocation[T](val clazzTag: ClassTag[T]) {
    *                ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def must(beWord: BeWord)(implicit prettifier: Prettifier, pos: source.Position): ResultOfBeWordForAnType[T] =
+  //DOTTY-ONLY infix def must(beWord: BeWord)(using prettifier: Prettifier, pos: source.Position): ResultOfBeWordForAnType[T] =
   // SKIP-DOTTY-START 
   def must(beWord: BeWord)(implicit prettifier: Prettifier, pos: source.Position): ResultOfBeWordForAnType[T] =
   // SKIP-DOTTY-END
@@ -120,10 +117,7 @@ final class ResultOfAnTypeInvocation[T](val clazzTag: ClassTag[T]) {
    *
    * This method is here to direct people trying to use the above syntax to use <code>noException</code> instead.
    */
-  //DOTTY-ONLY infix def must(notWord: NotWord): PleaseUseNoExceptionShouldSyntaxInstead =
-  // SKIP-DOTTY-START 
-  def must(notWord: NotWord): PleaseUseNoExceptionShouldSyntaxInstead =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def must(notWord: NotWord): PleaseUseNoExceptionShouldSyntaxInstead =
     new PleaseUseNoExceptionShouldSyntaxInstead
 
   /**
@@ -138,7 +132,7 @@ final class ResultOfAnTypeInvocation[T](val clazzTag: ClassTag[T]) {
   def mustBe(thrownBy: ResultOfThrownByApplication)(implicit prettifier: Prettifier, pos: source.Position): org.scalatest.Assertion = 
     checkThrownBy(clazz, thrownBy, pos)
   // SKIP-DOTTY-END
-  //DOTTY-ONLY infix inline def mustBe(thrownBy: ResultOfThrownByApplication)(implicit prettifier: Prettifier): org.scalatest.Assertion = 
+  //DOTTY-ONLY infix inline def mustBe(thrownBy: ResultOfThrownByApplication)(using prettifier: Prettifier): org.scalatest.Assertion = 
   //DOTTY-ONLY   ${ org.scalatest.matchers.MatchersHelper.checkThrownByMacro('{clazz}, '{thrownBy}) }
 
   /**
@@ -153,7 +147,7 @@ final class ResultOfAnTypeInvocation[T](val clazzTag: ClassTag[T]) {
   def must(beThrownBy: ResultOfBeThrownBy)(implicit prettifier: Prettifier, pos: source.Position): org.scalatest.Assertion = 
     checkBeThrownBy(clazz, beThrownBy, pos)
   // SKIP-DOTTY-END
-  //DOTTY-ONLY infix inline def must(beThrownBy: ResultOfBeThrownBy)(implicit prettifier: Prettifier): org.scalatest.Assertion = 
+  //DOTTY-ONLY infix inline def must(beThrownBy: ResultOfBeThrownBy)(using prettifier: Prettifier): org.scalatest.Assertion = 
   //DOTTY-ONLY   ${ org.scalatest.matchers.MatchersHelper.checkBeThrownByMacro('{clazz}, '{beThrownBy}) }
   
   override def toString: String = "an [" + clazz.getName + "]"

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeThrownBy.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeThrownBy.scala
@@ -26,10 +26,7 @@ final class ResultOfBeThrownBy(codeList: IndexedSeq[() => Unit]) {
 
   final class ResultOfAndBeWord {
 
-    //DOTTY-ONLY infix def thrownBy(code: => Unit) =
-    // SKIP-DOTTY-START
-    def thrownBy(code: => Unit) = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY infix */ def thrownBy(code: => Unit) = 
       new ResultOfBeThrownBy(codeList :+ (() => code))
 
   }
@@ -42,10 +39,7 @@ final class ResultOfBeThrownBy(codeList: IndexedSeq[() => Unit]) {
    *                         ^
    * </pre>
    */
-  //DOTTY-ONLY infix def and(beWord: BeWord) =
-  // SKIP-DOTTY-START 
-  def and(beWord: BeWord) = 
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def and(beWord: BeWord) = 
     new ResultOfAndBeWord
 
   private[scalatest] lazy val throwables: IndexedSeq[Option[Throwable]] =

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeWordForAType.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeWordForAType.scala
@@ -39,10 +39,7 @@ final class ResultOfBeWordForAType[T](clazz: Class[T], prettifier: Prettifier, p
    *                                ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def thrownBy(fun: => Any): Assertion = {
-  // SKIP-DOTTY-START 
-  def thrownBy(fun: => Any): Assertion = {
-  // SKIP-DOTTY-END  
+  /* DOTTY-ONLY infix */ def thrownBy(fun: => Any): Assertion = {
     try {
       checkExpectedException(fun, clazz, Resources.wrongException _, Resources.exceptionExpected _, pos)
       indicateSuccess(Resources.exceptionThrown(clazz.getName))

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeWordForAnType.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeWordForAnType.scala
@@ -39,10 +39,7 @@ final class ResultOfBeWordForAnType[T](clazz: Class[T], prettifier: Prettifier, 
    *                          ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def thrownBy(fun: => Any): Assertion = {
-  // SKIP-DOTTY-START 
-  def thrownBy(fun: => Any): Assertion = {
-  // SKIP-DOTTY-END  
+  /* DOTTY-ONLY infix */ def thrownBy(fun: => Any): Assertion = {
     try {
       checkExpectedException(fun, clazz, Resources.wrongException _, Resources.exceptionExpected _, pos)
       indicateSuccess(Resources.exceptionThrown(clazz.getName))

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeWordForNoException.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfBeWordForNoException.scala
@@ -35,10 +35,7 @@ final class ResultOfBeWordForNoException(pos: source.Position) {
    *                       ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def thrownBy(fun: => Any): Assertion = {
-  // SKIP-DOTTY-START 
-  def thrownBy(fun: => Any): Assertion = {
-  // SKIP-DOTTY-END  
+  /* DOTTY-ONLY infix */ def thrownBy(fun: => Any): Assertion = {
     checkNoException(fun, pos)
   }
 

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfContainWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfContainWord.scala
@@ -45,7 +45,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def oneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit containing: Containing[L]): Assertion = {
+  //DOTTY-ONLY infix def oneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using containing: Containing[L]): Assertion = {
   // SKIP-DOTTY-START 
   def oneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit containing: Containing[L]): Assertion = {
   // SKIP-DOTTY-END  
@@ -81,7 +81,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def oneElementOf(elements: Iterable[Any])(implicit containing: Containing[L]): Assertion = {
+  //DOTTY-ONLY infix def oneElementOf(elements: Iterable[Any])(using containing: Containing[L]): Assertion = {
   // SKIP-DOTTY-START 
   def oneElementOf(elements: Iterable[Any])(implicit containing: Containing[L]): Assertion = {
   // SKIP-DOTTY-END  
@@ -102,7 +102,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def atLeastOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit aggregating: Aggregating[L]): Assertion = {
+  //DOTTY-ONLY infix def atLeastOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-START 
   def atLeastOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-END  
@@ -138,7 +138,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def atLeastOneElementOf(elements: Iterable[Any])(implicit aggregating: Aggregating[L]): Assertion = {
+  //DOTTY-ONLY infix def atLeastOneElementOf(elements: Iterable[Any])(using aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-START 
   def atLeastOneElementOf(elements: Iterable[Any])(implicit aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-END  
@@ -160,7 +160,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def noneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit containing: Containing[L]): Assertion = {
+  //DOTTY-ONLY infix def noneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using containing: Containing[L]): Assertion = {
   // SKIP-DOTTY-START 
   def noneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit containing: Containing[L]): Assertion = {
   // SKIP-DOTTY-END  
@@ -196,7 +196,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def noElementsOf(elements: Iterable[Any])(implicit containing: Containing[L]): Assertion = {
+  //DOTTY-ONLY infix def noElementsOf(elements: Iterable[Any])(using containing: Containing[L]): Assertion = {
   // SKIP-DOTTY-START 
   def noElementsOf(elements: Iterable[Any])(implicit containing: Containing[L]): Assertion = {
   // SKIP-DOTTY-END  
@@ -218,7 +218,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def theSameElementsAs(right: Iterable[_])(implicit aggregating: Aggregating[L]): Assertion = {
+  //DOTTY-ONLY infix def theSameElementsAs(right: Iterable[_])(using aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-START 
   def theSameElementsAs(right: Iterable[_])(implicit aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-END  
@@ -239,7 +239,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def theSameElementsInOrderAs(right: Iterable[_])(implicit sequencing: Sequencing[L]): Assertion = {
+  //DOTTY-ONLY infix def theSameElementsInOrderAs(right: Iterable[_])(using sequencing: Sequencing[L]): Assertion = {
   // SKIP-DOTTY-START 
   def theSameElementsInOrderAs(right: Iterable[_])(implicit sequencing: Sequencing[L]): Assertion = {
   // SKIP-DOTTY-END  
@@ -260,7 +260,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def only(right: Any*)(implicit aggregating: Aggregating[L]): Assertion = {
+  //DOTTY-ONLY infix def only(right: Any*)(using aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-START 
   def only(right: Any*)(implicit aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-END  
@@ -312,7 +312,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def inOrderOnly(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit sequencing: Sequencing[L]): Assertion = {
+  //DOTTY-ONLY infix def inOrderOnly(firstEle: Any, secondEle: Any, remainingEles: Any*)(using sequencing: Sequencing[L]): Assertion = {
   // SKIP-DOTTY-START 
   def inOrderOnly(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit sequencing: Sequencing[L]): Assertion = {
   // SKIP-DOTTY-END
@@ -348,7 +348,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def allOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit aggregating: Aggregating[L]): Assertion = {
+  //DOTTY-ONLY infix def allOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-START 
   def allOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-END  
@@ -387,7 +387,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def allElementsOf[R](elements: Iterable[R])(implicit aggregating: Aggregating[L]): Assertion = {
+  //DOTTY-ONLY infix def allElementsOf[R](elements: Iterable[R])(using aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-START 
   def allElementsOf[R](elements: Iterable[R])(implicit aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-END  
@@ -409,7 +409,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def inOrder(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit sequencing: Sequencing[L]): Assertion = {
+  //DOTTY-ONLY infix def inOrder(firstEle: Any, secondEle: Any, remainingEles: Any*)(using sequencing: Sequencing[L]): Assertion = {
   // SKIP-DOTTY-START 
   def inOrder(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit sequencing: Sequencing[L]): Assertion = {
   // SKIP-DOTTY-END  
@@ -445,7 +445,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def inOrderElementsOf[R](elements: Iterable[R])(implicit sequencing: Sequencing[L]): Assertion = {
+  //DOTTY-ONLY infix def inOrderElementsOf[R](elements: Iterable[R])(using sequencing: Sequencing[L]): Assertion = {
   // SKIP-DOTTY-START 
   def inOrderElementsOf[R](elements: Iterable[R])(implicit sequencing: Sequencing[L]): Assertion = {
   // SKIP-DOTTY-END  
@@ -467,7 +467,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                    ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def key(expectedKey: Any)(implicit keyMapping: KeyMapping[L]): Assertion = {
+  //DOTTY-ONLY infix def key(expectedKey: Any)(using keyMapping: KeyMapping[L]): Assertion = {
   // SKIP-DOTTY-START 
   def key(expectedKey: Any)(implicit keyMapping: KeyMapping[L]): Assertion = {
   // SKIP-DOTTY-END
@@ -488,7 +488,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                    ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def value(expectedValue: Any)(implicit valueMapping: ValueMapping[L]): Assertion = {
+  //DOTTY-ONLY infix def value(expectedValue: Any)(using valueMapping: ValueMapping[L]): Assertion = {
   // SKIP-DOTTY-START 
   def value(expectedValue: Any)(implicit valueMapping: ValueMapping[L]): Assertion = {
   // SKIP-DOTTY-END  
@@ -509,7 +509,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def atMostOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit aggregating: Aggregating[L]): Assertion = {
+  //DOTTY-ONLY infix def atMostOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-START 
   def atMostOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-END  
@@ -545,7 +545,7 @@ class ResultOfContainWord[L](left: L, shouldBeTrue: Boolean, prettifier: Prettif
    *                   ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def atMostOneElementOf[R](elements: Iterable[R])(implicit aggregating: Aggregating[L]): Assertion = {
+  //DOTTY-ONLY infix def atMostOneElementOf[R](elements: Iterable[R])(using aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-START 
   def atMostOneElementOf[R](elements: Iterable[R])(implicit aggregating: Aggregating[L]): Assertion = {
   // SKIP-DOTTY-END  

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfGreaterThanComparison.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfGreaterThanComparison.scala
@@ -43,7 +43,7 @@ final class ResultOfGreaterThanComparison[T : Ordering](val right: T) {
    *                 ^  ... invoked by this be method
    * </pre>
    */ 
-  def apply(left: T): Boolean = { 
+  /* DOTTY-ONLY infix */ def apply(left: T): Boolean = { 
     val ordering = implicitly[Ordering[T]]
     ordering.gt(left, right) // left > right
   }

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfGreaterThanOrEqualToComparison.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfGreaterThanOrEqualToComparison.scala
@@ -43,7 +43,7 @@ final class ResultOfGreaterThanOrEqualToComparison[T : Ordering](val right: T) {
    *                 ^  ... invoked by this be method
    * </pre>
    */ 
-  def apply(left: T): Boolean = {
+  /* DOTTY-ONLY infix */ def apply(left: T): Boolean = {
     val ordering = implicitly[Ordering[T]]
     ordering.gteq(left, right) // left >= right
   }

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfLengthWordApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfLengthWordApplication.scala
@@ -29,7 +29,7 @@ import org.scalactic.Prettifier
 final class ResultOfLengthWordApplication(val expectedLength: Long) {
 
   // TODO: SCALADOC
-  def apply[T : Length](resultOfOfTypeInvocation: ResultOfOfTypeInvocation[T]): HavePropertyMatcher[T, Long] = { 
+  /* DOTTY-ONLY infix */ def apply[T : Length](resultOfOfTypeInvocation: ResultOfOfTypeInvocation[T]): HavePropertyMatcher[T, Long] = { 
     new HavePropertyMatcher[T, Long] {
       def apply(t: T): HavePropertyMatchResult[Long] = {
         val len = implicitly[Length[T]]

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfLessThanComparison.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfLessThanComparison.scala
@@ -43,7 +43,7 @@ final class ResultOfLessThanComparison[T : Ordering](val right: T) {
    *                 ^  ... invoked by this be method
    * </pre>
    */ 
-  def apply(left: T): Boolean = {
+  /* DOTTY-ONLY infix */ def apply(left: T): Boolean = {
     val ordering = implicitly[Ordering[T]]
     ordering.lt(left, right) // left < right
   }

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfLessThanOrEqualToComparison.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfLessThanOrEqualToComparison.scala
@@ -43,7 +43,7 @@ final class ResultOfLessThanOrEqualToComparison[T : Ordering](val right: T) {
    *                 ^  ... invoked by this be method
    * </pre>
    */ 
-  def apply(left: T): Boolean = {
+  /* DOTTY-ONLY infix */ def apply(left: T): Boolean = {
     val ordering = implicitly[Ordering[T]]
     ordering.lteq(left, right) // left <= right
   }

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfMessageWordApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfMessageWordApplication.scala
@@ -30,7 +30,7 @@ import org.scalactic.Prettifier
 final class ResultOfMessageWordApplication(val expectedMessage: String) {
 
   // TODO: SCALADOC
-  def apply[T : Messaging](resultOfOfTypeInvocation: ResultOfOfTypeInvocation[T]): HavePropertyMatcher[T, String] = {  
+  /* DOTTY-ONLY infix */ def apply[T : Messaging](resultOfOfTypeInvocation: ResultOfOfTypeInvocation[T]): HavePropertyMatcher[T, String] = {  
     new HavePropertyMatcher[T, String] {
       def apply(t: T): HavePropertyMatchResult[String] = {
         val messaging = implicitly[Messaging[T]]

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfNotExist.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfNotExist.scala
@@ -35,10 +35,7 @@ final class ResultOfNotExist(notWord: NotWord) {
    *                        ^
    * </pre>
    */
-  //DOTTY-ONLY infix def and(anotherMatcher: Matcher[Any]): MatcherFactory1[Any, Existence] =
-  // SKIP-DOTTY-START 
-  def and(anotherMatcher: Matcher[Any]): MatcherFactory1[Any, Existence] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def and(anotherMatcher: Matcher[Any]): MatcherFactory1[Any, Existence] =
     notWord.exist.and(anotherMatcher)
 
   import scala.language.higherKinds
@@ -51,10 +48,7 @@ final class ResultOfNotExist(notWord: NotWord) {
    *                        ^
    * </pre>
    */
-  //DOTTY-ONLY infix def and[TYPECLASS1[_]](anotherMatcherFactory: MatcherFactory1[Any, TYPECLASS1]): MatcherFactory2[Any, Existence, TYPECLASS1] =
-  // SKIP-DOTTY-START 
-  def and[TYPECLASS1[_]](anotherMatcherFactory: MatcherFactory1[Any, TYPECLASS1]): MatcherFactory2[Any, Existence, TYPECLASS1] = 
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def and[TYPECLASS1[_]](anotherMatcherFactory: MatcherFactory1[Any, TYPECLASS1]): MatcherFactory2[Any, Existence, TYPECLASS1] = 
     notWord.exist.and(anotherMatcherFactory)
 
   /**
@@ -65,10 +59,7 @@ final class ResultOfNotExist(notWord: NotWord) {
    *                        ^
    * </pre>
    */
-  //DOTTY-ONLY infix def or(anotherMatcher: Matcher[Any]): MatcherFactory1[Any, Existence] =
-  // SKIP-DOTTY-START 
-  def or(anotherMatcher: Matcher[Any]): MatcherFactory1[Any, Existence] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def or(anotherMatcher: Matcher[Any]): MatcherFactory1[Any, Existence] =
     notWord.exist.or(anotherMatcher)
     
   /**
@@ -79,10 +70,7 @@ final class ResultOfNotExist(notWord: NotWord) {
    *                        ^
    * </pre>
    */
-  //DOTTY-ONLY infix def or[TYPECLASS1[_]](anotherMatcherFactory: MatcherFactory1[Any, TYPECLASS1]): MatcherFactory2[Any, Existence, TYPECLASS1] = 
-  // SKIP-DOTTY-START 
-  def or[TYPECLASS1[_]](anotherMatcherFactory: MatcherFactory1[Any, TYPECLASS1]): MatcherFactory2[Any, Existence, TYPECLASS1] = 
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def or[TYPECLASS1[_]](anotherMatcherFactory: MatcherFactory1[Any, TYPECLASS1]): MatcherFactory2[Any, Existence, TYPECLASS1] = 
     notWord.exist.or(anotherMatcherFactory)  
     
   /**

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfSizeWordApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfSizeWordApplication.scala
@@ -29,7 +29,7 @@ import org.scalactic.Prettifier
 final class ResultOfSizeWordApplication(val expectedSize: Long) {
 
   // TODO: SCALADOC
-  def apply[T : Size](resultOfOfTypeInvocation: ResultOfOfTypeInvocation[T]): HavePropertyMatcher[T, Long] = {  
+  /* DOTTY-ONLY infix */ def apply[T : Size](resultOfOfTypeInvocation: ResultOfOfTypeInvocation[T]): HavePropertyMatcher[T, Long] = {  
     new HavePropertyMatcher[T, Long] {
       def apply(t: T): HavePropertyMatchResult[Long] = {
         val sz = implicitly[Size[T]]

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfTheTypeInvocation.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfTheTypeInvocation.scala
@@ -41,10 +41,7 @@ final class ResultOfTheTypeInvocation[T](clazzTag: ClassTag[T], pos: source.Posi
    *                                     ^
    * </pre>
    **/
-  //DOTTY-ONLY infix def thrownBy(fun: => Any): T = {
-  // SKIP-DOTTY-START 
-  def thrownBy(fun: => Any): T = {
-  // SKIP-DOTTY-END  
+  /* DOTTY-ONLY infix */ def thrownBy(fun: => Any): T = {
     checkExpectedException(fun, clazz, Resources.wrongException _, Resources.exceptionExpected _, pos)
   }
   

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/SizeWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/SizeWord.scala
@@ -31,7 +31,7 @@ final class SizeWord {
    *                          ^
    * </pre>
    */ 
-  def apply(expectedSize: Long): ResultOfSizeWordApplication = new ResultOfSizeWordApplication(expectedSize)
+  /* DOTTY-ONLY infix */ def apply(expectedSize: Long): ResultOfSizeWordApplication = new ResultOfSizeWordApplication(expectedSize)
   
   /**
    * Overrides toString to return "size"

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/StartWithWord.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/StartWithWord.scala
@@ -38,7 +38,7 @@ final class StartWithWord {
    *                          ^
    * </pre>
    */ 
-  def apply(right: String): Matcher[String] =
+  /* DOTTY-ONLY infix */ def apply(right: String): Matcher[String] =
     new Matcher[String] {
       def apply(left: String): MatchResult =
         MatchResult(
@@ -59,10 +59,7 @@ final class StartWithWord {
    *                          ^
    * </pre>
    */
-  //DOTTY-ONLY infix def regex[T <: String](right: T): Matcher[T] =
-  // SKIP-DOTTY-START 
-  def regex[T <: String](right: T): Matcher[T] = 
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def regex[T <: String](right: T): Matcher[T] = 
     regex(right.r)
   
   /**
@@ -73,10 +70,7 @@ final class StartWithWord {
    *                               ^
    * </pre>
    */
-  //DOTTY-ONLY infix def regex(regexWithGroups: RegexWithGroups) =
-  // SKIP-DOTTY-START 	
-  def regex(regexWithGroups: RegexWithGroups) = 
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def regex(regexWithGroups: RegexWithGroups) = 
     new Matcher[String] {
       def apply(left: String): MatchResult = 
         startWithRegexWithGroups(left, regexWithGroups.regex, regexWithGroups.groups)
@@ -92,10 +86,7 @@ final class StartWithWord {
    *                         ^
    * </pre>
    */
-  //DOTTY-ONLY infix def regex(rightRegex: Regex): Matcher[String] =
-  // SKIP-DOTTY-START 
-  def regex(rightRegex: Regex): Matcher[String] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def regex(rightRegex: Regex): Matcher[String] =
     new Matcher[String] {
       def apply(left: String): MatchResult =
         MatchResult(

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherDeciderSpec.scala
@@ -295,15 +295,15 @@ class AllElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Exp
 
     it("should take specified normalization in scope when 'should contain' is used") {
 
-      (List("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (after being trimmed)
-      (Set("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (after being trimmed)
-      (Array("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (after being trimmed)
-      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain allElementsOf Seq(1 -> "one", 2 -> "two ", 3 -> "three")) (after being mapTrimmed)
+      (List("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
+      (Set("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
+      (Array("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
+      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain allElementsOf Seq(1 -> "one", 2 -> "two ", 3 -> "three")) (using after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (after being trimmed)
-      (javaSet("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (after being trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (after being javaMapTrimmed)
+      (javaList("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
+      (javaSet("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (using after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -325,38 +325,38 @@ class AllElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Exp
 
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain allElementsOf Seq(1, 2, 3)) (after being incremented)
+        (left1 should contain allElementsOf Seq(1, 2, 3)) (using after being incremented)
       }
       checkShouldContainStackDepth(e1, left1, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain allElementsOf Seq(1, 2, 3)) (after being incremented)
+        (left2 should contain allElementsOf Seq(1, 2, 3)) (using after being incremented)
       }
       checkShouldContainStackDepth(e2, left2, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain allElementsOf Seq(1, 2, 3)) (after being incremented)
+        (left3 should contain allElementsOf Seq(1, 2, 3)) (using after being incremented)
       }
       checkShouldContainStackDepth(e3, left3, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain allElementsOf Seq(1 -> "one", 2 -> "two", 3 -> "three")) (after being mapIncremented)
+        (left4 should contain allElementsOf Seq(1 -> "one", 2 -> "two", 3 -> "three")) (using after being mapIncremented)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> "one", 2 -> "two", 3 -> "three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain allElementsOf Seq(1, 2, 3)) (after being incremented)
+        (left5 should contain allElementsOf Seq(1, 2, 3)) (using after being incremented)
       }
       checkShouldContainStackDepth(e5, left5, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (after being javaMapIncremented)
+        (left6 should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using after being javaMapIncremented)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -405,14 +405,14 @@ class AllElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Exp
 
     it("should take specified equality and normalization when 'should contain' is used") {
 
-      (List("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Set("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Array("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> "ONE ", 2 -> "TWO", 3 -> "THREE ") should contain allElementsOf Seq(1 -> "one", 2 -> "two ", 3 -> "three")) (decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Set("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Array("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> "ONE ", 2 -> "TWO", 3 -> "THREE ") should contain allElementsOf Seq(1 -> "one", 2 -> "two ", 3 -> "three")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "ONE "), Entry(2, "TWO"), Entry(3, "THREE ")) should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "ONE "), Entry(2, "TWO"), Entry(3, "THREE ")) should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -432,38 +432,38 @@ class AllElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Exp
 
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain allElementsOf Seq(" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left1 should contain allElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left2 = Set("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain allElementsOf Seq(" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left2 should contain allElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left3 = Array("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain allElementsOf Seq(" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left3 should contain allElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain allElementsOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should contain allElementsOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> " one", 2 -> "two ", 3 -> " three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("one ", " two", "three ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain allElementsOf Seq(" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left5 should contain allElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain allElementsOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should contain allElementsOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherDeciderSpec.scala
@@ -295,15 +295,15 @@ class AllElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Exp
 
     it("should take specified normalization in scope when 'should contain' is used") {
 
-      (List("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
-      (Set("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
-      (Array("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
-      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain allElementsOf Seq(1 -> "one", 2 -> "two ", 3 -> "three")) (using after being mapTrimmed)
+      (List("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Set("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Array("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain allElementsOf Seq(1 -> "one", 2 -> "two ", 3 -> "three")) (/* DOTTY-ONLY using */ after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
-      (javaSet("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (using after being javaMapTrimmed)
+      (javaList("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaSet("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (/* DOTTY-ONLY using */ after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -325,38 +325,38 @@ class AllElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Exp
 
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain allElementsOf Seq(1, 2, 3)) (using after being incremented)
+        (left1 should contain allElementsOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ after being incremented)
       }
       checkShouldContainStackDepth(e1, left1, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain allElementsOf Seq(1, 2, 3)) (using after being incremented)
+        (left2 should contain allElementsOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ after being incremented)
       }
       checkShouldContainStackDepth(e2, left2, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain allElementsOf Seq(1, 2, 3)) (using after being incremented)
+        (left3 should contain allElementsOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ after being incremented)
       }
       checkShouldContainStackDepth(e3, left3, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain allElementsOf Seq(1 -> "one", 2 -> "two", 3 -> "three")) (using after being mapIncremented)
+        (left4 should contain allElementsOf Seq(1 -> "one", 2 -> "two", 3 -> "three")) (/* DOTTY-ONLY using */ after being mapIncremented)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> "one", 2 -> "two", 3 -> "three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain allElementsOf Seq(1, 2, 3)) (using after being incremented)
+        (left5 should contain allElementsOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ after being incremented)
       }
       checkShouldContainStackDepth(e5, left5, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using after being javaMapIncremented)
+        (left6 should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ after being javaMapIncremented)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -405,14 +405,14 @@ class AllElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Exp
 
     it("should take specified equality and normalization when 'should contain' is used") {
 
-      (List("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Set("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Array("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> "ONE ", 2 -> "TWO", 3 -> "THREE ") should contain allElementsOf Seq(1 -> "one", 2 -> "two ", 3 -> "three")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Set("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Array("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> "ONE ", 2 -> "TWO", 3 -> "THREE ") should contain allElementsOf Seq(1 -> "one", 2 -> "two ", 3 -> "three")) (/* DOTTY-ONLY using */ decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "ONE "), Entry(2, "TWO"), Entry(3, "THREE ")) should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList("A ", "B", "C ") should contain allElementsOf Seq("a", "b ", "c ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "ONE "), Entry(2, "TWO"), Entry(3, "THREE ")) should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (/* DOTTY-ONLY using */ decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -432,38 +432,38 @@ class AllElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Exp
 
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain allElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left1 should contain allElementsOf Seq(" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left2 = Set("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain allElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left2 should contain allElementsOf Seq(" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left3 = Array("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain allElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left3 should contain allElementsOf Seq(" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain allElementsOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should contain allElementsOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (/* DOTTY-ONLY using */ decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> " one", 2 -> "two ", 3 -> " three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("one ", " two", "three ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain allElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left5 should contain allElementsOf Seq(" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain allElementsOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should contain allElementsOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (/* DOTTY-ONLY using */ decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherEqualitySpec.scala
@@ -247,19 +247,19 @@ class AllElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec {
 
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain allElementsOf Seq(1, 2, 3)) (using equality)
+        (left1 should contain allElementsOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e1, left1, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain allElementsOf Seq(1, 2, 3)) (using equality)
+        (left2 should contain allElementsOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e2, left2, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain allElementsOf Seq(1, 2, 3)) (using equality)
+        (left3 should contain allElementsOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e3, left3, Seq(1, 2, 3), thisLineNumber - 2)
 
@@ -267,14 +267,14 @@ class AllElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec {
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain allElementsOf Seq(1 -> "one", 2 -> "two", 3 -> "three")) (using mapEquality)
+        (left4 should contain allElementsOf Seq(1 -> "one", 2 -> "two", 3 -> "three")) (/* DOTTY-ONLY using */ mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> "one", 2 -> "two", 3 -> "three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain allElementsOf Seq(1, 2, 3)) (using equality)
+        (left5 should contain allElementsOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e5, left5, Seq(1, 2, 3), thisLineNumber - 2)
 
@@ -282,7 +282,7 @@ class AllElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec {
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using javaMapEquality)
+        (left6 should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherEqualitySpec.scala
@@ -216,14 +216,14 @@ class AllElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec {
       val mapTrimEquality = new MapTrimEquality
       val javaMapTrimEquality = new JavaMapTrimEquality
 
-      (List("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3 ")) (trimEquality)
-      (Set("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3 ")) (trimEquality)
-      (Array("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3 ")) (trimEquality)
-      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain allElementsOf Seq(1 -> "one", 2 -> "two ", 3 -> "three")) (mapTrimEquality)
+      (List("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3 ")) (/* DOTTY-ONLY using */ trimEquality)
+      (Set("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3 ")) (/* DOTTY-ONLY using */ trimEquality)
+      (Array("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3 ")) (/* DOTTY-ONLY using */ trimEquality)
+      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain allElementsOf Seq(1 -> "one", 2 -> "two ", 3 -> "three")) (/* DOTTY-ONLY using */ mapTrimEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3 ")) (trimEquality)
-      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (javaMapTrimEquality)
+      (javaList("1 ", "2", "3 ") should contain allElementsOf Seq("1", "2 ", "3 ")) (/* DOTTY-ONLY using */ trimEquality)
+      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (/* DOTTY-ONLY using */ javaMapTrimEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllElementsOfContainMatcherEqualitySpec.scala
@@ -247,19 +247,19 @@ class AllElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec {
 
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain allElementsOf Seq(1, 2, 3)) (equality)
+        (left1 should contain allElementsOf Seq(1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e1, left1, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain allElementsOf Seq(1, 2, 3)) (equality)
+        (left2 should contain allElementsOf Seq(1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e2, left2, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain allElementsOf Seq(1, 2, 3)) (equality)
+        (left3 should contain allElementsOf Seq(1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e3, left3, Seq(1, 2, 3), thisLineNumber - 2)
 
@@ -267,14 +267,14 @@ class AllElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec {
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain allElementsOf Seq(1 -> "one", 2 -> "two", 3 -> "three")) (mapEquality)
+        (left4 should contain allElementsOf Seq(1 -> "one", 2 -> "two", 3 -> "three")) (using mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> "one", 2 -> "two", 3 -> "three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain allElementsOf Seq(1, 2, 3)) (equality)
+        (left5 should contain allElementsOf Seq(1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e5, left5, Seq(1, 2, 3), thisLineNumber - 2)
 
@@ -282,7 +282,7 @@ class AllElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec {
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (javaMapEquality)
+        (left6 should contain allElementsOf Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherDeciderSpec.scala
@@ -300,15 +300,15 @@ class AllOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly 
     
     it("should take specified normalization in scope when 'should contain' is used") {
       
-      (List("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (using after being trimmed)
-      (Set("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (using after being trimmed)
-      (Array("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (using after being trimmed)
-      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain allOf (1 -> "one", 2 -> "two ", 3 -> "three")) (using after being mapTrimmed)
+      (List("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Set("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Array("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain allOf (1 -> "one", 2 -> "two ", 3 -> "three")) (/* DOTTY-ONLY using */ after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (using after being trimmed)
-      (javaSet("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (using after being trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain allOf (Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (using after being javaMapTrimmed)
+      (javaList("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaSet("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain allOf (Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (/* DOTTY-ONLY using */ after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -330,38 +330,38 @@ class AllOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly 
       
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain allOf (1, 2, 3)) (using after being incremented)
+        (left1 should contain allOf (1, 2, 3)) (/* DOTTY-ONLY using */ after being incremented)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain allOf (1, 2, 3)) (using after being incremented)
+        (left2 should contain allOf (1, 2, 3)) (/* DOTTY-ONLY using */ after being incremented)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain allOf (1, 2, 3)) (using after being incremented)
+        (left3 should contain allOf (1, 2, 3)) (/* DOTTY-ONLY using */ after being incremented)
       }
         checkShouldContainStackDepth(e3, left3, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain allOf (1 -> "one", 2 -> "two", 3 -> "three")) (using after being mapIncremented)
+        (left4 should contain allOf (1 -> "one", 2 -> "two", 3 -> "three")) (/* DOTTY-ONLY using */ after being mapIncremented)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> "one", 2 -> "two", 3 -> "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain allOf (1, 2, 3)) (using after being incremented)
+        (left5 should contain allOf (1, 2, 3)) (/* DOTTY-ONLY using */ after being incremented)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(1, 2, 3)), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain allOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using after being javaMapIncremented)
+        (left6 should contain allOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ after being javaMapIncremented)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -410,14 +410,14 @@ class AllOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly 
     
     it("should take specified equality and normalization when 'should contain' is used") {
       
-      (List("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Set("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Array("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> "ONE ", 2 -> "TWO", 3 -> "THREE ") should contain allOf (1 -> "one", 2 -> "two ", 3 -> "three")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Set("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Array("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> "ONE ", 2 -> "TWO", 3 -> "THREE ") should contain allOf (1 -> "one", 2 -> "two ", 3 -> "three")) (/* DOTTY-ONLY using */ decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "ONE "), Entry(2, "TWO"), Entry(3, "THREE ")) should contain allOf (Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "ONE "), Entry(2, "TWO"), Entry(3, "THREE ")) should contain allOf (Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (/* DOTTY-ONLY using */ decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -437,38 +437,38 @@ class AllOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly 
       
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain allOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left1 should contain allOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left2 = Set("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain allOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left2 should contain allOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left3 = Array("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain allOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left3 should contain allOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
       
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain allOf (1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should contain allOf (1 -> " one", 2 -> "two ", 3 -> " three")) (/* DOTTY-ONLY using */ decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> " one", 2 -> "two ", 3 -> " three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("one ", " two", "three ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain allOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left5 should contain allOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain allOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should contain allOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (/* DOTTY-ONLY using */ decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherDeciderSpec.scala
@@ -300,15 +300,15 @@ class AllOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly 
     
     it("should take specified normalization in scope when 'should contain' is used") {
       
-      (List("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (after being trimmed)
-      (Set("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (after being trimmed)
-      (Array("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (after being trimmed)
-      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain allOf (1 -> "one", 2 -> "two ", 3 -> "three")) (after being mapTrimmed)
+      (List("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (using after being trimmed)
+      (Set("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (using after being trimmed)
+      (Array("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (using after being trimmed)
+      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain allOf (1 -> "one", 2 -> "two ", 3 -> "three")) (using after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (after being trimmed)
-      (javaSet("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (after being trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain allOf (Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (after being javaMapTrimmed)
+      (javaList("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (using after being trimmed)
+      (javaSet("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3")) (using after being trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain allOf (Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (using after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -330,38 +330,38 @@ class AllOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly 
       
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain allOf (1, 2, 3)) (after being incremented)
+        (left1 should contain allOf (1, 2, 3)) (using after being incremented)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain allOf (1, 2, 3)) (after being incremented)
+        (left2 should contain allOf (1, 2, 3)) (using after being incremented)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain allOf (1, 2, 3)) (after being incremented)
+        (left3 should contain allOf (1, 2, 3)) (using after being incremented)
       }
         checkShouldContainStackDepth(e3, left3, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain allOf (1 -> "one", 2 -> "two", 3 -> "three")) (after being mapIncremented)
+        (left4 should contain allOf (1 -> "one", 2 -> "two", 3 -> "three")) (using after being mapIncremented)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> "one", 2 -> "two", 3 -> "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain allOf (1, 2, 3)) (after being incremented)
+        (left5 should contain allOf (1, 2, 3)) (using after being incremented)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(1, 2, 3)), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain allOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (after being javaMapIncremented)
+        (left6 should contain allOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using after being javaMapIncremented)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -410,14 +410,14 @@ class AllOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly 
     
     it("should take specified equality and normalization when 'should contain' is used") {
       
-      (List("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Set("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Array("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> "ONE ", 2 -> "TWO", 3 -> "THREE ") should contain allOf (1 -> "one", 2 -> "two ", 3 -> "three")) (decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Set("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Array("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> "ONE ", 2 -> "TWO", 3 -> "THREE ") should contain allOf (1 -> "one", 2 -> "two ", 3 -> "three")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "ONE "), Entry(2, "TWO"), Entry(3, "THREE ")) should contain allOf (Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList("A ", "B", "C ") should contain allOf ("a", "b ", "c ")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "ONE "), Entry(2, "TWO"), Entry(3, "THREE ")) should contain allOf (Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -437,38 +437,38 @@ class AllOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly 
       
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain allOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left1 should contain allOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left2 = Set("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain allOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left2 should contain allOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left3 = Array("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain allOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left3 should contain allOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
       
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain allOf (1 -> " one", 2 -> "two ", 3 -> " three")) (decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should contain allOf (1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> " one", 2 -> "two ", 3 -> " three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("one ", " two", "three ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain allOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left5 should contain allOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain allOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should contain allOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherEqualitySpec.scala
@@ -220,14 +220,14 @@ class AllOfContainMatcherEqualitySpec extends funspec.AnyFunSpec {
       val mapTrimEquality = new MapTrimEquality
       val javaMapTrimEquality = new JavaMapTrimEquality
       
-      (List("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3 ")) (trimEquality)
-      (Set("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3 ")) (trimEquality)
-      (Array("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3 ")) (trimEquality)
-      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain allOf (1 -> "one", 2 -> "two ", 3 -> "three")) (mapTrimEquality)
+      (List("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3 ")) (/* DOTTY-ONLY using */ trimEquality)
+      (Set("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3 ")) (/* DOTTY-ONLY using */ trimEquality)
+      (Array("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3 ")) (/* DOTTY-ONLY using */ trimEquality)
+      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain allOf (1 -> "one", 2 -> "two ", 3 -> "three")) (/* DOTTY-ONLY using */ mapTrimEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3 ")) (trimEquality)
-      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain allOf (Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (javaMapTrimEquality)
+      (javaList("1 ", "2", "3 ") should contain allOf ("1", "2 ", "3 ")) (/* DOTTY-ONLY using */ trimEquality)
+      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain allOf (Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (/* DOTTY-ONLY using */ javaMapTrimEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherEqualitySpec.scala
@@ -251,19 +251,19 @@ class AllOfContainMatcherEqualitySpec extends funspec.AnyFunSpec {
         
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain allOf (1, 2, 3)) (using equality)
+        (left1 should contain allOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain allOf (1, 2, 3)) (using equality)
+        (left2 should contain allOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain allOf (1, 2, 3)) (using equality)
+        (left3 should contain allOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
@@ -271,14 +271,14 @@ class AllOfContainMatcherEqualitySpec extends funspec.AnyFunSpec {
         
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain allOf (1 -> "one", 2 -> "two", 3 -> "three")) (using mapEquality)
+        (left4 should contain allOf (1 -> "one", 2 -> "two", 3 -> "three")) (/* DOTTY-ONLY using */ mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> "one", 2 -> "two", 3 -> "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain allOf (1, 2, 3)) (using equality)
+        (left5 should contain allOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(1, 2, 3)), thisLineNumber - 2)
 
@@ -286,7 +286,7 @@ class AllOfContainMatcherEqualitySpec extends funspec.AnyFunSpec {
       
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain allOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using javaMapEquality)
+        (left6 should contain allOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/AllOfContainMatcherEqualitySpec.scala
@@ -251,19 +251,19 @@ class AllOfContainMatcherEqualitySpec extends funspec.AnyFunSpec {
         
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain allOf (1, 2, 3)) (equality)
+        (left1 should contain allOf (1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain allOf (1, 2, 3)) (equality)
+        (left2 should contain allOf (1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain allOf (1, 2, 3)) (equality)
+        (left3 should contain allOf (1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
@@ -271,14 +271,14 @@ class AllOfContainMatcherEqualitySpec extends funspec.AnyFunSpec {
         
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain allOf (1 -> "one", 2 -> "two", 3 -> "three")) (mapEquality)
+        (left4 should contain allOf (1 -> "one", 2 -> "two", 3 -> "three")) (using mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> "one", 2 -> "two", 3 -> "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain allOf (1, 2, 3)) (equality)
+        (left5 should contain allOf (1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(1, 2, 3)), thisLineNumber - 2)
 
@@ -286,7 +286,7 @@ class AllOfContainMatcherEqualitySpec extends funspec.AnyFunSpec {
       
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain allOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (javaMapEquality)
+        (left6 should contain allOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachAllSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachAllSuite.scala
@@ -175,7 +175,7 @@ class BeforeAndAfterEachAllSuite extends AnyFunSuite {
   }
 
   test("if super.runTest returns normally, but afterEach completes abruptly with an " +
-    "exception, runTest will return a status that contains that exception as an unreportedException (using BeforeAndAfterAllConfigMap).") {
+    "exception, runTest will return a status that contains that exception as an unreportedException (/* DOTTY-ONLY using */ BeforeAndAfterAllConfigMap).") {
 
     class MySuite extends AnyFunSpec with BeforeAndAfterEach with BeforeAndAfterAllConfigMap {
       override def afterEach(): Unit = { throw new NumberFormatException }
@@ -264,7 +264,7 @@ class BeforeAndAfterEachAllSuite extends AnyFunSuite {
   }
 
   test("If super.run returns normally, but afterAll completes abruptly with an " +
-    "exception, the status returned by run will contain that exception as its unreportedException (using BeforeAndAfterAllConfigMap).") {
+    "exception, the status returned by run will contain that exception as its unreportedException (/* DOTTY-ONLY using */ BeforeAndAfterAllConfigMap).") {
 
     class MySuite extends AnyFunSpec with BeforeAndAfterEach with BeforeAndAfterAllConfigMap {
       override def afterAll(cm: ConfigMap): Unit = { throw new NumberFormatException }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachTestDataAsyncSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachTestDataAsyncSuite.scala
@@ -293,7 +293,7 @@ class BeforeAndAfterEachTestDataAsyncSuite extends AsyncFunSuite {
   }
   
   test("If super.run returns normally, but afterAll completes abruptly with an " +
-    "exception, runTest will return a status that contains that exception as an unreportedException (using BeforeAndAfterAllConfigMap).") {
+    "exception, runTest will return a status that contains that exception as an unreportedException (/* DOTTY-ONLY using */ BeforeAndAfterAllConfigMap).") {
     class MySuite extends AnyFunSuite with BeforeAndAfterEachTestData with BeforeAndAfterAllConfigMap {
       override def afterAll(cm: ConfigMap): Unit = { throw new NumberFormatException }
       test("test July") {}

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachTestDataSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/BeforeAndAfterEachTestDataSuite.scala
@@ -271,7 +271,7 @@ class BeforeAndAfterEachTestDataSuite extends AnyFunSuite {
   }
   
   test("If super.run returns normally, but afterAll completes abruptly with an " +
-    "exception, runTest will return a status that contains that exception as an unreportedException (using BeforeAndAfterAllConfigMap).") {
+    "exception, runTest will return a status that contains that exception as an unreportedException (/* DOTTY-ONLY using */ BeforeAndAfterAllConfigMap).") {
     class MySuite extends AnyFunSuite with BeforeAndAfterEachTestData with BeforeAndAfterAllConfigMap {
       override def afterAll(cm: ConfigMap): Unit = { throw new NumberFormatException }
       test("test July") {}

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrDeciderSpec.scala
@@ -46,23 +46,23 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List(" three", " one", "two ")
         val right2 = List(" one", "two ", " three")
         
-        (left should (contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain theSameElementsInOrderAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain allOf (" three", "two ", " one"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain inOrder (" one", "two ", " three"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain oneOf (" one", " four", "five "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain atLeastOneOf (" one", " three", "five "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain only (" three", " one", "two "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain inOrderOnly (" one", "two ", " three"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain noneOf (" seven", "eight ", " nine"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsInOrderAs (right2) and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain allOf (" three", " one", "two ") and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain inOrder (" one", "two ", " three") and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain oneOf (" one", " four", "five ") and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain atLeastOneOf (" one", " three", "five ") and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain only (" three", " one", "two ") and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain inOrderOnly (" one", "two ", " three") and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain noneOf (" seven", "eight ", " nine") and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain theSameElementsInOrderAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain allOf (" three", "two ", " one"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain inOrder (" one", "two ", " three"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain oneOf (" one", " four", "five "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain atLeastOneOf (" one", " three", "five "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain only (" three", " one", "two "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain inOrderOnly (" one", "two ", " three"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain noneOf (" seven", "eight ", " nine"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsInOrderAs (right2) and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain allOf (" three", " one", "two ") and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain inOrder (" one", "two ", " three") and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain oneOf (" one", " four", "five ") and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain atLeastOneOf (" one", " three", "five ") and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain only (" three", " one", "two ") and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain inOrderOnly (" one", "two ", " three") and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain noneOf (" seven", "eight ", " nine") and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         
       }
       
@@ -71,7 +71,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right = List(" three", "two ", " one")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsInOrderAs right and contain theSameElementsAs right)) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+          (left should (contain theSameElementsInOrderAs right and contain theSameElementsAs right)) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -84,7 +84,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right = List(" three", "two ", " one")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsAs right and contain theSameElementsInOrderAs right)) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+          (left should (contain theSameElementsAs right and contain theSameElementsInOrderAs right)) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right) + ", but " + decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -98,14 +98,14 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List("eight ", " one", "two ")
         val right2 = List(" one", "two ", " three")
         
-        (left should (not contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain allOf ("eight ", "two ", " one") and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain inOrder (" one", "two ", "eight ") and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain oneOf (" six", "eight ", " five") and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain only ("eight ", " one", "two ") and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain inOrderOnly (" one", "two ", "eight ") and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain inOrderOnly (" one", "two ", "eight ") and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain allOf ("eight ", "two ", " one") and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain inOrder (" one", "two ", "eight ") and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain oneOf (" six", "eight ", " five") and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain only ("eight ", " one", "two ") and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain inOrderOnly (" one", "two ", "eight ") and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain inOrderOnly (" one", "two ", "eight ") and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
       }
       
       it("should pass when contain and not contain passes") {
@@ -114,14 +114,14 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List(" eight", "one ", " two")
         val right2 = List(" one", "two ", " three")
         
-        (left should (contain theSameElementsAs (right2) and not contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)        
-        (left should (contain theSameElementsAs (right2) and not contain theSameElementsInOrderAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) and not contain allOf (" eight", " two", "one "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) and not contain inOrder ("one ", " two", " eight"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) and not contain oneOf ("six ", " eight", "five "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) and not contain only (" eight", "one ", " two"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) and not contain inOrderOnly ("one ", " two", " eight"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) and not contain noneOf ("one ", " two", " eight"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) and not contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)        
+        (left should (contain theSameElementsAs (right2) and not contain theSameElementsInOrderAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) and not contain allOf (" eight", " two", "one "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) and not contain inOrder ("one ", " two", " eight"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) and not contain oneOf ("six ", " eight", "five "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) and not contain only (" eight", "one ", " two"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) and not contain inOrderOnly ("one ", " two", " eight"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) and not contain noneOf ("one ", " two", " eight"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
       }
       
       it("should pass when not contain and not contain passes") {
@@ -130,14 +130,14 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List(" eight", "one ", " two")
         val right2 = List("one ", " two", " eight")
         
-        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsInOrderAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) and not contain allOf (" eight", " two", "one "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) and not contain inOrder ("one ", " two", " eight"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) and not contain oneOf ("six ", " eight", "five "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) and not contain only (" eight", "one ", " two"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) and not contain inOrderOnly ("one ", " two", " eight"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) and not contain noneOf ("one ", " two", " eight"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsInOrderAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain allOf (" eight", " two", "one "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain inOrder ("one ", " two", " eight"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain oneOf ("six ", " eight", "five "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain only (" eight", "one ", " two"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain inOrderOnly ("one ", " two", " eight"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain noneOf ("one ", " two", " eight"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
       }
       
       it("should failed with correctly stack depth and message when first not contain failed but second contain passed") {
@@ -147,7 +147,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right2 = List(" three", "two ", " one")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs right2)) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+          (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs right2)) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -162,7 +162,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right2 = List(" one", "two ", " three")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsAs right1 and not contain theSameElementsInOrderAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
+          (left should (contain theSameElementsAs right1 and not contain theSameElementsInOrderAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right1) + ", but " + decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -177,7 +177,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right2 = List(" three", "two ", " one")        
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) and not contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
+          (left should (not contain theSameElementsInOrderAs (right1) and not contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -194,23 +194,23 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List("five ", " one", "two ")
         val right2 = List(" one", "two ", " three")
         
-        (left should (contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain theSameElementsInOrderAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain allOf (" three", "two ", " one"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain inOrder (" one", "two ", " three"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain oneOf (" one", " four", "five "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain atLeastOneOf (" one", " three", "five "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain only (" three", " one", "two "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain inOrderOnly (" one", "two ", " three"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain noneOf ("seven ", " eight", "nine "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsInOrderAs (right2) or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain allOf (" three", "two ", " one") or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain inOrder (" one", "two ", " three") or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain oneOf (" one", " four", "five ") or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain atLeastOneOf (" one", " three", "five ") or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain only (" three", " one", "two ") or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain inOrderOnly (" one", "two ", " three") or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain noneOf ("seven ", " eight", "nine ") or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain theSameElementsInOrderAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain allOf (" three", "two ", " one"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain inOrder (" one", "two ", " three"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain oneOf (" one", " four", "five "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain atLeastOneOf (" one", " three", "five "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain only (" three", " one", "two "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain inOrderOnly (" one", "two ", " three"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain noneOf ("seven ", " eight", "nine "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsInOrderAs (right2) or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain allOf (" three", "two ", " one") or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain inOrder (" one", "two ", " three") or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain oneOf (" one", " four", "five ") or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain atLeastOneOf (" one", " three", "five ") or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain only (" three", " one", "two ") or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain inOrderOnly (" one", "two ", " three") or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain noneOf ("seven ", " eight", "nine ") or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         
       }
       
@@ -221,7 +221,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right2 = List(" three", "two ", " one")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsAs right1 or contain theSameElementsInOrderAs right2)) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+          (left should (contain theSameElementsAs right1 or contain theSameElementsInOrderAs right2)) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " did not contain the same elements as " + decorateToStringValue(prettifier, right1) + ", and " + decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -235,14 +235,14 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List("eight ", " one", "two ")
         val right2 = List(" one", "two ", " three")
         
-        (left should (not contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
-        (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain allOf ("eight ", "two ", " one") or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain inOrder (" one", "two ", "eight ") or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain oneOf (" six", "eight ", " five") or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain only ("eight ", " one", "two ") or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain inOrderOnly (" one", "two ", "eight ") or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain noneOf (" one", "two ", "eight ") or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
+        (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain allOf ("eight ", "two ", " one") or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain inOrder (" one", "two ", "eight ") or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain oneOf (" six", "eight ", " five") or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain only ("eight ", " one", "two ") or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain inOrderOnly (" one", "two ", "eight ") or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain noneOf (" one", "two ", "eight ") or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
       }
       
       it("should pass when contain and not contain passes") {
@@ -251,14 +251,14 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List("eight ", " one", "two ")
         val right2 = List(" one", "two ", " three")
         
-        (left should (contain theSameElementsAs (right2) or not contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) or not contain theSameElementsInOrderAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) or not contain allOf ("eight ", "two ", " one"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) or not contain inOrder (" one", "two ", "eight "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) or not contain oneOf (" six", "eight ", " five"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) or not contain only ("eight ", " one", "two "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) or not contain inOrderOnly (" one", "two ", "eight "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) or not contain noneOf (" one", "two ", "eight "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain theSameElementsInOrderAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain allOf ("eight ", "two ", " one"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain inOrder (" one", "two ", "eight "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain oneOf (" six", "eight ", " five"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain only ("eight ", " one", "two "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain inOrderOnly (" one", "two ", "eight "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain noneOf (" one", "two ", "eight "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         
       }
       
@@ -268,14 +268,14 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List("eight ", " one", "two ")
         val right2 = List(" one", "two ", "eight ")
         
-        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsInOrderAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) or not contain allOf ("eight ", "two ", " one"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) or not contain inOrder (" one", "two ", "eight "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) or not contain oneOf (" six", "eight ", " five"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) or not contain only ("eight ", " one", "two "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) or not contain inOrderOnly (" one", "two ", "eight "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) or not contain noneOf (" one", "two ", "eight "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsInOrderAs (right1))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain allOf ("eight ", "two ", " one"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain inOrder (" one", "two ", "eight "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain oneOf (" six", "eight ", " five"))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain only ("eight ", " one", "two "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain inOrderOnly (" one", "two ", "eight "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain noneOf (" one", "two ", "eight "))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
       }
       
       it("should failed with correctly stack depth and message when first not contain failed and second contain failed") {
@@ -285,7 +285,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right2 = List(" eight", "two ", " one")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs right2)) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
+          (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs right2)) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1) + ", and " + decorateToStringValue(prettifier, left) + " did not contain the same elements as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -299,7 +299,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right = List(" three", "two ", " one")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsInOrderAs (right) or not contain theSameElementsAs (right))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+          (left should (contain theSameElementsInOrderAs (right) or not contain theSameElementsAs (right))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right) + ", and " + decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -314,7 +314,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right2 = List(" three", "two ", " one")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) or not contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
+          (left should (not contain theSameElementsInOrderAs (right1) or not contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1) + ", and " + decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrDeciderSpec.scala
@@ -46,23 +46,23 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List(" three", " one", "two ")
         val right2 = List(" one", "two ", " three")
         
-        (left should (contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain theSameElementsInOrderAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain allOf (" three", "two ", " one"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain inOrder (" one", "two ", " three"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain oneOf (" one", " four", "five "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain atLeastOneOf (" one", " three", "five "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain only (" three", " one", "two "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain inOrderOnly (" one", "two ", " three"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) and contain noneOf (" seven", "eight ", " nine"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsInOrderAs (right2) and contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain allOf (" three", " one", "two ") and contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain inOrder (" one", "two ", " three") and contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain oneOf (" one", " four", "five ") and contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain atLeastOneOf (" one", " three", "five ") and contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain only (" three", " one", "two ") and contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain inOrderOnly (" one", "two ", " three") and contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain noneOf (" seven", "eight ", " nine") and contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain theSameElementsInOrderAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain allOf (" three", "two ", " one"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain inOrder (" one", "two ", " three"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain oneOf (" one", " four", "five "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain atLeastOneOf (" one", " three", "five "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain only (" three", " one", "two "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain inOrderOnly (" one", "two ", " three"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) and contain noneOf (" seven", "eight ", " nine"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsInOrderAs (right2) and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain allOf (" three", " one", "two ") and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain inOrder (" one", "two ", " three") and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain oneOf (" one", " four", "five ") and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain atLeastOneOf (" one", " three", "five ") and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain only (" three", " one", "two ") and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain inOrderOnly (" one", "two ", " three") and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain noneOf (" seven", "eight ", " nine") and contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         
       }
       
@@ -71,7 +71,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right = List(" three", "two ", " one")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsInOrderAs right and contain theSameElementsAs right)) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+          (left should (contain theSameElementsInOrderAs right and contain theSameElementsAs right)) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -84,7 +84,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right = List(" three", "two ", " one")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsAs right and contain theSameElementsInOrderAs right)) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+          (left should (contain theSameElementsAs right and contain theSameElementsInOrderAs right)) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right) + ", but " + decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -98,14 +98,14 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List("eight ", " one", "two ")
         val right2 = List(" one", "two ", " three")
         
-        (left should (not contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain allOf ("eight ", "two ", " one") and contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain inOrder (" one", "two ", "eight ") and contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain oneOf (" six", "eight ", " five") and contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain only ("eight ", " one", "two ") and contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain inOrderOnly (" one", "two ", "eight ") and contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain inOrderOnly (" one", "two ", "eight ") and contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain allOf ("eight ", "two ", " one") and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain inOrder (" one", "two ", "eight ") and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain oneOf (" six", "eight ", " five") and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain only ("eight ", " one", "two ") and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain inOrderOnly (" one", "two ", "eight ") and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain inOrderOnly (" one", "two ", "eight ") and contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
       }
       
       it("should pass when contain and not contain passes") {
@@ -114,14 +114,14 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List(" eight", "one ", " two")
         val right2 = List(" one", "two ", " three")
         
-        (left should (contain theSameElementsAs (right2) and not contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)        
-        (left should (contain theSameElementsAs (right2) and not contain theSameElementsInOrderAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) and not contain allOf (" eight", " two", "one "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) and not contain inOrder ("one ", " two", " eight"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) and not contain oneOf ("six ", " eight", "five "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) and not contain only (" eight", "one ", " two"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) and not contain inOrderOnly ("one ", " two", " eight"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) and not contain noneOf ("one ", " two", " eight"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) and not contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)        
+        (left should (contain theSameElementsAs (right2) and not contain theSameElementsInOrderAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) and not contain allOf (" eight", " two", "one "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) and not contain inOrder ("one ", " two", " eight"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) and not contain oneOf ("six ", " eight", "five "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) and not contain only (" eight", "one ", " two"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) and not contain inOrderOnly ("one ", " two", " eight"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) and not contain noneOf ("one ", " two", " eight"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
       }
       
       it("should pass when not contain and not contain passes") {
@@ -130,14 +130,14 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List(" eight", "one ", " two")
         val right2 = List("one ", " two", " eight")
         
-        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsInOrderAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) and not contain allOf (" eight", " two", "one "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) and not contain inOrder ("one ", " two", " eight"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) and not contain oneOf ("six ", " eight", "five "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) and not contain only (" eight", "one ", " two"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) and not contain inOrderOnly ("one ", " two", " eight"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) and not contain noneOf ("one ", " two", " eight"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsInOrderAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain allOf (" eight", " two", "one "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain inOrder ("one ", " two", " eight"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain oneOf ("six ", " eight", "five "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain only (" eight", "one ", " two"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain inOrderOnly ("one ", " two", " eight"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) and not contain noneOf ("one ", " two", " eight"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
       }
       
       it("should failed with correctly stack depth and message when first not contain failed but second contain passed") {
@@ -147,7 +147,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right2 = List(" three", "two ", " one")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs right2)) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+          (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs right2)) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -162,7 +162,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right2 = List(" one", "two ", " three")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsAs right1 and not contain theSameElementsInOrderAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
+          (left should (contain theSameElementsAs right1 and not contain theSameElementsInOrderAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right1) + ", but " + decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -177,7 +177,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right2 = List(" three", "two ", " one")        
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) and not contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
+          (left should (not contain theSameElementsInOrderAs (right1) and not contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -194,23 +194,23 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List("five ", " one", "two ")
         val right2 = List(" one", "two ", " three")
         
-        (left should (contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain theSameElementsInOrderAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain allOf (" three", "two ", " one"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain inOrder (" one", "two ", " three"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain oneOf (" one", " four", "five "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain atLeastOneOf (" one", " three", "five "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain only (" three", " one", "two "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain inOrderOnly (" one", "two ", " three"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right1) or contain noneOf ("seven ", " eight", "nine "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsInOrderAs (right2) or contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain allOf (" three", "two ", " one") or contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain inOrder (" one", "two ", " three") or contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain oneOf (" one", " four", "five ") or contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain atLeastOneOf (" one", " three", "five ") or contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain only (" three", " one", "two ") or contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain inOrderOnly (" one", "two ", " three") or contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain noneOf ("seven ", " eight", "nine ") or contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain theSameElementsInOrderAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain allOf (" three", "two ", " one"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain inOrder (" one", "two ", " three"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain oneOf (" one", " four", "five "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain atLeastOneOf (" one", " three", "five "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain only (" three", " one", "two "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain inOrderOnly (" one", "two ", " three"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right1) or contain noneOf ("seven ", " eight", "nine "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsInOrderAs (right2) or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain allOf (" three", "two ", " one") or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain inOrder (" one", "two ", " three") or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain oneOf (" one", " four", "five ") or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain atLeastOneOf (" one", " three", "five ") or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain only (" three", " one", "two ") or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain inOrderOnly (" one", "two ", " three") or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain noneOf ("seven ", " eight", "nine ") or contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         
       }
       
@@ -221,7 +221,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right2 = List(" three", "two ", " one")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsAs right1 or contain theSameElementsInOrderAs right2)) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+          (left should (contain theSameElementsAs right1 or contain theSameElementsInOrderAs right2)) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " did not contain the same elements as " + decorateToStringValue(prettifier, right1) + ", and " + decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -235,14 +235,14 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List("eight ", " one", "two ")
         val right2 = List(" one", "two ", " three")
         
-        (left should (not contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
-        (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain allOf ("eight ", "two ", " one") or contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain inOrder (" one", "two ", "eight ") or contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain oneOf (" six", "eight ", " five") or contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain only ("eight ", " one", "two ") or contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain inOrderOnly (" one", "two ", "eight ") or contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain noneOf (" one", "two ", "eight ") or contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
+        (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain allOf ("eight ", "two ", " one") or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain inOrder (" one", "two ", "eight ") or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain oneOf (" six", "eight ", " five") or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain only ("eight ", " one", "two ") or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain inOrderOnly (" one", "two ", "eight ") or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain noneOf (" one", "two ", "eight ") or contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
       }
       
       it("should pass when contain and not contain passes") {
@@ -251,14 +251,14 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List("eight ", " one", "two ")
         val right2 = List(" one", "two ", " three")
         
-        (left should (contain theSameElementsAs (right2) or not contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) or not contain theSameElementsInOrderAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) or not contain allOf ("eight ", "two ", " one"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) or not contain inOrder (" one", "two ", "eight "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) or not contain oneOf (" six", "eight ", " five"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) or not contain only ("eight ", " one", "two "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) or not contain inOrderOnly (" one", "two ", "eight "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (contain theSameElementsAs (right2) or not contain noneOf (" one", "two ", "eight "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain theSameElementsInOrderAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain allOf ("eight ", "two ", " one"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain inOrder (" one", "two ", "eight "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain oneOf (" six", "eight ", " five"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain only ("eight ", " one", "two "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain inOrderOnly (" one", "two ", "eight "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (contain theSameElementsAs (right2) or not contain noneOf (" one", "two ", "eight "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         
       }
       
@@ -268,14 +268,14 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right1 = List("eight ", " one", "two ")
         val right2 = List(" one", "two ", "eight ")
         
-        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsInOrderAs (right1))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) or not contain allOf ("eight ", "two ", " one"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) or not contain inOrder (" one", "two ", "eight "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) or not contain oneOf (" six", "eight ", " five"))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) or not contain only ("eight ", " one", "two "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) or not contain inOrderOnly (" one", "two ", "eight "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
-        (left should (not contain theSameElementsAs (right2) or not contain noneOf (" one", "two ", "eight "))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsInOrderAs (right1))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain allOf ("eight ", "two ", " one"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain inOrder (" one", "two ", "eight "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain oneOf (" six", "eight ", " five"))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain only ("eight ", " one", "two "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain inOrderOnly (" one", "two ", "eight "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+        (left should (not contain theSameElementsAs (right2) or not contain noneOf (" one", "two ", "eight "))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
       }
       
       it("should failed with correctly stack depth and message when first not contain failed and second contain failed") {
@@ -285,7 +285,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right2 = List(" eight", "two ", " one")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs right2)) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
+          (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs right2)) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1) + ", and " + decorateToStringValue(prettifier, left) + " did not contain the same elements as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -299,7 +299,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right = List(" three", "two ", " one")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsInOrderAs (right) or not contain theSameElementsAs (right))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
+          (left should (contain theSameElementsInOrderAs (right) or not contain theSameElementsAs (right))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right) + ", and " + decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))
@@ -314,7 +314,7 @@ class ContainMatcherAndOrDeciderSpec extends AnyFunSpec with Explicitly {
         val right2 = List(" three", "two ", " one")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) or not contain theSameElementsAs (right2))) (decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
+          (left should (not contain theSameElementsInOrderAs (right1) or not contain theSameElementsAs (right2))) (using decided by equality afterBeing trimmed, decided by equality afterBeing trimmed) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1) + ", and " + decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrDeciderSpec.scala"))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrExplicitEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrExplicitEqualitySpec.scala
@@ -44,23 +44,23 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List(" 3", " 1", "2 ")
         val right2 = List(" 1", "2 ", " 3")
         
-        (left should (contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain theSameElementsInOrderAs (right2))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain allOf (" 3", "2 ", " 1"))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain inOrder (" 1", "2 ", " 3"))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain oneOf (" 1", " 4", "5 "))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain atLeastOneOf (" 1", " 3", "5 "))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain only (" 3", " 1", "2 "))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain inOrderOnly (" 1", "2 ", " 3"))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain noneOf (" 7", "8 ", " 9"))) (equality, equality)
-        (left should (contain theSameElementsInOrderAs (right2) and contain theSameElementsAs (right1))) (equality, equality)
-        (left should (contain allOf (" 3", " 1", "2 ") and contain theSameElementsAs (right1))) (equality, equality)
-        (left should (contain inOrder (" 1", "2 ", " 3") and contain theSameElementsAs (right1))) (equality, equality)
-        (left should (contain oneOf (" 1", " 4", "5 ") and contain theSameElementsAs (right1))) (equality, equality)
-        (left should (contain atLeastOneOf (" 1", " 3", "5 ") and contain theSameElementsAs (right1))) (equality, equality)
-        (left should (contain only (" 3", " 1", "2 ") and contain theSameElementsAs (right1))) (equality, equality)
-        (left should (contain inOrderOnly (" 1", "2 ", " 3") and contain theSameElementsAs (right1))) (equality, equality)
-        (left should (contain noneOf (" 7", "8 ", " 9") and contain theSameElementsAs (right1))) (equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain theSameElementsInOrderAs (right2))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain allOf (" 3", "2 ", " 1"))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain inOrder (" 1", "2 ", " 3"))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain oneOf (" 1", " 4", "5 "))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain atLeastOneOf (" 1", " 3", "5 "))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain only (" 3", " 1", "2 "))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain inOrderOnly (" 1", "2 ", " 3"))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain noneOf (" 7", "8 ", " 9"))) (using equality, equality)
+        (left should (contain theSameElementsInOrderAs (right2) and contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain allOf (" 3", " 1", "2 ") and contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain inOrder (" 1", "2 ", " 3") and contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain oneOf (" 1", " 4", "5 ") and contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain atLeastOneOf (" 1", " 3", "5 ") and contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain only (" 3", " 1", "2 ") and contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain inOrderOnly (" 1", "2 ", " 3") and contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain noneOf (" 7", "8 ", " 9") and contain theSameElementsAs (right1))) (using equality, equality)
         
       }
       
@@ -69,7 +69,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right = List(" 3", "2 ", " 1")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsInOrderAs right and contain theSameElementsAs right)) (equality, equality)
+          (left should (contain theSameElementsInOrderAs right and contain theSameElementsAs right)) (using equality, equality)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -82,7 +82,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right = List(" 3", "2 ", " 1")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsAs right and contain theSameElementsInOrderAs right)) (equality, equality) 
+          (left should (contain theSameElementsAs right and contain theSameElementsInOrderAs right)) (using equality, equality) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right) + ", but " + decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -96,14 +96,14 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List("8 ", " 1", "2 ")
         val right2 = List(" 1", "2 ", " 3")
         
-        (left should (not contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (equality, equality)
-        (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs (right2))) (equality, equality)
-        (left should (not contain allOf ("8 ", "2 ", " 1") and contain theSameElementsAs (right2))) (equality, equality)
-        (left should (not contain inOrder (" 1", "2 ", "8 ") and contain theSameElementsAs (right2))) (equality, equality)
-        (left should (not contain oneOf (" 6", "8 ", " 5") and contain theSameElementsAs (right2))) (equality, equality)
-        (left should (not contain only ("8 ", " 1", "2 ") and contain theSameElementsAs (right2))) (equality, equality)
-        (left should (not contain inOrderOnly (" 1", "2 ", "8 ") and contain theSameElementsAs (right2))) (equality, equality)
-        (left should (not contain inOrderOnly (" 1", "2 ", "8 ") and contain theSameElementsAs (right2))) (equality, equality)
+        (left should (not contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain allOf ("8 ", "2 ", " 1") and contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain inOrder (" 1", "2 ", "8 ") and contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain oneOf (" 6", "8 ", " 5") and contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain only ("8 ", " 1", "2 ") and contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain inOrderOnly (" 1", "2 ", "8 ") and contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain inOrderOnly (" 1", "2 ", "8 ") and contain theSameElementsAs (right2))) (using equality, equality)
       }
       
       it("should pass when contain and not contain passes") {
@@ -112,14 +112,14 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List(" 8", "1 ", " 2")
         val right2 = List(" 1", "2 ", " 3")
         
-        (left should ((contain theSameElementsAs (right2)) and not contain theSameElementsAs (right1))) (equality, equality)
-        (left should ((contain theSameElementsAs (right2)) and not contain theSameElementsInOrderAs (right1))) (equality, equality)
-        (left should ((contain theSameElementsAs (right2)) and not contain allOf (" 8", " 2", "1 "))) (equality, equality)
-        (left should ((contain theSameElementsAs (right2)) and not contain inOrder ("1 ", " 2", " 8"))) (equality, equality)
-        (left should ((contain theSameElementsAs (right2)) and not contain oneOf ("6 ", " 8", "5 "))) (equality, equality)
-        (left should ((contain theSameElementsAs (right2)) and not contain only (" 8", "1 ", " 2"))) (equality, equality)
-        (left should ((contain theSameElementsAs (right2)) and not contain inOrderOnly ("1 ", " 2", " 8"))) (equality, equality)
-        (left should ((contain theSameElementsAs (right2)) and not contain noneOf ("1 ", " 2", " 8"))) (equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain theSameElementsAs (right1))) (using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain theSameElementsInOrderAs (right1))) (using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain allOf (" 8", " 2", "1 "))) (using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain inOrder ("1 ", " 2", " 8"))) (using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain oneOf ("6 ", " 8", "5 "))) (using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain only (" 8", "1 ", " 2"))) (using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain inOrderOnly ("1 ", " 2", " 8"))) (using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain noneOf ("1 ", " 2", " 8"))) (using equality, equality)
       }
       
       it("should pass when not contain and not contain passes") {
@@ -128,14 +128,14 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List(" 8", "1 ", " 2")
         val right2 = List("1 ", " 2", " 8")
         
-        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsAs (right1))) (equality, equality)
-        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsInOrderAs (right1))) (equality, equality)
-        (left should (not contain theSameElementsAs (right2) and not contain allOf (" 8", " 2", "1 "))) (equality, equality)
-        (left should (not contain theSameElementsAs (right2) and not contain inOrder ("1 ", " 2", " 8"))) (equality, equality)
-        (left should (not contain theSameElementsAs (right2) and not contain oneOf ("6 ", " 8", "5 "))) (equality, equality)
-        (left should (not contain theSameElementsAs (right2) and not contain only (" 8", "1 ", " 2"))) (equality, equality)
-        (left should (not contain theSameElementsAs (right2) and not contain inOrderOnly ("1 ", " 2", " 8"))) (equality, equality)
-        (left should (not contain theSameElementsAs (right2) and not contain noneOf ("1 ", " 2", " 8"))) (equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsInOrderAs (right1))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain allOf (" 8", " 2", "1 "))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain inOrder ("1 ", " 2", " 8"))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain oneOf ("6 ", " 8", "5 "))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain only (" 8", "1 ", " 2"))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain inOrderOnly ("1 ", " 2", " 8"))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain noneOf ("1 ", " 2", " 8"))) (using equality, equality)
       }
       
       it("should failed with correctly stack depth and message when first not contain failed but second contain passed") {
@@ -145,7 +145,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right2 = List(" 3", "2 ", " 1")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs right2)) (equality, equality) 
+          (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs right2)) (using equality, equality) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -160,7 +160,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right2 = List(" 1", "2 ", " 3")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should ((contain theSameElementsAs right1) and not contain theSameElementsInOrderAs (right2))) (equality, equality) 
+          (left should ((contain theSameElementsAs right1) and not contain theSameElementsInOrderAs (right2))) (using equality, equality) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right1) + ", but " + decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -175,7 +175,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right2 = List(" 3", "2 ", " 1")        
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) and not contain theSameElementsAs (right2))) (equality, equality)
+          (left should (not contain theSameElementsInOrderAs (right1) and not contain theSameElementsAs (right2))) (using equality, equality)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -192,23 +192,23 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List("5 ", " 1", "2 ")
         val right2 = List(" 1", "2 ", " 3")
         
-        (left should (contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain theSameElementsInOrderAs (right2))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain allOf (" 3", "2 ", " 1"))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain inOrder (" 1", "2 ", " 3"))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain oneOf (" 1", " 4", "5 "))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain atLeastOneOf (" 1", " 3", "5 "))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain only (" 3", " 1", "2 "))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain inOrderOnly (" 1", "2 ", " 3"))) (equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain noneOf ("7 ", " 8", "9 "))) (equality, equality)
-        (left should (contain theSameElementsInOrderAs (right2) or contain theSameElementsAs (right1))) (equality, equality)
-        (left should (contain allOf (" 3", "2 ", " 1") or contain theSameElementsAs (right1))) (equality, equality)
-        (left should (contain inOrder (" 1", "2 ", " 3") or contain theSameElementsAs (right1))) (equality, equality)
-        (left should (contain oneOf (" 1", " 4", "5 ") or contain theSameElementsAs (right1))) (equality, equality)
-        (left should (contain atLeastOneOf (" 1", " 3", "5 ") or contain theSameElementsAs (right1))) (equality, equality)
-        (left should (contain only (" 3", " 1", "2 ") or contain theSameElementsAs (right1))) (equality, equality)
-        (left should (contain inOrderOnly (" 1", "2 ", " 3") or contain theSameElementsAs (right1))) (equality, equality)
-        (left should (contain noneOf ("7 ", " 8", "9 ") or contain theSameElementsAs (right1))) (equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain theSameElementsInOrderAs (right2))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain allOf (" 3", "2 ", " 1"))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain inOrder (" 1", "2 ", " 3"))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain oneOf (" 1", " 4", "5 "))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain atLeastOneOf (" 1", " 3", "5 "))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain only (" 3", " 1", "2 "))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain inOrderOnly (" 1", "2 ", " 3"))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain noneOf ("7 ", " 8", "9 "))) (using equality, equality)
+        (left should (contain theSameElementsInOrderAs (right2) or contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain allOf (" 3", "2 ", " 1") or contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain inOrder (" 1", "2 ", " 3") or contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain oneOf (" 1", " 4", "5 ") or contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain atLeastOneOf (" 1", " 3", "5 ") or contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain only (" 3", " 1", "2 ") or contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain inOrderOnly (" 1", "2 ", " 3") or contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain noneOf ("7 ", " 8", "9 ") or contain theSameElementsAs (right1))) (using equality, equality)
         
       }
       
@@ -219,7 +219,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right2 = List(" 3", "2 ", " 1")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsAs right1 or contain theSameElementsInOrderAs right2)) (equality, equality)
+          (left should (contain theSameElementsAs right1 or contain theSameElementsInOrderAs right2)) (using equality, equality)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " did not contain the same elements as " + decorateToStringValue(prettifier, right1) + ", and " + decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -233,14 +233,14 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List("8 ", " 1", "2 ")
         val right2 = List(" 1", "2 ", " 3")
         
-        (left should (not contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (equality, equality)
-        (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs (right2))) (equality, equality)
-        (left should (not contain allOf ("8 ", "2 ", " 1") or contain theSameElementsAs (right2))) (equality, equality)
-        (left should (not contain inOrder (" 1", "2 ", "8 ") or contain theSameElementsAs (right2))) (equality, equality)
-        (left should (not contain oneOf (" 6", "8 ", " 5") or contain theSameElementsAs (right2))) (equality, equality)
-        (left should (not contain only ("8 ", " 1", "2 ") or contain theSameElementsAs (right2))) (equality, equality)
-        (left should (not contain inOrderOnly (" 1", "2 ", "8 ") or contain theSameElementsAs (right2))) (equality, equality)
-        (left should (not contain noneOf (" 1", "2 ", "8 ") or contain theSameElementsAs (right2))) (equality, equality)
+        (left should (not contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain allOf ("8 ", "2 ", " 1") or contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain inOrder (" 1", "2 ", "8 ") or contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain oneOf (" 6", "8 ", " 5") or contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain only ("8 ", " 1", "2 ") or contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain inOrderOnly (" 1", "2 ", "8 ") or contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain noneOf (" 1", "2 ", "8 ") or contain theSameElementsAs (right2))) (using equality, equality)
       }
       
       it("should pass when contain and not contain passes") {
@@ -249,14 +249,14 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List("8 ", " 1", "2 ")
         val right2 = List(" 1", "2 ", " 3")
         
-        (left should ((contain theSameElementsAs (right2)) or not contain theSameElementsAs (right1))) (equality, equality)
-        (left should ((contain theSameElementsAs (right2)) or not contain theSameElementsInOrderAs (right1))) (equality, equality)
-        (left should ((contain theSameElementsAs (right2)) or not contain allOf ("8 ", "2 ", " 1"))) (equality, equality)
-        (left should ((contain theSameElementsAs (right2)) or not contain inOrder (" 1", "2 ", "8 "))) (equality, equality)
-        (left should ((contain theSameElementsAs (right2)) or not contain oneOf (" 6", "8 ", " 5"))) (equality, equality)
-        (left should ((contain theSameElementsAs (right2)) or not contain only ("8 ", " 1", "2 "))) (equality, equality)
-        (left should ((contain theSameElementsAs (right2)) or not contain inOrderOnly (" 1", "2 ", "8 ")))(equality, equality)
-        (left should ((contain theSameElementsAs (right2)) or not contain noneOf (" 1", "2 ", "8 "))) (equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain theSameElementsAs (right1))) (using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain theSameElementsInOrderAs (right1))) (using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain allOf ("8 ", "2 ", " 1"))) (using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain inOrder (" 1", "2 ", "8 "))) (using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain oneOf (" 6", "8 ", " 5"))) (using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain only ("8 ", " 1", "2 "))) (using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain inOrderOnly (" 1", "2 ", "8 ")))(using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain noneOf (" 1", "2 ", "8 "))) (using equality, equality)
         
       }
       
@@ -266,14 +266,14 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List("8 ", " 1", "2 ")
         val right2 = List(" 1", "2 ", "8 ")
         
-        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsAs (right1))) (equality, equality)
-        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsInOrderAs (right1))) (equality, equality)
-        (left should (not contain theSameElementsAs (right2) or not contain allOf ("8 ", "2 ", " 1"))) (equality, equality)
-        (left should (not contain theSameElementsAs (right2) or not contain inOrder (" 1", "2 ", "8 "))) (equality, equality)
-        (left should (not contain theSameElementsAs (right2) or not contain oneOf (" 6", "8 ", " 5"))) (equality, equality)
-        (left should (not contain theSameElementsAs (right2) or not contain only ("8 ", " 1", "2 "))) (equality, equality)
-        (left should (not contain theSameElementsAs (right2) or not contain inOrderOnly (" 1", "2 ", "8 "))) (equality, equality)
-        (left should (not contain theSameElementsAs (right2) or not contain noneOf (" 1", "2 ", "8 "))) (equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsInOrderAs (right1))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain allOf ("8 ", "2 ", " 1"))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain inOrder (" 1", "2 ", "8 "))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain oneOf (" 6", "8 ", " 5"))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain only ("8 ", " 1", "2 "))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain inOrderOnly (" 1", "2 ", "8 "))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain noneOf (" 1", "2 ", "8 "))) (using equality, equality)
       }
       
       it("should failed with correctly stack depth and message when first not contain failed and second contain failed") {
@@ -283,7 +283,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right2 = List(" 8", "2 ", " 1")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs right2)) (equality, equality)
+          (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs right2)) (using equality, equality)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1) + ", and " + decorateToStringValue(prettifier, left) + " did not contain the same elements as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -297,7 +297,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right = List(" 3", "2 ", " 1")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsInOrderAs (right) or not contain theSameElementsAs (right))) (equality, equality) 
+          (left should (contain theSameElementsInOrderAs (right) or not contain theSameElementsAs (right))) (using equality, equality) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right) + ", and " + decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -312,7 +312,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right2 = List(" 3", "2 ", " 1")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) or not contain theSameElementsAs (right2))) (equality, equality) 
+          (left should (not contain theSameElementsInOrderAs (right1) or not contain theSameElementsAs (right2))) (using equality, equality) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1) + ", and " + decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrExplicitEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ContainMatcherAndOrExplicitEqualitySpec.scala
@@ -44,23 +44,23 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List(" 3", " 1", "2 ")
         val right2 = List(" 1", "2 ", " 3")
         
-        (left should (contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain theSameElementsInOrderAs (right2))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain allOf (" 3", "2 ", " 1"))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain inOrder (" 1", "2 ", " 3"))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain oneOf (" 1", " 4", "5 "))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain atLeastOneOf (" 1", " 3", "5 "))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain only (" 3", " 1", "2 "))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain inOrderOnly (" 1", "2 ", " 3"))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) and contain noneOf (" 7", "8 ", " 9"))) (using equality, equality)
-        (left should (contain theSameElementsInOrderAs (right2) and contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (contain allOf (" 3", " 1", "2 ") and contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (contain inOrder (" 1", "2 ", " 3") and contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (contain oneOf (" 1", " 4", "5 ") and contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (contain atLeastOneOf (" 1", " 3", "5 ") and contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (contain only (" 3", " 1", "2 ") and contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (contain inOrderOnly (" 1", "2 ", " 3") and contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (contain noneOf (" 7", "8 ", " 9") and contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain theSameElementsInOrderAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain allOf (" 3", "2 ", " 1"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain inOrder (" 1", "2 ", " 3"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain oneOf (" 1", " 4", "5 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain atLeastOneOf (" 1", " 3", "5 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain only (" 3", " 1", "2 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain inOrderOnly (" 1", "2 ", " 3"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) and contain noneOf (" 7", "8 ", " 9"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsInOrderAs (right2) and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain allOf (" 3", " 1", "2 ") and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain inOrder (" 1", "2 ", " 3") and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain oneOf (" 1", " 4", "5 ") and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain atLeastOneOf (" 1", " 3", "5 ") and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain only (" 3", " 1", "2 ") and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain inOrderOnly (" 1", "2 ", " 3") and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain noneOf (" 7", "8 ", " 9") and contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
         
       }
       
@@ -69,7 +69,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right = List(" 3", "2 ", " 1")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsInOrderAs right and contain theSameElementsAs right)) (using equality, equality)
+          (left should (contain theSameElementsInOrderAs right and contain theSameElementsAs right)) (/* DOTTY-ONLY using */ equality, equality)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -82,7 +82,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right = List(" 3", "2 ", " 1")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsAs right and contain theSameElementsInOrderAs right)) (using equality, equality) 
+          (left should (contain theSameElementsAs right and contain theSameElementsInOrderAs right)) (/* DOTTY-ONLY using */ equality, equality) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right) + ", but " + decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -96,14 +96,14 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List("8 ", " 1", "2 ")
         val right2 = List(" 1", "2 ", " 3")
         
-        (left should (not contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (not contain allOf ("8 ", "2 ", " 1") and contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (not contain inOrder (" 1", "2 ", "8 ") and contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (not contain oneOf (" 6", "8 ", " 5") and contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (not contain only ("8 ", " 1", "2 ") and contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (not contain inOrderOnly (" 1", "2 ", "8 ") and contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (not contain inOrderOnly (" 1", "2 ", "8 ") and contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right1) and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain allOf ("8 ", "2 ", " 1") and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain inOrder (" 1", "2 ", "8 ") and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain oneOf (" 6", "8 ", " 5") and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain only ("8 ", " 1", "2 ") and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain inOrderOnly (" 1", "2 ", "8 ") and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain inOrderOnly (" 1", "2 ", "8 ") and contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
       }
       
       it("should pass when contain and not contain passes") {
@@ -112,14 +112,14 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List(" 8", "1 ", " 2")
         val right2 = List(" 1", "2 ", " 3")
         
-        (left should ((contain theSameElementsAs (right2)) and not contain theSameElementsAs (right1))) (using equality, equality)
-        (left should ((contain theSameElementsAs (right2)) and not contain theSameElementsInOrderAs (right1))) (using equality, equality)
-        (left should ((contain theSameElementsAs (right2)) and not contain allOf (" 8", " 2", "1 "))) (using equality, equality)
-        (left should ((contain theSameElementsAs (right2)) and not contain inOrder ("1 ", " 2", " 8"))) (using equality, equality)
-        (left should ((contain theSameElementsAs (right2)) and not contain oneOf ("6 ", " 8", "5 "))) (using equality, equality)
-        (left should ((contain theSameElementsAs (right2)) and not contain only (" 8", "1 ", " 2"))) (using equality, equality)
-        (left should ((contain theSameElementsAs (right2)) and not contain inOrderOnly ("1 ", " 2", " 8"))) (using equality, equality)
-        (left should ((contain theSameElementsAs (right2)) and not contain noneOf ("1 ", " 2", " 8"))) (using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain theSameElementsInOrderAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain allOf (" 8", " 2", "1 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain inOrder ("1 ", " 2", " 8"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain oneOf ("6 ", " 8", "5 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain only (" 8", "1 ", " 2"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain inOrderOnly ("1 ", " 2", " 8"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should ((contain theSameElementsAs (right2)) and not contain noneOf ("1 ", " 2", " 8"))) (/* DOTTY-ONLY using */ equality, equality)
       }
       
       it("should pass when not contain and not contain passes") {
@@ -128,14 +128,14 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List(" 8", "1 ", " 2")
         val right2 = List("1 ", " 2", " 8")
         
-        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsInOrderAs (right1))) (using equality, equality)
-        (left should (not contain theSameElementsAs (right2) and not contain allOf (" 8", " 2", "1 "))) (using equality, equality)
-        (left should (not contain theSameElementsAs (right2) and not contain inOrder ("1 ", " 2", " 8"))) (using equality, equality)
-        (left should (not contain theSameElementsAs (right2) and not contain oneOf ("6 ", " 8", "5 "))) (using equality, equality)
-        (left should (not contain theSameElementsAs (right2) and not contain only (" 8", "1 ", " 2"))) (using equality, equality)
-        (left should (not contain theSameElementsAs (right2) and not contain inOrderOnly ("1 ", " 2", " 8"))) (using equality, equality)
-        (left should (not contain theSameElementsAs (right2) and not contain noneOf ("1 ", " 2", " 8"))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain theSameElementsInOrderAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain allOf (" 8", " 2", "1 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain inOrder ("1 ", " 2", " 8"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain oneOf ("6 ", " 8", "5 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain only (" 8", "1 ", " 2"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain inOrderOnly ("1 ", " 2", " 8"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsAs (right2) and not contain noneOf ("1 ", " 2", " 8"))) (/* DOTTY-ONLY using */ equality, equality)
       }
       
       it("should failed with correctly stack depth and message when first not contain failed but second contain passed") {
@@ -145,7 +145,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right2 = List(" 3", "2 ", " 1")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs right2)) (using equality, equality) 
+          (left should (not contain theSameElementsInOrderAs (right1) and contain theSameElementsAs right2)) (/* DOTTY-ONLY using */ equality, equality) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -160,7 +160,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right2 = List(" 1", "2 ", " 3")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should ((contain theSameElementsAs right1) and not contain theSameElementsInOrderAs (right2))) (using equality, equality) 
+          (left should ((contain theSameElementsAs right1) and not contain theSameElementsInOrderAs (right2))) (/* DOTTY-ONLY using */ equality, equality) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right1) + ", but " + decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -175,7 +175,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right2 = List(" 3", "2 ", " 1")        
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) and not contain theSameElementsAs (right2))) (using equality, equality)
+          (left should (not contain theSameElementsInOrderAs (right1) and not contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -192,23 +192,23 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List("5 ", " 1", "2 ")
         val right2 = List(" 1", "2 ", " 3")
         
-        (left should (contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain theSameElementsInOrderAs (right2))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain allOf (" 3", "2 ", " 1"))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain inOrder (" 1", "2 ", " 3"))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain oneOf (" 1", " 4", "5 "))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain atLeastOneOf (" 1", " 3", "5 "))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain only (" 3", " 1", "2 "))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain inOrderOnly (" 1", "2 ", " 3"))) (using equality, equality)
-        (left should (contain theSameElementsAs (right1) or contain noneOf ("7 ", " 8", "9 "))) (using equality, equality)
-        (left should (contain theSameElementsInOrderAs (right2) or contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (contain allOf (" 3", "2 ", " 1") or contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (contain inOrder (" 1", "2 ", " 3") or contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (contain oneOf (" 1", " 4", "5 ") or contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (contain atLeastOneOf (" 1", " 3", "5 ") or contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (contain only (" 3", " 1", "2 ") or contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (contain inOrderOnly (" 1", "2 ", " 3") or contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (contain noneOf ("7 ", " 8", "9 ") or contain theSameElementsAs (right1))) (using equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain theSameElementsInOrderAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain allOf (" 3", "2 ", " 1"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain inOrder (" 1", "2 ", " 3"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain oneOf (" 1", " 4", "5 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain atLeastOneOf (" 1", " 3", "5 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain only (" 3", " 1", "2 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain inOrderOnly (" 1", "2 ", " 3"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsAs (right1) or contain noneOf ("7 ", " 8", "9 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain theSameElementsInOrderAs (right2) or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain allOf (" 3", "2 ", " 1") or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain inOrder (" 1", "2 ", " 3") or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain oneOf (" 1", " 4", "5 ") or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain atLeastOneOf (" 1", " 3", "5 ") or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain only (" 3", " 1", "2 ") or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain inOrderOnly (" 1", "2 ", " 3") or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (contain noneOf ("7 ", " 8", "9 ") or contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
         
       }
       
@@ -219,7 +219,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right2 = List(" 3", "2 ", " 1")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsAs right1 or contain theSameElementsInOrderAs right2)) (using equality, equality)
+          (left should (contain theSameElementsAs right1 or contain theSameElementsInOrderAs right2)) (/* DOTTY-ONLY using */ equality, equality)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " did not contain the same elements as " + decorateToStringValue(prettifier, right1) + ", and " + decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -233,14 +233,14 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List("8 ", " 1", "2 ")
         val right2 = List(" 1", "2 ", " 3")
         
-        (left should (not contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (not contain allOf ("8 ", "2 ", " 1") or contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (not contain inOrder (" 1", "2 ", "8 ") or contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (not contain oneOf (" 6", "8 ", " 5") or contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (not contain only ("8 ", " 1", "2 ") or contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (not contain inOrderOnly (" 1", "2 ", "8 ") or contain theSameElementsAs (right2))) (using equality, equality)
-        (left should (not contain noneOf (" 1", "2 ", "8 ") or contain theSameElementsAs (right2))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right1) or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain allOf ("8 ", "2 ", " 1") or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain inOrder (" 1", "2 ", "8 ") or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain oneOf (" 6", "8 ", " 5") or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain only ("8 ", " 1", "2 ") or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain inOrderOnly (" 1", "2 ", "8 ") or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain noneOf (" 1", "2 ", "8 ") or contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality)
       }
       
       it("should pass when contain and not contain passes") {
@@ -249,14 +249,14 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List("8 ", " 1", "2 ")
         val right2 = List(" 1", "2 ", " 3")
         
-        (left should ((contain theSameElementsAs (right2)) or not contain theSameElementsAs (right1))) (using equality, equality)
-        (left should ((contain theSameElementsAs (right2)) or not contain theSameElementsInOrderAs (right1))) (using equality, equality)
-        (left should ((contain theSameElementsAs (right2)) or not contain allOf ("8 ", "2 ", " 1"))) (using equality, equality)
-        (left should ((contain theSameElementsAs (right2)) or not contain inOrder (" 1", "2 ", "8 "))) (using equality, equality)
-        (left should ((contain theSameElementsAs (right2)) or not contain oneOf (" 6", "8 ", " 5"))) (using equality, equality)
-        (left should ((contain theSameElementsAs (right2)) or not contain only ("8 ", " 1", "2 "))) (using equality, equality)
-        (left should ((contain theSameElementsAs (right2)) or not contain inOrderOnly (" 1", "2 ", "8 ")))(using equality, equality)
-        (left should ((contain theSameElementsAs (right2)) or not contain noneOf (" 1", "2 ", "8 "))) (using equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain theSameElementsInOrderAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain allOf ("8 ", "2 ", " 1"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain inOrder (" 1", "2 ", "8 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain oneOf (" 6", "8 ", " 5"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain only ("8 ", " 1", "2 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain inOrderOnly (" 1", "2 ", "8 ")))(/* DOTTY-ONLY using */ equality, equality)
+        (left should ((contain theSameElementsAs (right2)) or not contain noneOf (" 1", "2 ", "8 "))) (/* DOTTY-ONLY using */ equality, equality)
         
       }
       
@@ -266,14 +266,14 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right1 = List("8 ", " 1", "2 ")
         val right2 = List(" 1", "2 ", "8 ")
         
-        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsAs (right1))) (using equality, equality)
-        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsInOrderAs (right1))) (using equality, equality)
-        (left should (not contain theSameElementsAs (right2) or not contain allOf ("8 ", "2 ", " 1"))) (using equality, equality)
-        (left should (not contain theSameElementsAs (right2) or not contain inOrder (" 1", "2 ", "8 "))) (using equality, equality)
-        (left should (not contain theSameElementsAs (right2) or not contain oneOf (" 6", "8 ", " 5"))) (using equality, equality)
-        (left should (not contain theSameElementsAs (right2) or not contain only ("8 ", " 1", "2 "))) (using equality, equality)
-        (left should (not contain theSameElementsAs (right2) or not contain inOrderOnly (" 1", "2 ", "8 "))) (using equality, equality)
-        (left should (not contain theSameElementsAs (right2) or not contain noneOf (" 1", "2 ", "8 "))) (using equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain theSameElementsInOrderAs (right1))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain allOf ("8 ", "2 ", " 1"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain inOrder (" 1", "2 ", "8 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain oneOf (" 6", "8 ", " 5"))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain only ("8 ", " 1", "2 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain inOrderOnly (" 1", "2 ", "8 "))) (/* DOTTY-ONLY using */ equality, equality)
+        (left should (not contain theSameElementsAs (right2) or not contain noneOf (" 1", "2 ", "8 "))) (/* DOTTY-ONLY using */ equality, equality)
       }
       
       it("should failed with correctly stack depth and message when first not contain failed and second contain failed") {
@@ -283,7 +283,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right2 = List(" 8", "2 ", " 1")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs right2)) (using equality, equality)
+          (left should (not contain theSameElementsInOrderAs (right1) or contain theSameElementsAs right2)) (/* DOTTY-ONLY using */ equality, equality)
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1) + ", and " + decorateToStringValue(prettifier, left) + " did not contain the same elements as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -297,7 +297,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right = List(" 3", "2 ", " 1")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (contain theSameElementsInOrderAs (right) or not contain theSameElementsAs (right))) (using equality, equality) 
+          (left should (contain theSameElementsInOrderAs (right) or not contain theSameElementsAs (right))) (/* DOTTY-ONLY using */ equality, equality) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right) + ", and " + decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))
@@ -312,7 +312,7 @@ class ContainMatcherAndOrExplicitEqualitySpec extends AnyFunSpec with Explicitly
         val right2 = List(" 3", "2 ", " 1")
         
         val e = intercept[exceptions.TestFailedException] {
-          (left should (not contain theSameElementsInOrderAs (right1) or not contain theSameElementsAs (right2))) (using equality, equality) 
+          (left should (not contain theSameElementsInOrderAs (right1) or not contain theSameElementsAs (right2))) (/* DOTTY-ONLY using */ equality, equality) 
         }
         e.message should be (Some(decorateToStringValue(prettifier, left) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, right1) + ", and " + decorateToStringValue(prettifier, left) + " contained the same elements as " + decorateToStringValue(prettifier, right2)))
         e.failedCodeFileName should be (Some("ContainMatcherAndOrExplicitEqualitySpec.scala"))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfLogicalAndSpec.scala
@@ -94,16 +94,16 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -140,16 +140,16 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -185,16 +185,16 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain allElementsOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain allElementsOf Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("happy", "birthday", "to", "you")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -230,16 +230,16 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -275,16 +275,16 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")) + ", but " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -321,16 +321,16 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -366,16 +366,16 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -437,14 +437,14 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HO", "HELLO") and contain allElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HO", "HELLO") and contain allElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all elements of " + decorateToStringValue(prettifier, List("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all elements of " + decorateToStringValue(prettifier, List("HELLO", "HI")) + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all elements of " + decorateToStringValue(prettifier, List("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -501,14 +501,14 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain allElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allElementsOf Seq("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allElementsOf Seq("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all elements of " + decorateToStringValue(prettifier, List("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -564,14 +564,14 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allElementsOf (Seq("TO", "YOU")) and not contain allElementsOf (Seq("HO", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("TO", "YOU")) and not contain allElementsOf (Seq("HO", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) and not contain allElementsOf (Seq("HO", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) and not contain allElementsOf (Seq("HO", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all elements of " + decorateToStringValue(prettifier, List("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allElementsOf (Seq("HO", "HE")) and not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allElementsOf (Seq("HO", "HE")) and not contain allElementsOf (Seq("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all elements of " + decorateToStringValue(prettifier, List("HO", "HE")) + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all elements of " + decorateToStringValue(prettifier, List("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -628,14 +628,14 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain allElementsOf (Seq("HO", "HELLO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain allElementsOf (Seq("HO", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) and not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) and not contain allElementsOf (Seq("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain allElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain allElementsOf (Seq("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all elements of " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfLogicalAndSpec.scala
@@ -94,16 +94,16 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -140,16 +140,16 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -185,16 +185,16 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain allElementsOf Seq("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain allElementsOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("happy", "birthday", "to", "you")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -230,16 +230,16 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -275,16 +275,16 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")) + ", but " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -321,16 +321,16 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -366,16 +366,16 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -437,14 +437,14 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HO", "HELLO") and contain allElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HO", "HELLO") and contain allElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all elements of " + decorateToStringValue(prettifier, List("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HO", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all elements of " + decorateToStringValue(prettifier, List("HELLO", "HI")) + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all elements of " + decorateToStringValue(prettifier, List("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -501,14 +501,14 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain allElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allElementsOf Seq("HO", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allElementsOf Seq("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all elements of " + decorateToStringValue(prettifier, List("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -564,14 +564,14 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allElementsOf (Seq("TO", "YOU")) and not contain allElementsOf (Seq("HO", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("TO", "YOU")) and not contain allElementsOf (Seq("HO", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) and not contain allElementsOf (Seq("HO", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) and not contain allElementsOf (Seq("HO", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all elements of " + decorateToStringValue(prettifier, List("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allElementsOf (Seq("HO", "HE")) and not contain allElementsOf (Seq("HELLO", "HI")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allElementsOf (Seq("HO", "HE")) and not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all elements of " + decorateToStringValue(prettifier, List("HO", "HE")) + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all elements of " + decorateToStringValue(prettifier, List("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -628,14 +628,14 @@ class EveryShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain allElementsOf (Seq("HO", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain allElementsOf (Seq("HO", "HELLO")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) and not contain allElementsOf (Seq("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) and not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain allElementsOf (Seq("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain allElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all elements of " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfLogicalOrSpec.scala
@@ -90,14 +90,14 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", and " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -130,14 +130,14 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -169,14 +169,14 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -208,14 +208,14 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -247,14 +247,14 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -287,14 +287,14 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -326,14 +326,14 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -386,12 +386,12 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all elements of " + decorateToStringValue(prettifier, List("HELLO", "HO")) + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all elements of " + decorateToStringValue(prettifier, List("hello", "ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -429,12 +429,12 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all elements of " + decorateToStringValue(prettifier, List("HELLO", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -471,12 +471,12 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "ho")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "ho")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all elements of " + decorateToStringValue(prettifier, List("HELLO", "HI")) + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all elements of " + decorateToStringValue(prettifier, List("hello", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -514,12 +514,12 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("howdy", "hello", "hi")) or not contain allElementsOf (Seq("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HI")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("howdy", "hello", "hi")) or not contain allElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) or not contain allElementsOf (Seq("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) or not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all elements of " + decorateToStringValue(prettifier, List("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfLogicalOrSpec.scala
@@ -90,14 +90,14 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", and " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -130,14 +130,14 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -169,14 +169,14 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -208,14 +208,14 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -247,14 +247,14 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -287,14 +287,14 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -326,14 +326,14 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -386,12 +386,12 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all elements of " + decorateToStringValue(prettifier, List("HELLO", "HO")) + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all elements of " + decorateToStringValue(prettifier, List("hello", "ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -429,12 +429,12 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all elements of " + decorateToStringValue(prettifier, List("HELLO", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -471,12 +471,12 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "ho")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "ho")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all elements of " + decorateToStringValue(prettifier, List("HELLO", "HI")) + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all elements of " + decorateToStringValue(prettifier, List("hello", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -514,12 +514,12 @@ class EveryShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("howdy", "hello", "hi")) or not contain allElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("howdy", "hello", "hi")) or not contain allElementsOf (Seq("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) or not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) or not contain allElementsOf (Seq("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all elements of " + decorateToStringValue(prettifier, List("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfSpec.scala
@@ -73,14 +73,14 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList should contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain allElementsOf Seq("fee", "fie", "foe", "fam")) (decided by upperCaseStringEquality)
+          (fumList should contain allElementsOf Seq("fee", "fie", "foe", "fam")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain allElementsOf Seq("fee", "fie", "foe", "fie", "fum")
@@ -113,14 +113,14 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("fee", "fie", "foe", "fam"))) (decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("fee", "fie", "foe", "fam"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should (contain allElementsOf Seq("fee", "fie", "foe", "fie", "fum"))
@@ -185,13 +185,13 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain allElementsOf (Seq("NICE", "TO", "MEET", "YOU", "TOO")))) (decided by upperCaseStringEquality)
+        (toList should (not contain allElementsOf (Seq("NICE", "TO", "MEET", "YOU", "TOO")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain allElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toList should (not contain allElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain allElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain allElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList should (not contain allElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -218,13 +218,13 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain allElementsOf Seq("happy", "birthday", "to", "you", "dear")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain allElementsOf Seq("happy", "birthday", "to", "you", "dear")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -251,13 +251,13 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain allElementsOf Seq("NICE", "TO", "MEET", "YOU", "TOO"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain allElementsOf Seq("NICE", "TO", "MEET", "YOU", "TOO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -307,14 +307,14 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain allElementsOf Seq("HE", "HI")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain allElementsOf Seq("HE", "HI")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain allElementsOf Seq("HO", "HI")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain allElementsOf Seq("HO", "HI")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain allElementsOf Seq("he", "hi")) (decided by defaultEquality[String])
+        (all (hiLists) should contain allElementsOf Seq("he", "hi")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain allElementsOf Seq("ho", "hi")) (decided by defaultEquality[String])
+          (all (hiLists) should contain allElementsOf Seq("ho", "hi")) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -356,14 +356,14 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allElementsOf Seq("HE", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HE", "HI"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain allElementsOf Seq("he", "hi"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain allElementsOf Seq("he", "hi"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("ho", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain allElementsOf Seq("ho", "hi"))) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -393,13 +393,13 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain allElementsOf (Seq("NICE", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain allElementsOf (Seq("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain allElementsOf (Seq("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain allElementsOf (Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain allElementsOf (Seq(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain allElementsOf (Seq(" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) should not contain allElementsOf (Seq(" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -429,13 +429,13 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain allElementsOf (Seq("NICE", "MEET", "YOU")))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain allElementsOf (Seq("NICE", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allElementsOf (Seq("YOU", "TO")))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain allElementsOf (Seq("YOU", "TO")))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain allElementsOf (Seq(" YOU ", " TO ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allElementsOf (Seq(" YOU ", " TO ")))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain allElementsOf (Seq(" YOU ", " TO ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -465,13 +465,13 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain allElementsOf Seq("NICE", "MEET", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain allElementsOf Seq("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allElementsOf Seq("YOU", "TO")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain allElementsOf Seq("YOU", "TO")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain allElementsOf Seq(" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allElementsOf Seq(" YOU ", " TO ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain allElementsOf Seq(" YOU ", " TO ")) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -501,13 +501,13 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain allElementsOf Seq("NICE", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain allElementsOf Seq("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allElementsOf Seq("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain allElementsOf Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain allElementsOf Seq(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allElementsOf Seq(" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain allElementsOf Seq(" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllElementsOfSpec.scala
@@ -73,14 +73,14 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList should contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain allElementsOf Seq("fee", "fie", "foe", "fam")) (using decided by upperCaseStringEquality)
+          (fumList should contain allElementsOf Seq("fee", "fie", "foe", "fam")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain allElementsOf Seq("fee", "fie", "foe", "fie", "fum")
@@ -113,14 +113,14 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("fee", "fie", "foe", "fam"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("fee", "fie", "foe", "fam"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should (contain allElementsOf Seq("fee", "fie", "foe", "fie", "fum"))
@@ -185,13 +185,13 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain allElementsOf (Seq("NICE", "TO", "MEET", "YOU", "TOO")))) (using decided by upperCaseStringEquality)
+        (toList should (not contain allElementsOf (Seq("NICE", "TO", "MEET", "YOU", "TOO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain allElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toList should (not contain allElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain allElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain allElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList should (not contain allElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -218,13 +218,13 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain allElementsOf Seq("happy", "birthday", "to", "you", "dear")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain allElementsOf Seq("happy", "birthday", "to", "you", "dear")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -251,13 +251,13 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain allElementsOf Seq("NICE", "TO", "MEET", "YOU", "TOO"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain allElementsOf Seq("NICE", "TO", "MEET", "YOU", "TOO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -307,14 +307,14 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain allElementsOf Seq("HE", "HI")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain allElementsOf Seq("HE", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain allElementsOf Seq("HO", "HI")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain allElementsOf Seq("HO", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain allElementsOf Seq("he", "hi")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain allElementsOf Seq("he", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain allElementsOf Seq("ho", "hi")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain allElementsOf Seq("ho", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -356,14 +356,14 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allElementsOf Seq("HE", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain allElementsOf Seq("he", "hi"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain allElementsOf Seq("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("ho", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain allElementsOf Seq("ho", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -393,13 +393,13 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain allElementsOf (Seq("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain allElementsOf (Seq("NICE", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain allElementsOf (Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain allElementsOf (Seq("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain allElementsOf (Seq(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain allElementsOf (Seq(" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain allElementsOf (Seq(" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -429,13 +429,13 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain allElementsOf (Seq("NICE", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain allElementsOf (Seq("NICE", "MEET", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allElementsOf (Seq("YOU", "TO")))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain allElementsOf (Seq("YOU", "TO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain allElementsOf (Seq(" YOU ", " TO ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allElementsOf (Seq(" YOU ", " TO ")))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain allElementsOf (Seq(" YOU ", " TO ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -465,13 +465,13 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain allElementsOf Seq("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain allElementsOf Seq("NICE", "MEET", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allElementsOf Seq("YOU", "TO")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain allElementsOf Seq("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain allElementsOf Seq(" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allElementsOf Seq(" YOU ", " TO ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain allElementsOf Seq(" YOU ", " TO ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -501,13 +501,13 @@ class EveryShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain allElementsOf Seq("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain allElementsOf Seq("NICE", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allElementsOf Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain allElementsOf Seq("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain allElementsOf Seq(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allElementsOf Seq(" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain allElementsOf Seq(" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalAndSpec.scala
@@ -93,16 +93,16 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -150,16 +150,16 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -200,16 +200,16 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain allOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain allOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -250,16 +250,16 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -300,16 +300,16 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\"") + ", but " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain allOf ("FIE", "FEE", "FUM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allOf ("FIE", "FEE", "FUM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -357,16 +357,16 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -407,16 +407,16 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -483,14 +483,14 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HO", "HELLO") and contain allOf ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HO", "HELLO") and contain allOf ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")" + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -558,14 +558,14 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -626,14 +626,14 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allOf ("TO", "YOU") and not contain allOf ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("TO", "YOU") and not contain allOf ("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allOf ("HELLO", "HI") and not contain allOf ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allOf ("HELLO", "HI") and not contain allOf ("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allOf ("HO", "HE") and not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allOf ("HO", "HE") and not contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HE\")" + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -701,14 +701,14 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain allOf ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain allOf ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain allOf ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain allOf ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all of " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalAndSpec.scala
@@ -93,16 +93,16 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -150,16 +150,16 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FAM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -200,16 +200,16 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain allOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain allOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -250,16 +250,16 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -300,16 +300,16 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\"") + ", but " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain allOf ("FIE", "FEE", "FUM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allOf ("FIE", "FEE", "FUM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -357,16 +357,16 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -407,16 +407,16 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -483,14 +483,14 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HO", "HELLO") and contain allOf ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HO", "HELLO") and contain allOf ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HO", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")" + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -558,14 +558,14 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -626,14 +626,14 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allOf ("TO", "YOU") and not contain allOf ("HO", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("TO", "YOU") and not contain allOf ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allOf ("HELLO", "HI") and not contain allOf ("HO", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allOf ("HELLO", "HI") and not contain allOf ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allOf ("HO", "HE") and not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allOf ("HO", "HE") and not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HE\")" + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -701,14 +701,14 @@ class EveryShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain allOf ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain allOf ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain allOf ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain allOf ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all of " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalOrSpec.scala
@@ -89,14 +89,14 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -140,14 +140,14 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -184,14 +184,14 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -228,14 +228,14 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -272,14 +272,14 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -323,14 +323,14 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -367,14 +367,14 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -432,12 +432,12 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HELLO\", \"HO\")" + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"hello\", \"ho\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -486,12 +486,12 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain allOf ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -533,12 +533,12 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")" + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all of " + "(\"hello\", \"hi\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -587,12 +587,12 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allOf ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfLogicalOrSpec.scala
@@ -89,14 +89,14 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -140,14 +140,14 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -184,14 +184,14 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -228,14 +228,14 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -272,14 +272,14 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -323,14 +323,14 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -367,14 +367,14 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -432,12 +432,12 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HELLO\", \"HO\")" + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"hello\", \"ho\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -486,12 +486,12 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " did not contain all of " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -533,12 +533,12 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")" + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all of " + "(\"hello\", \"hi\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -587,12 +587,12 @@ class EveryShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, Many("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfSpec.scala
@@ -73,14 +73,14 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain allOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList should contain allOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain allOf ("fee", "fie", "foe", "fam")) (decided by upperCaseStringEquality)
+          (fumList should contain allOf ("fee", "fie", "foe", "fam")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain allOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain allOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain allOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -118,14 +118,14 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain allOf ("fee", "fie", "foe", "fam"))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("fee", "fie", "foe", "fam"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -200,13 +200,13 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (decided by upperCaseStringEquality)
+        (toList should (not contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList should (not contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should (not contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -238,13 +238,13 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain allOf ("happy", "birthday", "to", "you", "dear")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain allOf ("happy", "birthday", "to", "you", "dear")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -276,13 +276,13 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -337,14 +337,14 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain allOf ("HE", "HI")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain allOf ("HE", "HI")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain allOf ("HO", "HI")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain allOf ("HO", "HI")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain allOf ("he", "hi")) (decided by defaultEquality[String])
+        (all (hiLists) should contain allOf ("he", "hi")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain allOf ("ho", "hi")) (decided by defaultEquality[String])
+          (all (hiLists) should contain allOf ("ho", "hi")) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -391,14 +391,14 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allOf ("HE", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HE", "HI"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HO", "HI"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain allOf ("he", "hi"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain allOf ("he", "hi"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("ho", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain allOf ("ho", "hi"))) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -433,13 +433,13 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain allOf ("NICE", "MEET", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain allOf ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain allOf ("YOU", "TO")) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain allOf ("YOU", "TO")) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain allOf (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain allOf (" YOU ", " TO ")) (after being lowerCased and trimmed)
+          (all (toLists) should not contain allOf (" YOU ", " TO ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -474,13 +474,13 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain allOf ("NICE", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain allOf ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allOf ("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain allOf ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain allOf (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allOf (" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain allOf (" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -515,13 +515,13 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain allOf ("NICE", "MEET", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain allOf ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allOf ("YOU", "TO")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain allOf ("YOU", "TO")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain allOf (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allOf (" YOU ", " TO ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain allOf (" YOU ", " TO ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -556,13 +556,13 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain allOf ("NICE", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain allOf ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allOf ("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain allOf ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain allOf (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allOf (" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain allOf (" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAllOfSpec.scala
@@ -73,14 +73,14 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain allOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList should contain allOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain allOf ("fee", "fie", "foe", "fam")) (using decided by upperCaseStringEquality)
+          (fumList should contain allOf ("fee", "fie", "foe", "fam")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain allOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain allOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain allOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -118,14 +118,14 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain allOf ("fee", "fie", "foe", "fam"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("fee", "fie", "foe", "fam"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -200,13 +200,13 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (using decided by upperCaseStringEquality)
+        (toList should (not contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList should (not contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should (not contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -238,13 +238,13 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain allOf ("happy", "birthday", "to", "you", "dear")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain allOf ("happy", "birthday", "to", "you", "dear")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -276,13 +276,13 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -337,14 +337,14 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain allOf ("HE", "HI")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain allOf ("HE", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain allOf ("HO", "HI")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain allOf ("HO", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain allOf ("he", "hi")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain allOf ("he", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain allOf ("ho", "hi")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain allOf ("ho", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -391,14 +391,14 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allOf ("HE", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain allOf ("he", "hi"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain allOf ("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("ho", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain allOf ("ho", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -433,13 +433,13 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain allOf ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain allOf ("NICE", "MEET", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain allOf ("YOU", "TO")) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain allOf ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain allOf (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain allOf (" YOU ", " TO ")) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain allOf (" YOU ", " TO ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -474,13 +474,13 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain allOf ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain allOf ("NICE", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allOf ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain allOf ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain allOf (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allOf (" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain allOf (" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -515,13 +515,13 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain allOf ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain allOf ("NICE", "MEET", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allOf ("YOU", "TO")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain allOf ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain allOf (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allOf (" YOU ", " TO ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain allOf (" YOU ", " TO ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -556,13 +556,13 @@ class EveryShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain allOf ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain allOf ("NICE", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allOf ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain allOf ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain allOf (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allOf (" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain allOf (" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfLogicalAndSpec.scala
@@ -85,16 +85,16 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -131,16 +131,16 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality[Every[String]], after being lowerCased and trimmed)
+        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by defaultEquality[Every[String]], after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -176,16 +176,16 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -221,16 +221,16 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -266,16 +266,16 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -312,16 +312,16 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -357,16 +357,16 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -434,14 +434,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") and contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", but " + decorateToStringValue(prettifier, One("hi")) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -498,14 +498,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) and contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("hi")) and contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("hi")) and contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -561,14 +561,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -625,14 +625,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfLogicalAndSpec.scala
@@ -85,16 +85,16 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -131,16 +131,16 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by defaultEquality[Every[String]], after being lowerCased and trimmed)
+        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality[Every[String]], after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -176,16 +176,16 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -221,16 +221,16 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -266,16 +266,16 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -312,16 +312,16 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[Every[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -357,16 +357,16 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -434,14 +434,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") and contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", but " + decorateToStringValue(prettifier, One("hi")) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -498,14 +498,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) and contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("hi")) and contain atLeastOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("hi")) and contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -561,14 +561,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -625,14 +625,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfLogicalOrSpec.scala
@@ -80,14 +80,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("fie", "fee", "fum", "foe") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("fie", "fee", "fum", "foe") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fie", "fee", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -120,14 +120,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (equal (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by defaultEquality[List[String]], after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality[List[String]], after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -159,14 +159,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -198,14 +198,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -237,14 +237,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -277,14 +277,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -316,14 +316,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -376,12 +376,12 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -419,12 +419,12 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (One("hi")) or contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("ho")) or contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("hi")) or contain atLeastOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("ho")) or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) or contain atLeastOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -461,12 +461,12 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -504,12 +504,12 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("hi")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("hi")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfLogicalOrSpec.scala
@@ -80,14 +80,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("fie", "fee", "fum", "foe") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("fie", "fee", "fum", "foe") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fie", "fee", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -120,14 +120,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (equal (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality[List[String]], after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -159,14 +159,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -198,14 +198,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -237,14 +237,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -277,14 +277,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -316,14 +316,14 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -376,12 +376,12 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -419,12 +419,12 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (One("hi")) or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("ho")) or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("hi")) or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("ho")) or contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) or contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -461,12 +461,12 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -504,12 +504,12 @@ class EveryShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("hi")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("hi")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfSpec.scala
@@ -60,14 +60,14 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList should contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atLeastOneElementOf Seq("fum", "foe")) (using decided by upperCaseStringEquality)
+          (fumList should contain atLeastOneElementOf Seq("fum", "foe")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain atLeastOneElementOf Seq("fee", "fie", "foe", "fie", "fum")
@@ -100,14 +100,14 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should (contain atLeastOneElementOf Seq("fee", "fie", "foe", "fie", "fum"))
@@ -189,13 +189,13 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain atLeastOneElementOf (Seq("to", "you")))) (using decided by upperCaseStringEquality)
+        (toList should (not contain atLeastOneElementOf (Seq("to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toList should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
 
@@ -223,13 +223,13 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain atLeastOneElementOf Seq("to", "you")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain atLeastOneElementOf Seq("to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -256,13 +256,13 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
 
@@ -313,14 +313,14 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -362,14 +362,14 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -414,13 +414,13 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atLeastOneElementOf (Seq("to", "you"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain atLeastOneElementOf (Seq("to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneElementOf (Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain atLeastOneElementOf (Seq("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain atLeastOneElementOf (Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneElementOf (Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain atLeastOneElementOf (Seq(" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -467,13 +467,13 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atLeastOneElementOf (Seq("to", "you")))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atLeastOneElementOf (Seq("to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -503,13 +503,13 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atLeastOneElementOf Seq("to", "you")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atLeastOneElementOf Seq("to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -539,13 +539,13 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneElementOfSpec.scala
@@ -60,14 +60,14 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList should contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atLeastOneElementOf Seq("fum", "foe")) (decided by upperCaseStringEquality)
+          (fumList should contain atLeastOneElementOf Seq("fum", "foe")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain atLeastOneElementOf Seq("fee", "fie", "foe", "fie", "fum")
@@ -100,14 +100,14 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should (contain atLeastOneElementOf Seq("fee", "fie", "foe", "fie", "fum"))
@@ -189,13 +189,13 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain atLeastOneElementOf (Seq("to", "you")))) (decided by upperCaseStringEquality)
+        (toList should (not contain atLeastOneElementOf (Seq("to", "you")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toList should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
 
@@ -223,13 +223,13 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain atLeastOneElementOf Seq("to", "you")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain atLeastOneElementOf Seq("to", "you")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -256,13 +256,13 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
 
@@ -313,14 +313,14 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (decided by defaultEquality[String])
+          (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -362,14 +362,14 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -414,13 +414,13 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atLeastOneElementOf (Seq("to", "you"))) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain atLeastOneElementOf (Seq("to", "you"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneElementOf (Seq("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain atLeastOneElementOf (Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain atLeastOneElementOf (Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneElementOf (Seq(" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should not contain atLeastOneElementOf (Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -467,13 +467,13 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atLeastOneElementOf (Seq("to", "you")))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atLeastOneElementOf (Seq("to", "you")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -503,13 +503,13 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atLeastOneElementOf Seq("to", "you")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atLeastOneElementOf Seq("to", "you")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -539,13 +539,13 @@ class EveryShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalAndSpec.scala
@@ -84,16 +84,16 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -141,16 +141,16 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atLeastOneOf ("fum", "foe"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by defaultEquality, after being lowerCased and trimmed)
+        (fumList should (equal (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -191,16 +191,16 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -241,16 +241,16 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -291,16 +291,16 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\"") + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -348,16 +348,16 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (toList) and not contain atLeastOneOf ("fum", "foe"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atLeastOneOf ("fum", "foe"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -398,16 +398,16 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -480,14 +480,14 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("hi", "he") and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("hi", "he") and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " contained at least one of (\"HI\", \"HE\"), but " + decorateToStringValue(prettifier, One("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -555,14 +555,14 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("hi")) and contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("hi")) and contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", but " + decorateToStringValue(prettifier, One("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -623,14 +623,14 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " did not contain at least one of (\"hi\", \"he\"), but " + decorateToStringValue(prettifier, One("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -698,14 +698,14 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, One("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalAndSpec.scala
@@ -84,16 +84,16 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -141,16 +141,16 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality, after being lowerCased and trimmed)
+        (fumList should (equal (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by defaultEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -191,16 +191,16 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -241,16 +241,16 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -291,16 +291,16 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\"") + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -348,16 +348,16 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (toList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) and not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -398,16 +398,16 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -480,14 +480,14 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("hi", "he") and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("hi", "he") and contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " contained at least one of (\"HI\", \"HE\"), but " + decorateToStringValue(prettifier, One("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -555,14 +555,14 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) and contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("hi")) and contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("hi")) and contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", but " + decorateToStringValue(prettifier, One("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -623,14 +623,14 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") and not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " did not contain at least one of (\"hi\", \"he\"), but " + decorateToStringValue(prettifier, One("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -698,14 +698,14 @@ class EveryShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) and not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, One("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalOrSpec.scala
@@ -79,14 +79,14 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("fie", "fee", "fum", "foe") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("fie", "fee", "fum", "foe") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\"") + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -130,14 +130,14 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (fumList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) or contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) or contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by defaultEquality, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -174,14 +174,14 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -218,14 +218,14 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("fum", "foe") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -262,14 +262,14 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -313,14 +313,14 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (toList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -357,14 +357,14 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -422,12 +422,12 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " did not contain at least one of (\"hi\", \"he\"), and " + decorateToStringValue(prettifier, One("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -476,12 +476,12 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (One("hi")) or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("ho")) or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("hi")) or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("ho")) or contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) or contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", and " + decorateToStringValue(prettifier, One("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -523,12 +523,12 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " contained at least one of (\"HI\", \"HE\"), and " + decorateToStringValue(prettifier, One("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -577,12 +577,12 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("hi")) or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("hi")) or not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) or not contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", and " + decorateToStringValue(prettifier, One("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfLogicalOrSpec.scala
@@ -79,14 +79,14 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("fie", "fee", "fum", "foe") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("fie", "fee", "fum", "foe") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\"") + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -130,14 +130,14 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (fumList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atLeastOneOf ("fum", "foe"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) or contain atLeastOneOf ("fum", "foe"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) or contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by defaultEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -174,14 +174,14 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -218,14 +218,14 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("fum", "foe") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -262,14 +262,14 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -313,14 +313,14 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (toList) or not contain atLeastOneOf ("fum", "foe"))) (decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atLeastOneOf ("fum", "foe"))) (decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -357,14 +357,14 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -422,12 +422,12 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " did not contain at least one of (\"hi\", \"he\"), and " + decorateToStringValue(prettifier, One("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -476,12 +476,12 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (One("hi")) or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("ho")) or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("hi")) or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("ho")) or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", and " + decorateToStringValue(prettifier, One("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -523,12 +523,12 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " contained at least one of (\"HI\", \"HE\"), and " + decorateToStringValue(prettifier, One("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -577,12 +577,12 @@ class EveryShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("hi")) or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("hi")) or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", and " + decorateToStringValue(prettifier, One("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfSpec.scala
@@ -60,14 +60,14 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList should contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atLeastOneOf ("fum", "foe")) (using decided by upperCaseStringEquality)
+          (fumList should contain atLeastOneOf ("fum", "foe")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -105,14 +105,14 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -158,19 +158,19 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
       }
       it("should use an explicitly provided Equality") {
         // SKIP-DOTTY-START
-        (toList should not contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
+        (toList should not contain atLeastOneOf ("to", "you")) (decided by upperCaseStringEquality)
         // SKIP-DOTTY-END
         //DOTTY-ONLY (toList should not contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
           // SKIP-DOTTY-START
-          (toList should not contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList should not contain atLeastOneOf ("TO", "YOU")) (decided by upperCaseStringEquality)
           // SKIP-DOTTY-END
           //DOTTY-ONLY (toList should not contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList should not contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
           // SKIP-DOTTY-START
-          (toList should not contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList should not contain atLeastOneOf (" TO ", " YOU ")) (after being lowerCased and trimmed)
           // SKIP-DOTTY-END
           //DOTTY-ONLY (toList should not contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
@@ -213,13 +213,13 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
+        (toList should (not contain atLeastOneOf ("to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList should (not contain atLeastOneOf ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should (not contain atLeastOneOf (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
 
@@ -252,13 +252,13 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain atLeastOneOf ("to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain atLeastOneOf ("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain atLeastOneOf (" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -290,13 +290,13 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain atLeastOneOf ("to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain atLeastOneOf ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
 
@@ -352,14 +352,14 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneOf ("hi", "he")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain atLeastOneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atLeastOneOf ("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain atLeastOneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -406,14 +406,14 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -463,13 +463,13 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain atLeastOneOf ("to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain atLeastOneOf ("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain atLeastOneOf (" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -521,13 +521,13 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atLeastOneOf ("to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atLeastOneOf ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain atLeastOneOf (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -562,13 +562,13 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atLeastOneOf ("to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atLeastOneOf ("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain atLeastOneOf (" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -603,13 +603,13 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atLeastOneOf ("to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atLeastOneOf ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtLeastOneOfSpec.scala
@@ -60,14 +60,14 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList should contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atLeastOneOf ("fum", "foe")) (decided by upperCaseStringEquality)
+          (fumList should contain atLeastOneOf ("fum", "foe")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -105,14 +105,14 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -158,19 +158,19 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
       }
       it("should use an explicitly provided Equality") {
         // SKIP-DOTTY-START
-        (toList should not contain atLeastOneOf ("to", "you")) (decided by upperCaseStringEquality)
+        (toList should not contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
         // SKIP-DOTTY-END
         //DOTTY-ONLY (toList should not contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
           // SKIP-DOTTY-START
-          (toList should not contain atLeastOneOf ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList should not contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
           // SKIP-DOTTY-END
           //DOTTY-ONLY (toList should not contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList should not contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
           // SKIP-DOTTY-START
-          (toList should not contain atLeastOneOf (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList should not contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
           // SKIP-DOTTY-END
           //DOTTY-ONLY (toList should not contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
@@ -213,13 +213,13 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain atLeastOneOf ("to", "you"))) (decided by upperCaseStringEquality)
+        (toList should (not contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneOf ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList should (not contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneOf (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should (not contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
 
@@ -252,13 +252,13 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain atLeastOneOf ("to", "you")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneOf ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneOf (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -290,13 +290,13 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain atLeastOneOf ("to", "you"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneOf ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
 
@@ -352,14 +352,14 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneOf ("hi", "he")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain atLeastOneOf ("hi", "he")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atLeastOneOf ("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain atLeastOneOf ("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (decided by defaultEquality[String])
+          (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -406,14 +406,14 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -463,13 +463,13 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atLeastOneOf ("to", "you")) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneOf ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneOf (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) should not contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -521,13 +521,13 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atLeastOneOf ("to", "you"))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneOf ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneOf (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -562,13 +562,13 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atLeastOneOf ("to", "you")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneOf ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneOf (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -603,13 +603,13 @@ class EveryShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atLeastOneOf ("to", "you"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneOf ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfLogicalAndSpec.scala
@@ -88,16 +88,16 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", but " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -134,16 +134,16 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -179,16 +179,16 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -224,16 +224,16 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -269,16 +269,16 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -315,16 +315,16 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -360,16 +360,16 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -437,14 +437,14 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HE", "HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") and contain atMostOneElementOf Seq("HE", "HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") and contain atMostOneElementOf Seq("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -501,14 +501,14 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneElementOf Seq("HO", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneElementOf Seq("HO", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain atMostOneElementOf Seq("HO", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain atMostOneElementOf Seq("HO", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "he")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -564,14 +564,14 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HO")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HO")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -628,14 +628,14 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("HI", "HO")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("HI", "HO")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "he")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "he")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "ho")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "ho")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, Many("hi", "ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfLogicalAndSpec.scala
@@ -88,16 +88,16 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", but " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -134,16 +134,16 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -179,16 +179,16 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -224,16 +224,16 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -269,16 +269,16 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -315,16 +315,16 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -360,16 +360,16 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -437,14 +437,14 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HE", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") and contain atMostOneElementOf Seq("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") and contain atMostOneElementOf Seq("HE", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -501,14 +501,14 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneElementOf Seq("HO", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneElementOf Seq("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain atMostOneElementOf Seq("HO", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain atMostOneElementOf Seq("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "he")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -564,14 +564,14 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HO")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HO")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -628,14 +628,14 @@ class EveryShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("HI", "HO")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("HI", "HO")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "he")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "he")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "ho")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "ho")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, Many("hi", "ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfLogicalOrSpec.scala
@@ -85,14 +85,14 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -125,14 +125,14 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -164,14 +164,14 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -203,14 +203,14 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -242,14 +242,14 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")) + ", and " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -282,14 +282,14 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -321,14 +321,14 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -381,12 +381,12 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HE", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HE", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -424,12 +424,12 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneElementOf Seq("HI", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("HO")) or contain atMostOneElementOf Seq("HI", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneElementOf Seq("HI", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("HO")) or contain atMostOneElementOf Seq("HI", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("HO")) or contain atMostOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("HO")) or contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, One("HO")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -466,12 +466,12 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")) or not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")) or not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HE", "HEY", "HOWDY")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HE", "HEY", "HOWDY")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -509,12 +509,12 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (One("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneElementOf (Seq("HI", "HO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneElementOf (Seq("HI", "HO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "he")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfLogicalOrSpec.scala
@@ -85,14 +85,14 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -125,14 +125,14 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -164,14 +164,14 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -203,14 +203,14 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -242,14 +242,14 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")) + ", and " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -282,14 +282,14 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -321,14 +321,14 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -381,12 +381,12 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HE", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -424,12 +424,12 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneElementOf Seq("HI", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("HO")) or contain atMostOneElementOf Seq("HI", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneElementOf Seq("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("HO")) or contain atMostOneElementOf Seq("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("HO")) or contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("HO")) or contain atMostOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, One("HO")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -466,12 +466,12 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")) or not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")) or not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HE", "HEY", "HOWDY")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HE", "HEY", "HOWDY")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -509,12 +509,12 @@ class EveryShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (One("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneElementOf (Seq("HI", "HO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneElementOf (Seq("HI", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "he")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfSpec.scala
@@ -74,12 +74,12 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
+        (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+          (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+          (fumList should contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
 
         }
         fumList should contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
@@ -115,12 +115,12 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+          (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
         fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
       }
@@ -187,11 +187,11 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))
         }
@@ -220,11 +220,11 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
+          (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (fumList shouldNot contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList shouldNot contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -253,11 +253,11 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+          (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (fumList shouldNot (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList shouldNot (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -309,14 +309,14 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atMostOneElementOf Seq("hi", "ho")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain atMostOneElementOf Seq("hi", "ho")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atMostOneElementOf Seq("hi", "HE")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain atMostOneElementOf Seq("hi", "HE")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
 
@@ -359,14 +359,14 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "ho"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "HE"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "HE"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
 
@@ -397,11 +397,11 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) should not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) should not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -433,11 +433,11 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) should (not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+        (all (toLists) should (not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         }
@@ -469,11 +469,11 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -505,11 +505,11 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot (contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot (contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneElementOfSpec.scala
@@ -74,12 +74,12 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (decided by upperCaseStringEquality)
+        (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+          (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+          (fumList should contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
 
         }
         fumList should contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
@@ -115,12 +115,12 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+          (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         }
         fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
       }
@@ -187,11 +187,11 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")))) (decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")))) (using decided by upperCaseStringEquality)
         }
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))
         }
@@ -220,11 +220,11 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (decided by upperCaseStringEquality)
+          (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
         }
-        (fumList shouldNot contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList shouldNot contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -253,11 +253,11 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+          (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         }
-        (fumList shouldNot (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList shouldNot (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -309,14 +309,14 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atMostOneElementOf Seq("hi", "ho")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain atMostOneElementOf Seq("hi", "ho")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atMostOneElementOf Seq("hi", "HE")) (decided by defaultEquality[String])
+        (all (hiLists) should contain atMostOneElementOf Seq("hi", "HE")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (decided by defaultEquality[String])
+          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (using decided by defaultEquality[String])
         }
       }
 
@@ -359,14 +359,14 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "ho"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "ho"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "HE"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "HE"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (using decided by defaultEquality[String])
         }
       }
 
@@ -397,11 +397,11 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) should not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) should not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -433,11 +433,11 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) should (not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+        (all (toLists) should (not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         }
@@ -469,11 +469,11 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -505,11 +505,11 @@ class EveryShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot (contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot (contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalAndSpec.scala
@@ -88,16 +88,16 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -145,16 +145,16 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -195,16 +195,16 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -245,16 +245,16 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -295,16 +295,16 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -352,16 +352,16 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -402,16 +402,16 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -484,14 +484,14 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HE", "HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("HI", "HE") and contain atMostOneOf ("HE", "HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("HI", "HE") and contain atMostOneOf ("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\"), but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -559,14 +559,14 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneOf ("HO", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneOf ("HO", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain atMostOneOf ("HO", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain atMostOneOf ("HO", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "he")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -627,14 +627,14 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneOf ("HI", "HO") and not contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneOf ("HI", "HO") and not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\"), but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -702,14 +702,14 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "he")) and not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "he")) and not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, Many("hi", "ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalAndSpec.scala
@@ -88,16 +88,16 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -145,16 +145,16 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -195,16 +195,16 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -245,16 +245,16 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -295,16 +295,16 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -352,16 +352,16 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -402,16 +402,16 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -484,14 +484,14 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HE", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("HI", "HE") and contain atMostOneOf ("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("HI", "HE") and contain atMostOneOf ("HE", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\"), but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -559,14 +559,14 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneOf ("HO", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneOf ("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain atMostOneOf ("HO", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain atMostOneOf ("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("hi", "he")) and contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "he")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -627,14 +627,14 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneOf ("HI", "HO") and not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneOf ("HI", "HO") and not contain atMostOneOf ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\"), but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -702,14 +702,14 @@ class EveryShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "he")) and not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "he")) and not contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, Many("hi", "ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalOrSpec.scala
@@ -85,14 +85,14 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -136,14 +136,14 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -180,14 +180,14 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -224,14 +224,14 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -268,14 +268,14 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\"") + ", and " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -319,14 +319,14 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -363,14 +363,14 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -428,12 +428,12 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\"), and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HE\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -482,12 +482,12 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("HO")) or contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneOf ("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("HO")) or contain atMostOneOf ("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("HO")) or contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("HO")) or contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, One("HO")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -529,12 +529,12 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneOf ("hi", "he") or not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("hi", "he") or not contain atMostOneOf ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneOf ("HE", "HEY", "HOWDY") or not contain atMostOneOf ("HE", "HEY", "HOWDY"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneOf ("HE", "HEY", "HOWDY") or not contain atMostOneOf ("HE", "HEY", "HOWDY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HE\", \"HEY\", \"HOWDY\"), and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HE\", \"HEY\", \"HOWDY\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -583,12 +583,12 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (One("ho")) or not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneOf ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneOf ("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "he")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfLogicalOrSpec.scala
@@ -85,14 +85,14 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -136,14 +136,14 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -180,14 +180,14 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -224,14 +224,14 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -268,14 +268,14 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\"") + ", and " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -319,14 +319,14 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -363,14 +363,14 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -428,12 +428,12 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\"), and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HE\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -482,12 +482,12 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("HO")) or contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("HO")) or contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "he")) or contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("HO")) or contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("HO")) or contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, One("HO")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -529,12 +529,12 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneOf ("hi", "he") or not contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("hi", "he") or not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneOf ("HE", "HEY", "HOWDY") or not contain atMostOneOf ("HE", "HEY", "HOWDY"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneOf ("HE", "HEY", "HOWDY") or not contain atMostOneOf ("HE", "HEY", "HOWDY"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HE\", \"HEY\", \"HOWDY\"), and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HE\", \"HEY\", \"HOWDY\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -583,12 +583,12 @@ class EveryShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (One("ho")) or not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "he")) or not contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "he")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfSpec.scala
@@ -74,12 +74,12 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
+        (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+          (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+          (fumList should contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
 
         }
         fumList should contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")
@@ -120,12 +120,12 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+          (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
         fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
       }
@@ -202,11 +202,11 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -240,11 +240,11 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
+          (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (fumList shouldNot contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList shouldNot contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -278,11 +278,11 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+          (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (fumList shouldNot (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList shouldNot (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -340,14 +340,14 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atMostOneOf ("hi", "ho")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain atMostOneOf ("hi", "ho")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneOf ("hi", "he")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain atMostOneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atMostOneOf ("hi", "HE")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain atMostOneOf ("hi", "HE")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneOf ("hi", "he")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain atMostOneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
 
@@ -396,14 +396,14 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneOf ("hi", "ho"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("hi", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atMostOneOf ("hi", "HE"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain atMostOneOf ("hi", "HE"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
 
@@ -440,11 +440,11 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) should not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+        (all (toLists) should not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -482,11 +482,11 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) should (not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) should (not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -524,11 +524,11 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -566,11 +566,11 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot (contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot (contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainAtMostOneOfSpec.scala
@@ -74,12 +74,12 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (decided by upperCaseStringEquality)
+        (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+          (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+          (fumList should contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
 
         }
         fumList should contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")
@@ -120,12 +120,12 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+          (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         }
         fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
       }
@@ -202,11 +202,11 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         }
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -240,11 +240,11 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (decided by upperCaseStringEquality)
+          (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
         }
-        (fumList shouldNot contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList shouldNot contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -278,11 +278,11 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+          (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         }
-        (fumList shouldNot (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList shouldNot (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -340,14 +340,14 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atMostOneOf ("hi", "ho")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain atMostOneOf ("hi", "ho")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneOf ("hi", "he")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain atMostOneOf ("hi", "he")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atMostOneOf ("hi", "HE")) (decided by defaultEquality[String])
+        (all (hiLists) should contain atMostOneOf ("hi", "HE")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneOf ("hi", "he")) (decided by defaultEquality[String])
+          (all (hiLists) should contain atMostOneOf ("hi", "he")) (using decided by defaultEquality[String])
         }
       }
 
@@ -396,14 +396,14 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneOf ("hi", "ho"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("hi", "ho"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atMostOneOf ("hi", "HE"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain atMostOneOf ("hi", "HE"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (using decided by defaultEquality[String])
         }
       }
 
@@ -440,11 +440,11 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) should not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+        (all (toLists) should not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -482,11 +482,11 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) should (not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) should (not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -524,11 +524,11 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -566,11 +566,11 @@ class EveryShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot (contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot (contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfLogicalAndSpec.scala
@@ -93,16 +93,16 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")) + ", but " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -139,16 +139,16 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -184,16 +184,16 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -229,16 +229,16 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -274,13 +274,13 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
       }
@@ -319,13 +319,13 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
       }
@@ -363,16 +363,16 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -433,14 +433,14 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HO", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HO", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HO", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -497,14 +497,14 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrderElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("he", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -560,14 +560,14 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) and not contain inOrderElementsOf (Seq("HO", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) and not contain inOrderElementsOf (Seq("HO", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -624,14 +624,14 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain inOrderElementsOf (Seq("HO", "HELLO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain inOrderElementsOf (Seq("HO", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("he", "hi", "hello")) and not contain inOrderElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("he", "hi", "hello")) and not contain inOrderElementsOf (Seq("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("he", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfLogicalAndSpec.scala
@@ -93,16 +93,16 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")) + ", but " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -139,16 +139,16 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -184,16 +184,16 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -229,16 +229,16 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -274,13 +274,13 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
       }
@@ -319,13 +319,13 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
       }
@@ -363,16 +363,16 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -433,14 +433,14 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HO", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HO", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HO", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -497,14 +497,14 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrderElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("he", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -560,14 +560,14 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HELLO", "HO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) and not contain inOrderElementsOf (Seq("HO", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) and not contain inOrderElementsOf (Seq("HO", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -624,14 +624,14 @@ class EveryShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain inOrderElementsOf (Seq("HO", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain inOrderElementsOf (Seq("HO", "HELLO")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("he", "hi", "hello")) and not contain inOrderElementsOf (Seq("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("he", "hi", "hello")) and not contain inOrderElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("he", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfLogicalOrSpec.scala
@@ -89,14 +89,14 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -129,14 +129,14 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain inOrderElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain inOrderElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -168,14 +168,14 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -207,14 +207,14 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -246,11 +246,11 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")) + ", and " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
       }
@@ -285,11 +285,11 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
       }
@@ -323,14 +323,14 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -382,12 +382,12 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HO")) + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("hello", "ho")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -425,12 +425,12 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -467,12 +467,12 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("hi", "hello")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -510,12 +510,12 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("he", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfLogicalOrSpec.scala
@@ -89,14 +89,14 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -129,14 +129,14 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain inOrderElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain inOrderElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -168,14 +168,14 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -207,14 +207,14 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -246,11 +246,11 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")) + ", and " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
       }
@@ -285,11 +285,11 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
       }
@@ -323,14 +323,14 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -382,12 +382,12 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HO")) + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("hello", "ho")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -425,12 +425,12 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -467,12 +467,12 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("hi", "hello")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -510,12 +510,12 @@ class EveryShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("he", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfSpec.scala
@@ -75,14 +75,14 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
+        (fumList should contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain inOrderElementsOf Seq("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
+          (fumList should contain inOrderElementsOf Seq("fee", "fie", "foe", "fum")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
+        (fumList should contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should do nothing when RHS contain duplicated value") {
         fumList should contain inOrderElementsOf Seq("fum", "fum", "foe", "fie", "fee")
@@ -113,14 +113,14 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should do nothing when RHS contain duplicated value") {
         fumList should (contain inOrderElementsOf Seq("fum", "fum", "foe", "fie", "fee"))
@@ -152,13 +152,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList should not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList should not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -185,13 +185,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY")))) (using decided by upperCaseStringEquality)
+        (toList should (not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toList should (not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList should (not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -218,13 +218,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -251,13 +251,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -306,14 +306,14 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain inOrderElementsOf Seq("HI", "HE")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain inOrderElementsOf Seq("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderElementsOf Seq("HI", "HO")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain inOrderElementsOf Seq("HI", "HO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain inOrderElementsOf Seq("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain inOrderElementsOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderElementsOf Seq("hi", "ho")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain inOrderElementsOf Seq("hi", "ho")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -354,14 +354,14 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain inOrderElementsOf Seq("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain inOrderElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("he", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain inOrderElementsOf Seq("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -390,13 +390,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain inOrderElementsOf (Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain inOrderElementsOf (Seq("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderElementsOf (Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain inOrderElementsOf (Seq("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain inOrderElementsOf (Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderElementsOf (Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain inOrderElementsOf (Seq(" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -425,13 +425,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain inOrderElementsOf (Seq("YOU", "TO")))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain inOrderElementsOf (Seq("YOU", "TO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderElementsOf (Seq("TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain inOrderElementsOf (Seq("TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain inOrderElementsOf (Seq(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderElementsOf (Seq(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain inOrderElementsOf (Seq(" TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -460,13 +460,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain inOrderElementsOf Seq("YOU", "TO")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain inOrderElementsOf Seq("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderElementsOf Seq("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain inOrderElementsOf Seq("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain inOrderElementsOf Seq(" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderElementsOf Seq(" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain inOrderElementsOf Seq(" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -495,13 +495,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain inOrderElementsOf Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain inOrderElementsOf Seq("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderElementsOf Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain inOrderElementsOf Seq("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain inOrderElementsOf Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderElementsOf Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain inOrderElementsOf Seq(" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderElementsOfSpec.scala
@@ -75,14 +75,14 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE")) (decided by upperCaseStringEquality)
+        (fumList should contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain inOrderElementsOf Seq("fee", "fie", "foe", "fum")) (decided by upperCaseStringEquality)
+          (fumList should contain inOrderElementsOf Seq("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ")) (after being lowerCased and trimmed)
+        (fumList should contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
       }
       it("should do nothing when RHS contain duplicated value") {
         fumList should contain inOrderElementsOf Seq("fum", "fum", "foe", "fie", "fee")
@@ -113,14 +113,14 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
       it("should do nothing when RHS contain duplicated value") {
         fumList should (contain inOrderElementsOf Seq("fum", "fum", "foe", "fie", "fee"))
@@ -152,13 +152,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList should not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList should not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList should not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -185,13 +185,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY")))) (decided by upperCaseStringEquality)
+        (toList should (not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toList should (not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList should (not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -218,13 +218,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -251,13 +251,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -306,14 +306,14 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain inOrderElementsOf Seq("HI", "HE")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain inOrderElementsOf Seq("HI", "HE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderElementsOf Seq("HI", "HO")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain inOrderElementsOf Seq("HI", "HO")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain inOrderElementsOf Seq("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain inOrderElementsOf Seq("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderElementsOf Seq("hi", "ho")) (decided by defaultEquality[String])
+          (all (hiLists) should contain inOrderElementsOf Seq("hi", "ho")) (using decided by defaultEquality[String])
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -354,14 +354,14 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HO"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain inOrderElementsOf Seq("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain inOrderElementsOf Seq("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("he", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain inOrderElementsOf Seq("he", "hi"))) (using decided by defaultEquality[String])
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -390,13 +390,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain inOrderElementsOf (Seq("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain inOrderElementsOf (Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderElementsOf (Seq("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain inOrderElementsOf (Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain inOrderElementsOf (Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderElementsOf (Seq(" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should not contain inOrderElementsOf (Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -425,13 +425,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain inOrderElementsOf (Seq("YOU", "TO")))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain inOrderElementsOf (Seq("YOU", "TO")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderElementsOf (Seq("TO", "YOU")))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain inOrderElementsOf (Seq("TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain inOrderElementsOf (Seq(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderElementsOf (Seq(" TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain inOrderElementsOf (Seq(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -460,13 +460,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain inOrderElementsOf Seq("YOU", "TO")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain inOrderElementsOf Seq("YOU", "TO")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderElementsOf Seq("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain inOrderElementsOf Seq("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain inOrderElementsOf Seq(" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderElementsOf Seq(" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain inOrderElementsOf Seq(" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -495,13 +495,13 @@ class EveryShouldContainInOrderElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain inOrderElementsOf Seq("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain inOrderElementsOf Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderElementsOf Seq("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain inOrderElementsOf Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain inOrderElementsOf Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderElementsOf Seq(" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain inOrderElementsOf Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalAndSpec.scala
@@ -93,16 +93,16 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -150,16 +150,16 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -200,16 +200,16 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -250,16 +250,16 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -300,13 +300,13 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -356,13 +356,13 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
@@ -405,16 +405,16 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -480,14 +480,14 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HO", "HELLO") and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HO", "HELLO") and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HO\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -555,14 +555,14 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("he", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -623,14 +623,14 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HELLO", "HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HELLO", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrder ("HI", "HELLO") and not contain inOrder ("HO", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrder ("HI", "HELLO") and not contain inOrder ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -698,14 +698,14 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain inOrder ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain inOrder ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("he", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalAndSpec.scala
@@ -93,16 +93,16 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -150,16 +150,16 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -200,16 +200,16 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -250,16 +250,16 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -300,13 +300,13 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -356,13 +356,13 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
@@ -405,16 +405,16 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -480,14 +480,14 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HO", "HELLO") and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HO", "HELLO") and contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HO\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -555,14 +555,14 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("he", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -623,14 +623,14 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HELLO", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrder ("HI", "HELLO") and not contain inOrder ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrder ("HI", "HELLO") and not contain inOrder ("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -698,14 +698,14 @@ class EveryShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain inOrder ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain inOrder ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("he", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalOrSpec.scala
@@ -89,14 +89,14 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -140,14 +140,14 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain inOrder (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain inOrder (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -184,14 +184,14 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -228,14 +228,14 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -272,11 +272,11 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", and " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -322,11 +322,11 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -365,14 +365,14 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -429,12 +429,12 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HO\")" + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"hello\", \"ho\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -483,12 +483,12 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -530,12 +530,12 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"hi\", \"hello\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -584,12 +584,12 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrder ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrder ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("he", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderLogicalOrSpec.scala
@@ -89,14 +89,14 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -140,14 +140,14 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain inOrder (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain inOrder (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -184,14 +184,14 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -228,14 +228,14 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -272,11 +272,11 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", and " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -322,11 +322,11 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -365,14 +365,14 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -429,12 +429,12 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HO\")" + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"hello\", \"ho\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -483,12 +483,12 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain inOrder ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -530,12 +530,12 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"hi\", \"hello\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -584,12 +584,12 @@ class EveryShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrder ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrder ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, Many("he", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalAndSpec.scala
@@ -93,16 +93,16 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -150,16 +150,16 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -200,16 +200,16 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -250,16 +250,16 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -300,13 +300,13 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -356,13 +356,13 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
@@ -405,16 +405,16 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -480,14 +480,14 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HO", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HO", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order" + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -555,14 +555,14 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -623,14 +623,14 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HELLO", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") and not contain inOrderOnly ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") and not contain inOrderOnly ("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order" + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -698,14 +698,14 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain inOrderOnly ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain inOrderOnly ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalAndSpec.scala
@@ -93,16 +93,16 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -150,16 +150,16 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -200,16 +200,16 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -250,16 +250,16 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -300,13 +300,13 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -356,13 +356,13 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
@@ -405,16 +405,16 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -480,14 +480,14 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HO", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HO", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order" + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -555,14 +555,14 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -623,14 +623,14 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HELLO", "HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HELLO", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") and not contain inOrderOnly ("HO", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") and not contain inOrderOnly ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order" + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -698,14 +698,14 @@ class EveryShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain inOrderOnly ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain inOrderOnly ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalOrSpec.scala
@@ -89,14 +89,14 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -140,14 +140,14 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -184,14 +184,14 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -228,14 +228,14 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -272,11 +272,11 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", and " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -322,11 +322,11 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -365,14 +365,14 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -429,12 +429,12 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")" + " in order" + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"hello\", \"ho\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -483,12 +483,12 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -530,12 +530,12 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order" + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"hi\", \"hello\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -584,12 +584,12 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlyLogicalOrSpec.scala
@@ -89,14 +89,14 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -140,14 +140,14 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -184,14 +184,14 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -228,14 +228,14 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -272,11 +272,11 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", and " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -322,11 +322,11 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -365,14 +365,14 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -429,12 +429,12 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")" + " in order" + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"hello\", \"ho\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -483,12 +483,12 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -530,12 +530,12 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order" + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"hi\", \"hello\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -584,12 +584,12 @@ class EveryShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlySpec.scala
@@ -74,14 +74,14 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
+        (fumList should contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain inOrderOnly ("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
+          (fumList should contain inOrderOnly ("fee", "fie", "foe", "fum")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
+        (fumList should contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -117,14 +117,14 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -161,13 +161,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
+        (toList should not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList should not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList should not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList should not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -199,13 +199,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList should (not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList should (not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should (not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -237,13 +237,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -275,13 +275,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -336,14 +336,14 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain inOrderOnly ("HI", "HE")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain inOrderOnly ("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderOnly ("HI", "HO")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain inOrderOnly ("HI", "HO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain inOrderOnly ("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain inOrderOnly ("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderOnly ("hi", "ho")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain inOrderOnly ("hi", "ho")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -390,14 +390,14 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderOnly ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HI", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain inOrderOnly ("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain inOrderOnly ("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("he", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain inOrderOnly ("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -432,13 +432,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain inOrderOnly ("YOU", "TO")) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain inOrderOnly ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderOnly ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain inOrderOnly ("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain inOrderOnly (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderOnly (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain inOrderOnly (" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -473,13 +473,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain inOrderOnly ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain inOrderOnly ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderOnly ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain inOrderOnly ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain inOrderOnly (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderOnly (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain inOrderOnly (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -514,13 +514,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain inOrderOnly ("YOU", "TO")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain inOrderOnly ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderOnly ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain inOrderOnly ("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain inOrderOnly (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderOnly (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain inOrderOnly (" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -555,13 +555,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain inOrderOnly ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain inOrderOnly ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderOnly ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain inOrderOnly ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain inOrderOnly (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderOnly (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain inOrderOnly (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderOnlySpec.scala
@@ -74,14 +74,14 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")) (decided by upperCaseStringEquality)
+        (fumList should contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain inOrderOnly ("fee", "fie", "foe", "fum")) (decided by upperCaseStringEquality)
+          (fumList should contain inOrderOnly ("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ")) (after being lowerCased and trimmed)
+        (fumList should contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -117,14 +117,14 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -161,13 +161,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (decided by upperCaseStringEquality)
+        (toList should not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList should not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList should not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList should not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList should not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -199,13 +199,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList should (not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList should (not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should (not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -237,13 +237,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -275,13 +275,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -336,14 +336,14 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain inOrderOnly ("HI", "HE")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain inOrderOnly ("HI", "HE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderOnly ("HI", "HO")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain inOrderOnly ("HI", "HO")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain inOrderOnly ("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain inOrderOnly ("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderOnly ("hi", "ho")) (decided by defaultEquality[String])
+          (all (hiLists) should contain inOrderOnly ("hi", "ho")) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -390,14 +390,14 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderOnly ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HI", "HO"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain inOrderOnly ("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain inOrderOnly ("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("he", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain inOrderOnly ("he", "hi"))) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -432,13 +432,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain inOrderOnly ("YOU", "TO")) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain inOrderOnly ("YOU", "TO")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderOnly ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain inOrderOnly ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain inOrderOnly (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderOnly (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) should not contain inOrderOnly (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -473,13 +473,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain inOrderOnly ("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain inOrderOnly ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderOnly ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain inOrderOnly ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain inOrderOnly (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderOnly (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain inOrderOnly (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -514,13 +514,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain inOrderOnly ("YOU", "TO")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain inOrderOnly ("YOU", "TO")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderOnly ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain inOrderOnly ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain inOrderOnly (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderOnly (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain inOrderOnly (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -555,13 +555,13 @@ class EveryShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain inOrderOnly ("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain inOrderOnly ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderOnly ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain inOrderOnly ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain inOrderOnly (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderOnly (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain inOrderOnly (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderSpec.scala
@@ -75,14 +75,14 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain inOrder ("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
+        (fumList should contain inOrder ("FUM", "FOE", "FIE", "FEE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain inOrder ("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
+          (fumList should contain inOrder ("fee", "fie", "foe", "fum")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
+        (fumList should contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -118,14 +118,14 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain inOrder ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -162,13 +162,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
+        (toList should not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList should not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList should not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList should not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -200,13 +200,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList should (not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList should (not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should (not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -238,13 +238,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -276,13 +276,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -337,14 +337,14 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain inOrder ("HI", "HE")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain inOrder ("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrder ("HI", "HO")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain inOrder ("HI", "HO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain inOrder ("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain inOrder ("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrder ("hi", "ho")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain inOrder ("hi", "ho")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -391,14 +391,14 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrder ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HI", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain inOrder ("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain inOrder ("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("he", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain inOrder ("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -433,13 +433,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain inOrder ("YOU", "TO")) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain inOrder ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrder ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain inOrder ("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain inOrder (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrder (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain inOrder (" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -474,13 +474,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain inOrder ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain inOrder ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrder ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain inOrder ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain inOrder (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrder (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain inOrder (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -515,13 +515,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain inOrder ("YOU", "TO")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain inOrder ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrder ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain inOrder ("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain inOrder (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrder (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain inOrder (" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -556,13 +556,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain inOrder ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain inOrder ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrder ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain inOrder ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain inOrder (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrder (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain inOrder (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainInOrderSpec.scala
@@ -75,14 +75,14 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain inOrder ("FUM", "FOE", "FIE", "FEE")) (decided by upperCaseStringEquality)
+        (fumList should contain inOrder ("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain inOrder ("fee", "fie", "foe", "fum")) (decided by upperCaseStringEquality)
+          (fumList should contain inOrder ("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ")) (after being lowerCased and trimmed)
+        (fumList should contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -118,14 +118,14 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain inOrder ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -162,13 +162,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (decided by upperCaseStringEquality)
+        (toList should not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList should not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList should not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList should not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList should not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -200,13 +200,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList should (not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList should (not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should (not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -238,13 +238,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -276,13 +276,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -337,14 +337,14 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain inOrder ("HI", "HE")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain inOrder ("HI", "HE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrder ("HI", "HO")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain inOrder ("HI", "HO")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain inOrder ("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain inOrder ("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrder ("hi", "ho")) (decided by defaultEquality[String])
+          (all (hiLists) should contain inOrder ("hi", "ho")) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -391,14 +391,14 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrder ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HI", "HO"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain inOrder ("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain inOrder ("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("he", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain inOrder ("he", "hi"))) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -433,13 +433,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain inOrder ("YOU", "TO")) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain inOrder ("YOU", "TO")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrder ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain inOrder ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain inOrder (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrder (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) should not contain inOrder (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -474,13 +474,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain inOrder ("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain inOrder ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrder ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain inOrder ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain inOrder (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrder (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain inOrder (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -515,13 +515,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain inOrder ("YOU", "TO")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain inOrder ("YOU", "TO")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrder ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain inOrder ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain inOrder (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrder (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain inOrder (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -556,13 +556,13 @@ class EveryShouldContainInOrderSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain inOrder ("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain inOrder ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrder ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain inOrder ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain inOrder (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrder (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain inOrder (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfLogicalAndSpec.scala
@@ -98,16 +98,16 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -144,16 +144,16 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -189,16 +189,16 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -234,16 +234,16 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -280,16 +280,16 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -326,16 +326,16 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -371,16 +371,16 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -448,14 +448,14 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("ho", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") and contain noElementsOf Seq("ho", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") and contain noElementsOf Seq("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -512,14 +512,14 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) and contain noElementsOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) and contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain noElementsOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("hi")) and contain noElementsOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("hi")) and contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -575,14 +575,14 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) and not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -639,14 +639,14 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) and not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain noElementsOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfLogicalAndSpec.scala
@@ -98,16 +98,16 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -144,16 +144,16 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -189,16 +189,16 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -234,16 +234,16 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -280,16 +280,16 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -326,16 +326,16 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -371,16 +371,16 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -448,14 +448,14 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("ho", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") and contain noElementsOf Seq("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") and contain noElementsOf Seq("ho", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -512,14 +512,14 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) and contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) and contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("hi")) and contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("hi")) and contain noElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -575,14 +575,14 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) and not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -639,14 +639,14 @@ class EveryShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) and not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain noElementsOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfLogicalOrSpec.scala
@@ -94,14 +94,14 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -134,14 +134,14 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -173,14 +173,14 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -212,14 +212,14 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -251,11 +251,11 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
@@ -290,14 +290,14 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -329,14 +329,14 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -389,12 +389,12 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -432,12 +432,12 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) or contain noElementsOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("ho")) or contain noElementsOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("hi")) or contain noElementsOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("ho")) or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) or contain noElementsOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -474,12 +474,12 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -517,12 +517,12 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) or not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("hi")) or not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain noElementsOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("hi")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) or not contain noElementsOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfLogicalOrSpec.scala
@@ -94,14 +94,14 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -134,14 +134,14 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -173,14 +173,14 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -212,14 +212,14 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -251,11 +251,11 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
@@ -290,14 +290,14 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -329,14 +329,14 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -389,12 +389,12 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -432,12 +432,12 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("ho")) or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("hi")) or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("ho")) or contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain noElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) or contain noElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -474,12 +474,12 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -517,12 +517,12 @@ class EveryShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("hi")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("hi")) or not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain noElementsOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) or not contain noElementsOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfSpec.scala
@@ -62,14 +62,14 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain noElementsOf Seq("FEE", "FAM", "FOE", "FU")) (using decided by upperCaseEquality)
+        (fumList should contain noElementsOf Seq("FEE", "FAM", "FOE", "FU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain noElementsOf Seq("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
+          (fumList should contain noElementsOf Seq("FEE", "FUM", "FOE", "FU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+          (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
-        (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ")) (using after being lowerCased and trimmed)
+        (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain noElementsOf Seq("fee", "fie", "foe", "fie", "fam")
@@ -102,13 +102,13 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("FEE", "FAM", "FOE", "FU"))) (using decided by upperCaseEquality)
+        (fumList should (contain noElementsOf Seq("FEE", "FAM", "FOE", "FU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FUM", "FOE", "FU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+          (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -141,11 +141,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseEquality)
+        (fumList should not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (fumList should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (fumList should not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -174,11 +174,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
+        (toList should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
+          (toList should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (toList should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+        (toList should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         }
@@ -207,11 +207,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
+        (fumList shouldNot contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (fumList shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (fumList shouldNot contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList shouldNot contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -240,11 +240,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+        (toList shouldNot (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+          (toList shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (toList shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (toList shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -296,14 +296,14 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain noElementsOf Seq("hi", "he")) (using decided by upperCaseEquality)
+        (all (hiLists) should contain noElementsOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain noElementsOf Seq("HI", "HE")) (using decided by upperCaseEquality)
+          (all (hiLists) should contain noElementsOf Seq("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain noElementsOf Seq("ho", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain noElementsOf Seq("ho", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain noElementsOf Seq("hi", "he")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain noElementsOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -345,14 +345,14 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseEquality)
+          (all (hiLists) should (contain noElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain noElementsOf Seq("ho", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain noElementsOf Seq("ho", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -382,11 +382,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+        (all (toLists) should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain noElementsOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+          (all (toLists) should not contain noElementsOf (Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) should not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) should not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -418,11 +418,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
+        (all (toLists) should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
+          (all (toLists) should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+        (all (toLists) should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         }
@@ -454,11 +454,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain noElementsOf Seq("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot contain noElementsOf Seq("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -490,11 +490,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot  (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot  (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot  (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot  (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoElementsOfSpec.scala
@@ -62,14 +62,14 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain noElementsOf Seq("FEE", "FAM", "FOE", "FU")) (decided by upperCaseEquality)
+        (fumList should contain noElementsOf Seq("FEE", "FAM", "FOE", "FU")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain noElementsOf Seq("FEE", "FUM", "FOE", "FU")) (decided by upperCaseEquality)
+          (fumList should contain noElementsOf Seq("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+          (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
         }
-        (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ")) (after being lowerCased and trimmed)
+        (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ")) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain noElementsOf Seq("fee", "fie", "foe", "fie", "fam")
@@ -102,13 +102,13 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("FEE", "FAM", "FOE", "FU"))) (decided by upperCaseEquality)
+        (fumList should (contain noElementsOf Seq("FEE", "FAM", "FOE", "FU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FUM", "FOE", "FU"))) (decided by upperCaseEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
         }
         fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+          (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -141,11 +141,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseEquality)
+        (fumList should not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (fumList should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
-        (fumList should not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -174,11 +174,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseEquality)
+        (toList should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseEquality)
+          (toList should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
         }
-        (toList should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+        (toList should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         }
@@ -207,11 +207,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseEquality)
+        (fumList shouldNot contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (fumList shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
-        (fumList shouldNot contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList shouldNot contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -240,11 +240,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+        (toList shouldNot (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+          (toList shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         }
-        (toList shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (toList shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -296,14 +296,14 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain noElementsOf Seq("hi", "he")) (decided by upperCaseEquality)
+        (all (hiLists) should contain noElementsOf Seq("hi", "he")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain noElementsOf Seq("HI", "HE")) (decided by upperCaseEquality)
+          (all (hiLists) should contain noElementsOf Seq("HI", "HE")) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain noElementsOf Seq("ho", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain noElementsOf Seq("ho", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain noElementsOf Seq("hi", "he")) (decided by defaultEquality[String])
+          (all (hiLists) should contain noElementsOf Seq("hi", "he")) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -345,14 +345,14 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (decided by upperCaseEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("HI", "HE"))) (decided by upperCaseEquality)
+          (all (hiLists) should (contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain noElementsOf Seq("ho", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain noElementsOf Seq("ho", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -382,11 +382,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+        (all (toLists) should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain noElementsOf (Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+          (all (toLists) should not contain noElementsOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         }
-        (all (toLists) should not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) should not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -418,11 +418,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseEquality)
+        (all (toLists) should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseEquality)
+          (all (toLists) should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
         }
-        (all (toLists) should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+        (all (toLists) should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         }
@@ -454,11 +454,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+        (all (toLists) shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain noElementsOf Seq("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+          (all (toLists) shouldNot contain noElementsOf Seq("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -490,11 +490,11 @@ class EveryShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot  (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+        (all (toLists) shouldNot  (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot  (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot  (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalAndSpec.scala
@@ -98,16 +98,16 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and contain noneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -155,16 +155,16 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -205,16 +205,16 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -255,16 +255,16 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -306,16 +306,16 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -363,16 +363,16 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -413,16 +413,16 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -495,14 +495,14 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("ho", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("HI", "HE") and contain noneOf ("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noneOf ("HI", "HE") and contain noneOf ("ho", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -570,14 +570,14 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) and contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) and contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("hi")) and contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("hi")) and contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -638,14 +638,14 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noneOf ("hi", "he") and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noneOf ("hi", "he") and not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -713,14 +713,14 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) and not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalAndSpec.scala
@@ -98,16 +98,16 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -155,16 +155,16 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -205,16 +205,16 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -255,16 +255,16 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -306,16 +306,16 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -363,16 +363,16 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -413,16 +413,16 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -495,14 +495,14 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("ho", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("HI", "HE") and contain noneOf ("ho", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noneOf ("HI", "HE") and contain noneOf ("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -570,14 +570,14 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) and contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) and contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("hi")) and contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("hi")) and contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -638,14 +638,14 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noneOf ("hi", "he") and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noneOf ("hi", "he") and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -713,14 +713,14 @@ class EveryShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalOrSpec.scala
@@ -94,14 +94,14 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -145,14 +145,14 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain noneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -189,14 +189,14 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -233,14 +233,14 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -277,11 +277,11 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
@@ -327,14 +327,14 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -371,14 +371,14 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -436,12 +436,12 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", and " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -490,12 +490,12 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("ho")) or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("hi")) or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("ho")) or contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) or contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", and " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -537,12 +537,12 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", and " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -591,12 +591,12 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("hi")) or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("hi")) or not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) or not contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", and " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfLogicalOrSpec.scala
@@ -94,14 +94,14 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -145,14 +145,14 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain noneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain noneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -189,14 +189,14 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -233,14 +233,14 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -277,11 +277,11 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
@@ -327,14 +327,14 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -371,14 +371,14 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -436,12 +436,12 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", and " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -490,12 +490,12 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("ho")) or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("hi")) or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("ho")) or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", and " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -537,12 +537,12 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", and " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -591,12 +591,12 @@ class EveryShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("hi")) or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("hi")) or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", and " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfSpec.scala
@@ -65,14 +65,14 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain noneOf ("FEE", "FAM", "FOE", "FU")) (using decided by upperCaseEquality)
+        (fumList should contain noneOf ("FEE", "FAM", "FOE", "FU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain noneOf ("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
+          (fumList should contain noneOf ("FEE", "FUM", "FOE", "FU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+          (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
-        (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ")) (using after being lowerCased and trimmed)
+        (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -110,13 +110,13 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("FEE", "FAM", "FOE", "FU"))) (using decided by upperCaseEquality)
+        (fumList should (contain noneOf ("FEE", "FAM", "FOE", "FU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
+          (fumList should (contain noneOf ("FEE", "FUM", "FOE", "FU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         intercept[TestFailedException] {
-          (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+          (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -154,11 +154,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should not contain noneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
+        (fumList should not contain noneOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (fumList should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (fumList should not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -192,11 +192,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+        (toList should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+          (toList should (not contain noneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (toList should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (toList should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -230,11 +230,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain noneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
+        (fumList shouldNot contain noneOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (fumList shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (fumList shouldNot contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList shouldNot contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -268,11 +268,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+        (toList shouldNot (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+          (toList shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (toList shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (toList shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -329,14 +329,14 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain noneOf ("hi", "he")) (using decided by upperCaseEquality)
+        (all (hiLists) should contain noneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain noneOf ("HI", "HE")) (using decided by upperCaseEquality)
+          (all (hiLists) should contain noneOf ("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain noneOf ("ho", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain noneOf ("ho", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain noneOf ("hi", "he")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain noneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -383,14 +383,14 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noneOf ("hi", "he"))) (using decided by upperCaseEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("HI", "HE"))) (using decided by upperCaseEquality)
+          (all (hiLists) should (contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain noneOf ("ho", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain noneOf ("ho", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("hi", "he"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -425,11 +425,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+        (all (toLists) should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain noneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+          (all (toLists) should not contain noneOf ("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) should not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+        (all (toLists) should not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -466,11 +466,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+        (all (toLists) should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+          (all (toLists) should (not contain noneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -507,11 +507,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain noneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot contain noneOf ("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -548,11 +548,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot  (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot  (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot  (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot  (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainNoneOfSpec.scala
@@ -65,14 +65,14 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain noneOf ("FEE", "FAM", "FOE", "FU")) (decided by upperCaseEquality)
+        (fumList should contain noneOf ("FEE", "FAM", "FOE", "FU")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain noneOf ("FEE", "FUM", "FOE", "FU")) (decided by upperCaseEquality)
+          (fumList should contain noneOf ("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+          (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
         }
-        (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ")) (after being lowerCased and trimmed)
+        (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ")) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -110,13 +110,13 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("FEE", "FAM", "FOE", "FU"))) (decided by upperCaseEquality)
+        (fumList should (contain noneOf ("FEE", "FAM", "FOE", "FU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FUM", "FOE", "FU"))) (decided by upperCaseEquality)
+          (fumList should (contain noneOf ("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
         }
         fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         intercept[TestFailedException] {
-          (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+          (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -154,11 +154,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should not contain noneOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseEquality)
+        (fumList should not contain noneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (fumList should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
-        (fumList should not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -192,11 +192,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+        (toList should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain noneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+          (toList should (not contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         }
-        (toList should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (toList should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -230,11 +230,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain noneOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseEquality)
+        (fumList shouldNot contain noneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (fumList shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
-        (fumList shouldNot contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList shouldNot contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -268,11 +268,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+        (toList shouldNot (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+          (toList shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         }
-        (toList shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (toList shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -329,14 +329,14 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain noneOf ("hi", "he")) (decided by upperCaseEquality)
+        (all (hiLists) should contain noneOf ("hi", "he")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain noneOf ("HI", "HE")) (decided by upperCaseEquality)
+          (all (hiLists) should contain noneOf ("HI", "HE")) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain noneOf ("ho", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain noneOf ("ho", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain noneOf ("hi", "he")) (decided by defaultEquality[String])
+          (all (hiLists) should contain noneOf ("hi", "he")) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -383,14 +383,14 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noneOf ("hi", "he"))) (decided by upperCaseEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("HI", "HE"))) (decided by upperCaseEquality)
+          (all (hiLists) should (contain noneOf ("HI", "HE"))) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain noneOf ("ho", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain noneOf ("ho", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("hi", "he"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain noneOf ("hi", "he"))) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -425,11 +425,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+        (all (toLists) should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain noneOf ("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+          (all (toLists) should not contain noneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         }
-        (all (toLists) should not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+        (all (toLists) should not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -466,11 +466,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+        (all (toLists) should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain noneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+          (all (toLists) should (not contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         }
-        (all (toLists) should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -507,11 +507,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+        (all (toLists) shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain noneOf ("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+          (all (toLists) shouldNot contain noneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -548,11 +548,11 @@ class EveryShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot  (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+        (all (toLists) shouldNot  (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot  (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot  (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfLogicalAndSpec.scala
@@ -98,16 +98,16 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fee", "fie", "foe", "fum") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fee", "fie", "foe", "fum") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -144,16 +144,16 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -189,16 +189,16 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -234,16 +234,16 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -279,16 +279,16 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", but " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -325,16 +325,16 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -370,16 +370,16 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -447,14 +447,14 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("hi", "he") and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneElementOf Seq("hi", "he") and contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -511,14 +511,14 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) and contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("hi")) and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("hi")) and contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -574,14 +574,14 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) and not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) and not contain oneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) and not contain oneElementOf (Seq("HO", "HEY", "HOWDY")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) and not contain oneElementOf (Seq("HO", "HEY", "HOWDY")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneElementOf (Seq("HO", "HEY", "HOWDY")) and not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneElementOf (Seq("HO", "HEY", "HOWDY")) and not contain oneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("HO", "HEY", "HOWDY")) + ", but " + FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -638,14 +638,14 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain oneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) and not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) and not contain oneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain oneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfLogicalAndSpec.scala
@@ -98,16 +98,16 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fee", "fie", "foe", "fum") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fee", "fie", "foe", "fum") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -144,16 +144,16 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -189,16 +189,16 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -234,16 +234,16 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -279,16 +279,16 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", but " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -325,16 +325,16 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -370,16 +370,16 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -447,14 +447,14 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("hi", "he") and contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneElementOf Seq("hi", "he") and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -511,14 +511,14 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) and contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("hi")) and contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("hi")) and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -574,14 +574,14 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) and not contain oneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) and not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) and not contain oneElementOf (Seq("HO", "HEY", "HOWDY")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) and not contain oneElementOf (Seq("HO", "HEY", "HOWDY")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneElementOf (Seq("HO", "HEY", "HOWDY")) and not contain oneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneElementOf (Seq("HO", "HEY", "HOWDY")) and not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("HO", "HEY", "HOWDY")) + ", but " + FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -638,14 +638,14 @@ class EveryShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain oneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) and not contain oneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) and not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain oneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfLogicalOrSpec.scala
@@ -94,14 +94,14 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow when RHS to contain duplicated value") {
@@ -134,14 +134,14 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -173,14 +173,14 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -212,14 +212,14 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -251,14 +251,14 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -291,14 +291,14 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -330,14 +330,14 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -390,12 +390,12 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("ho", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("ho", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("ho", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -433,12 +433,12 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("ho")) or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("hi")) or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("ho")) or contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) or contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -475,12 +475,12 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")) + ", and " + FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -518,12 +518,12 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("hi")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain oneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("hi")) or not contain oneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain oneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) or not contain oneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", and " + FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfLogicalOrSpec.scala
@@ -94,14 +94,14 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow when RHS to contain duplicated value") {
@@ -134,14 +134,14 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -173,14 +173,14 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -212,14 +212,14 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -251,14 +251,14 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -291,14 +291,14 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -330,14 +330,14 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -390,12 +390,12 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("ho", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("ho", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("ho", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -433,12 +433,12 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) or contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("ho")) or contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("hi")) or contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("ho")) or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) or contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -475,12 +475,12 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")) + ", and " + FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -518,12 +518,12 @@ class EveryShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) or not contain oneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("hi")) or not contain oneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain oneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("hi")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) or not contain oneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", and " + FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfSpec.scala
@@ -70,14 +70,14 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain oneElementOf Seq("FEE", "FUM", "FOE", "FU")) (decided by upperCaseEquality)
+        (fumList should contain oneElementOf Seq("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain oneElementOf Seq("fee", "fum", "foe", "fu")) (decided by upperCaseEquality)
+          (fumList should contain oneElementOf Seq("fee", "fum", "foe", "fu")) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain oneElementOf Seq("fee", "fie", "foe", "fie", "fum")
@@ -110,14 +110,14 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FUM", "FOE", "FU"))) (decided by upperCaseEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fee", "fum", "foe", "fu"))) (decided by upperCaseEquality)
+          (fumList should (contain oneElementOf Seq("fee", "fum", "foe", "fu"))) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should (contain oneElementOf Seq("fee", "fie", "foe", "fie", "fum"))
@@ -157,13 +157,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (toList should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (toList should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         toList should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -199,13 +199,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseEquality)
+        (toList should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseEquality)
+          (toList should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
         }
         toList should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -232,13 +232,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+        (toList shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (toList shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
         toList shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -265,13 +265,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (toList shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (toList shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         toList shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -321,14 +321,14 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain oneElementOf Seq("HI", "HE")) (decided by upperCaseEquality)
+        (all (hiLists) should contain oneElementOf Seq("HI", "HE")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneElementOf Seq("hi", "he")) (decided by upperCaseEquality)
+          (all (hiLists) should contain oneElementOf Seq("hi", "he")) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain oneElementOf Seq("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain oneElementOf Seq("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneElementOf Seq("ho", "he")) (decided by defaultEquality[String])
+          (all (hiLists) should contain oneElementOf Seq("ho", "he")) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -370,14 +370,14 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (decided by upperCaseEquality)
+          (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("ho", "he"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain oneElementOf Seq("ho", "he"))) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -422,13 +422,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (all (toLists) should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (all (toLists) should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         all (toLists) should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -475,13 +475,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseEquality)
+        (all (toLists) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseEquality)
+          (all (toLists) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
         }
         all (toLists) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -511,13 +511,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+        (all (toLists) shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (all (toLists) shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
         all (toLists) shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -547,13 +547,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (all (toLists) shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         all (toLists) shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneElementOfSpec.scala
@@ -70,14 +70,14 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain oneElementOf Seq("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
+        (fumList should contain oneElementOf Seq("FEE", "FUM", "FOE", "FU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain oneElementOf Seq("fee", "fum", "foe", "fu")) (using decided by upperCaseEquality)
+          (fumList should contain oneElementOf Seq("fee", "fum", "foe", "fu")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain oneElementOf Seq("fee", "fie", "foe", "fie", "fum")
@@ -110,14 +110,14 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FUM", "FOE", "FU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fee", "fum", "foe", "fu"))) (using decided by upperCaseEquality)
+          (fumList should (contain oneElementOf Seq("fee", "fum", "foe", "fu"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should (contain oneElementOf Seq("fee", "fie", "foe", "fie", "fum"))
@@ -157,13 +157,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (toList should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (toList should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -199,13 +199,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
+        (toList should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
+          (toList should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -232,13 +232,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+        (toList shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (toList shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -265,13 +265,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (toList shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (toList shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -321,14 +321,14 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain oneElementOf Seq("HI", "HE")) (using decided by upperCaseEquality)
+        (all (hiLists) should contain oneElementOf Seq("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneElementOf Seq("hi", "he")) (using decided by upperCaseEquality)
+          (all (hiLists) should contain oneElementOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain oneElementOf Seq("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain oneElementOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneElementOf Seq("ho", "he")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain oneElementOf Seq("ho", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -370,14 +370,14 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseEquality)
+          (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("ho", "he"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain oneElementOf Seq("ho", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -422,13 +422,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (all (toLists) should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (all (toLists) should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -475,13 +475,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
+        (all (toLists) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
+          (all (toLists) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -511,13 +511,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -547,13 +547,13 @@ class EveryShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalAndSpec.scala
@@ -98,16 +98,16 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fee", "fie", "foe", "fum") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fee", "fie", "foe", "fum") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -155,16 +155,16 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain oneOf ("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -205,16 +205,16 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -255,16 +255,16 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -305,16 +305,16 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -362,16 +362,16 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -412,16 +412,16 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -494,14 +494,14 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("hi", "he") and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneOf ("hi", "he") and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -569,14 +569,14 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("hi")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("hi")) and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -637,14 +637,14 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneOf ("hi", "he") and not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("hi", "he") and not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneOf ("HI", "HE") and not contain oneOf ("HO", "HEY", "HOWDY"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneOf ("HI", "HE") and not contain oneOf ("HO", "HEY", "HOWDY"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneOf ("HO", "HEY", "HOWDY") and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneOf ("HO", "HEY", "HOWDY") and not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"HO\", \"HEY\", \"HOWDY\"")) + ", but " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -712,14 +712,14 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) and not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalAndSpec.scala
@@ -98,16 +98,16 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fee", "fie", "foe", "fum") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fee", "fie", "foe", "fum") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -155,16 +155,16 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -205,16 +205,16 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -255,16 +255,16 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -305,16 +305,16 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") and not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -362,16 +362,16 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -412,16 +412,16 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -494,14 +494,14 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("hi", "he") and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneOf ("hi", "he") and contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -569,14 +569,14 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) and contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) and contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("hi")) and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("hi")) and contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -637,14 +637,14 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneOf ("hi", "he") and not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("hi", "he") and not contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneOf ("HI", "HE") and not contain oneOf ("HO", "HEY", "HOWDY"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneOf ("HI", "HE") and not contain oneOf ("HO", "HEY", "HOWDY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneOf ("HO", "HEY", "HOWDY") and not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneOf ("HO", "HEY", "HOWDY") and not contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"HO\", \"HEY\", \"HOWDY\"")) + ", but " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -712,14 +712,14 @@ class EveryShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) and not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) and not contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalOrSpec.scala
@@ -94,14 +94,14 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -145,14 +145,14 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -189,14 +189,14 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -233,14 +233,14 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -277,14 +277,14 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -328,14 +328,14 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -372,14 +372,14 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -437,12 +437,12 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("ho", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("ho", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"ho\", \"hi\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -491,12 +491,12 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("ho")) or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("hi")) or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("ho")) or contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) or contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -538,12 +538,12 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", and " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -592,12 +592,12 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("hi")) or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("hi")) or not contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) or not contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", and " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfLogicalOrSpec.scala
@@ -94,14 +94,14 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -145,14 +145,14 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -189,14 +189,14 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -233,14 +233,14 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -277,14 +277,14 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -328,14 +328,14 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -372,14 +372,14 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -437,12 +437,12 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("ho", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("ho", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"ho\", \"hi\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -491,12 +491,12 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (One("hi")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("ho")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (One("hi")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("ho")) or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (One("hi")) or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (One("ho")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (One("ho")) or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -538,12 +538,12 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", and " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -592,12 +592,12 @@ class EveryShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("hi")) or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (One("ho")) or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("hi")) or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("hi")) or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("hi")) or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, One("hi")) + " was equal to " + decorateToStringValue(prettifier, One("hi")) + ", and " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfSpec.scala
@@ -73,14 +73,14 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain oneOf ("FEE", "FUM", "FOE", "FU")) (decided by upperCaseEquality)
+        (fumList should contain oneOf ("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain oneOf ("fee", "fum", "foe", "fu")) (decided by upperCaseEquality)
+          (fumList should contain oneOf ("fee", "fum", "foe", "fu")) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -118,14 +118,14 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FUM", "FOE", "FU"))) (decided by upperCaseEquality)
+        (fumList should (contain oneOf ("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fee", "fum", "foe", "fu"))) (decided by upperCaseEquality)
+          (fumList should (contain oneOf ("fee", "fum", "foe", "fu"))) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -170,13 +170,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain oneOf ("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+        (toList should not contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (toList should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
         toList should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -217,13 +217,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (toList should (not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (toList should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         toList should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -255,13 +255,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain oneOf ("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+        (toList shouldNot contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (toList shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
         toList shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -293,13 +293,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (toList shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (toList shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         toList shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -354,14 +354,14 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain oneOf ("HI", "HE")) (decided by upperCaseEquality)
+        (all (hiLists) should contain oneOf ("HI", "HE")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneOf ("hi", "he")) (decided by upperCaseEquality)
+          (all (hiLists) should contain oneOf ("hi", "he")) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain oneOf ("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain oneOf ("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneOf ("ho", "he")) (decided by defaultEquality[String])
+          (all (hiLists) should contain oneOf ("ho", "he")) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -408,14 +408,14 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneOf ("HI", "HE"))) (decided by upperCaseEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("hi", "he"))) (decided by upperCaseEquality)
+          (all (hiLists) should (contain oneOf ("hi", "he"))) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain oneOf ("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain oneOf ("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("ho", "he"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain oneOf ("ho", "he"))) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -465,13 +465,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain oneOf ("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+        (all (toLists) should not contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (all (toLists) should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
         all (toLists) should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -523,13 +523,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (all (toLists) should (not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (all (toLists) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         all (toLists) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -564,13 +564,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain oneOf ("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+        (all (toLists) shouldNot contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (all (toLists) shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
         all (toLists) shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -605,13 +605,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (all (toLists) shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         all (toLists) shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOneOfSpec.scala
@@ -73,14 +73,14 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain oneOf ("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
+        (fumList should contain oneOf ("FEE", "FUM", "FOE", "FU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain oneOf ("fee", "fum", "foe", "fu")) (using decided by upperCaseEquality)
+          (fumList should contain oneOf ("fee", "fum", "foe", "fu")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -118,14 +118,14 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
+        (fumList should (contain oneOf ("FEE", "FUM", "FOE", "FU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fee", "fum", "foe", "fu"))) (using decided by upperCaseEquality)
+          (fumList should (contain oneOf ("fee", "fum", "foe", "fu"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -170,13 +170,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+        (toList should not contain oneOf ("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (toList should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -217,13 +217,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (toList should (not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (toList should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -255,13 +255,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+        (toList shouldNot contain oneOf ("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (toList shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -293,13 +293,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (toList shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (toList shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -354,14 +354,14 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain oneOf ("HI", "HE")) (using decided by upperCaseEquality)
+        (all (hiLists) should contain oneOf ("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneOf ("hi", "he")) (using decided by upperCaseEquality)
+          (all (hiLists) should contain oneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain oneOf ("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain oneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneOf ("ho", "he")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain oneOf ("ho", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -408,14 +408,14 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneOf ("HI", "HE"))) (using decided by upperCaseEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("hi", "he"))) (using decided by upperCaseEquality)
+          (all (hiLists) should (contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain oneOf ("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("ho", "he"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain oneOf ("ho", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -465,13 +465,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+        (all (toLists) should not contain oneOf ("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (all (toLists) should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -523,13 +523,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (all (toLists) should (not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (all (toLists) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -564,13 +564,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot contain oneOf ("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -605,13 +605,13 @@ class EveryShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalAndSpec.scala
@@ -93,16 +93,16 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -193,16 +193,16 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FAM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -268,16 +268,16 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain only ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain only ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -343,16 +343,16 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -418,16 +418,16 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\"") + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain only ("FIE", "FEE", "FUM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain only ("FIE", "FEE", "FUM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -502,16 +502,16 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -568,16 +568,16 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -660,14 +660,14 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HO", "HELLO") and contain only ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HO", "HELLO") and contain only ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")" + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -784,14 +784,14 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "hello")) and contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) and contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "hello")) and contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("hi", "hello")) and contain only ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -887,14 +887,14 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain only ("HI") and not contain only ("HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HI") and not contain only ("HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain only ("HELLO", "HI") and not contain only ("HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain only ("HELLO", "HI") and not contain only ("HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain only ("HI") and not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain only ("HI") and not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HI\")" + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -1000,14 +1000,14 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain only ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) and not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) and not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain only ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain only ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalAndSpec.scala
@@ -93,16 +93,16 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -193,16 +193,16 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -268,16 +268,16 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain only ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain only ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -343,16 +343,16 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -418,16 +418,16 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\"") + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain only ("FIE", "FEE", "FUM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain only ("FIE", "FEE", "FUM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -502,16 +502,16 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -568,16 +568,16 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -660,14 +660,14 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HO", "HELLO") and contain only ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HO", "HELLO") and contain only ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")" + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -784,14 +784,14 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "hello")) and contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) and contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "hello")) and contain only ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("hi", "hello")) and contain only ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -887,14 +887,14 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain only ("HI") and not contain only ("HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HI") and not contain only ("HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain only ("HELLO", "HI") and not contain only ("HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain only ("HELLO", "HI") and not contain only ("HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain only ("HI") and not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain only ("HI") and not contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HI\")" + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -1000,14 +1000,14 @@ class EveryShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain only ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain only ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) and not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) and not contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain only ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain only ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalOrSpec.scala
@@ -89,14 +89,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -179,14 +179,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain only Set(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain only Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -248,14 +248,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -317,14 +317,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -386,14 +386,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -460,14 +460,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -520,14 +520,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -601,12 +601,12 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")" + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"hello\", \"ho\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -694,12 +694,12 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "hello")) or contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "hello")) or contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -766,12 +766,12 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")" + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"hello\", \"hi\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -843,12 +843,12 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "hi")) or not contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "hi")) or not contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) or not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) or not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlyLogicalOrSpec.scala
@@ -89,14 +89,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -179,14 +179,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain only Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain only Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -248,14 +248,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -317,14 +317,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -386,14 +386,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -460,14 +460,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -520,14 +520,14 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -601,12 +601,12 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")" + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"hello\", \"ho\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -694,12 +694,12 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "hello")) or contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "hello")) or contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain only ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain only ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -766,12 +766,12 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")" + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"hello\", \"hi\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -843,12 +843,12 @@ class EveryShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "hi")) or not contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain only ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "hi")) or not contain only ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) or not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) or not contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlySpec.scala
@@ -74,14 +74,14 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain only ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList should contain only ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain only ("fee", "fie", "foe")) (using decided by upperCaseStringEquality)
+          (fumList should contain only ("fee", "fie", "foe")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain only (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain only (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain only (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         if (ScalaTestVersions.BuiltForScalaVersion != "2.13" && !ScalaTestVersions.BuiltForScalaVersion.startsWith("3.")) { // For 2.13 and 3.x, the compiler will pass in args with single argument ().
@@ -144,14 +144,14 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain only ("fee", "fie", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain only ("fee", "fie", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         if (ScalaTestVersions.BuiltForScalaVersion != "2.13" && !ScalaTestVersions.BuiltForScalaVersion.startsWith("3.")) { // For 2.13 and 3.x, the compiler will pass in args with single argument ().
@@ -267,13 +267,13 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain only ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (toList should (not contain only ("NICE", "TO", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList should (not contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should (not contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -321,13 +321,13 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain only ("happy", "birthday", "to")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain only ("happy", "birthday", "to")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain only ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain only ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -385,13 +385,13 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain only ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain only ("NICE", "TO", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -481,14 +481,14 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain only ("HE", "HI")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain only ("HE", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain only ("HO", "HI")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain only ("HO", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain only ("he", "hi")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain only ("he", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain only ("ho", "hi")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain only ("ho", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -573,14 +573,14 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain only ("HE", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain only ("he", "hi"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain only ("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("ho", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain only ("ho", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -643,13 +643,13 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain only ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain only ("NICE", "MEET", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain only ("YOU", "TO")) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain only ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain only (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain only (" YOU ", " TO ")) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain only (" YOU ", " TO ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -703,13 +703,13 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain only ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain only ("NICE", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain only ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain only ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain only (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain only (" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain only (" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -763,13 +763,13 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain only ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain only ("NICE", "MEET", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain only ("YOU", "TO")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain only ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain only (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain only (" YOU ", " TO ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain only (" YOU ", " TO ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -832,13 +832,13 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain only ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain only ("NICE", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain only ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain only ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain only (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain only (" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain only (" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainOnlySpec.scala
@@ -74,14 +74,14 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain only ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList should contain only ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain only ("fee", "fie", "foe")) (decided by upperCaseStringEquality)
+          (fumList should contain only ("fee", "fie", "foe")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain only (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain only (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain only (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         if (ScalaTestVersions.BuiltForScalaVersion != "2.13" && !ScalaTestVersions.BuiltForScalaVersion.startsWith("3.")) { // For 2.13 and 3.x, the compiler will pass in args with single argument ().
@@ -144,14 +144,14 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain only ("fee", "fie", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("fee", "fie", "foe"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         if (ScalaTestVersions.BuiltForScalaVersion != "2.13" && !ScalaTestVersions.BuiltForScalaVersion.startsWith("3.")) { // For 2.13 and 3.x, the compiler will pass in args with single argument ().
@@ -267,13 +267,13 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain only ("NICE", "TO", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (toList should (not contain only ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList should (not contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should (not contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -321,13 +321,13 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain only ("happy", "birthday", "to")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain only ("happy", "birthday", "to")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain only ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain only ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -385,13 +385,13 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain only ("NICE", "TO", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain only ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -481,14 +481,14 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain only ("HE", "HI")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain only ("HE", "HI")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain only ("HO", "HI")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain only ("HO", "HI")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain only ("he", "hi")) (decided by defaultEquality[String])
+        (all (hiLists) should contain only ("he", "hi")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain only ("ho", "hi")) (decided by defaultEquality[String])
+          (all (hiLists) should contain only ("ho", "hi")) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -573,14 +573,14 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain only ("HE", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HE", "HI"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HO", "HI"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain only ("he", "hi"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain only ("he", "hi"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("ho", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain only ("ho", "hi"))) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -643,13 +643,13 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain only ("NICE", "MEET", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain only ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain only ("YOU", "TO")) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain only ("YOU", "TO")) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain only (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain only (" YOU ", " TO ")) (after being lowerCased and trimmed)
+          (all (toLists) should not contain only (" YOU ", " TO ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -703,13 +703,13 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain only ("NICE", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain only ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain only ("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain only ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain only (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain only (" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain only (" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -763,13 +763,13 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain only ("NICE", "MEET", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain only ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain only ("YOU", "TO")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain only ("YOU", "TO")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain only (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain only (" YOU ", " TO ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain only (" YOU ", " TO ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -832,13 +832,13 @@ class EveryShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain only ("NICE", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain only ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain only ("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain only ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain only (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain only (" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain only (" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainSpec.scala
@@ -66,15 +66,15 @@ class EveryShouldContainSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           caseLists should contain ("HI")
         }
-        (caseLists should contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
-        (caseLists should contain ("HI")) (using after being lowerCased)
-        (caseLists should contain ("HI ")) (using after being lowerCased and trimmed)
+        (caseLists should contain ("HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (caseLists should contain ("HI")) (/* DOTTY-ONLY using */ after being lowerCased)
+        (caseLists should contain ("HI ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
 
         {
           implicit val e = new Equality[String] {
             def areEqual(a: String, b: Any): Boolean = a != b
           }
-          (xs should contain ("hi")) (using decided by defaultEquality[String])
+          (xs should contain ("hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -153,13 +153,13 @@ class EveryShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists should not contain "HI"
         caseLists should not contain "HI "
-        (caseLists should not contain "HI ") (using decided by defaultEquality afterBeing lowerCased)
-        (caseLists should not contain "HI ") (using after being lowerCased)
+        (caseLists should not contain "HI ") (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (caseLists should not contain "HI ") (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists should not contain "HI") (using decided by defaultEquality afterBeing lowerCased)
+          (caseLists should not contain "HI") (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should not contain "HI ") (using after being lowerCased and trimmed)
+          (caseLists should not contain "HI ") (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -231,16 +231,16 @@ class EveryShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists should not (contain ("HI"))
         caseLists should not (contain ("HI "))
-        (caseLists should not (contain ("HI "))) (using decided by defaultEquality afterBeing lowerCased)
-        (caseLists should not (contain ("HI "))) (using after being lowerCased)
+        (caseLists should not (contain ("HI "))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (caseLists should not (contain ("HI "))) (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists should not (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
+          (caseLists should not (contain ("HI"))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should not (contain ("HI"))) (using after being lowerCased)
+          (caseLists should not (contain ("HI"))) (/* DOTTY-ONLY using */ after being lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should not (contain ("HI "))) (using after being lowerCased and trimmed)
+          (caseLists should not (contain ("HI "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -311,16 +311,16 @@ class EveryShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists should (not contain "HI")
         caseLists should (not contain "HI ")
-        (caseLists should (not contain "HI ")) (using decided by defaultEquality afterBeing lowerCased)
-        (caseLists should (not contain "HI ")) (using after being lowerCased)
+        (caseLists should (not contain "HI ")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (caseLists should (not contain "HI ")) (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists should (not contain "HI")) (using decided by defaultEquality afterBeing lowerCased)
+          (caseLists should (not contain "HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should (not contain "HI")) (using after being lowerCased)
+          (caseLists should (not contain "HI")) (/* DOTTY-ONLY using */ after being lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should (not contain "HI ")) (using after being lowerCased and trimmed)
+          (caseLists should (not contain "HI ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -391,13 +391,13 @@ class EveryShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists shouldNot contain ("HI")
         caseLists shouldNot contain ("HI ")
-        (caseLists shouldNot contain ("HI ")) (using decided by defaultEquality afterBeing lowerCased)
-        (caseLists shouldNot contain ("HI ")) (using after being lowerCased)
+        (caseLists shouldNot contain ("HI ")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (caseLists shouldNot contain ("HI ")) (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists shouldNot contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
+          (caseLists shouldNot contain ("HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists shouldNot contain ("HI ")) (using after being lowerCased and trimmed)
+          (caseLists shouldNot contain ("HI ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -469,16 +469,16 @@ class EveryShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists shouldNot (contain ("HI"))
         caseLists shouldNot (contain ("HI "))
-        (caseLists shouldNot (contain ("HI "))) (using decided by defaultEquality afterBeing lowerCased)
-        (caseLists shouldNot (contain ("HI "))) (using after being lowerCased)
+        (caseLists shouldNot (contain ("HI "))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (caseLists shouldNot (contain ("HI "))) (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists shouldNot (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
+          (caseLists shouldNot (contain ("HI"))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists shouldNot (contain ("HI"))) (using after being lowerCased)
+          (caseLists shouldNot (contain ("HI"))) (/* DOTTY-ONLY using */ after being lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists shouldNot (contain ("HI "))) (using after being lowerCased and trimmed)
+          (caseLists shouldNot (contain ("HI "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -586,8 +586,8 @@ class EveryShouldContainSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           all (hiLists) should contain ("HI ")
         }
-        (all (hiLists) should contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
-        (all (hiLists) should contain ("HI ")) (using after being trimmed and lowerCased)
+        (all (hiLists) should contain ("HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (all (hiLists) should contain ("HI ")) (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
         val hiHeHoLists: List[List[String]] = List(List("hi", "he", "ho"), List("hi", "he", "ho"), List("hi", "he", "ho"))
@@ -666,10 +666,10 @@ class EveryShouldContainSpec extends AnyFunSpec {
         all (hiLists) should not contain "HI"
         all (hiLists) should not contain "HI "
         intercept[TestFailedException] {
-          (all (hiLists) should not contain "HI") (using decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) should not contain "HI") (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) should not contain "HI ") (using after being trimmed and lowerCased)
+          (all (hiLists) should not contain "HI ") (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -725,10 +725,10 @@ class EveryShouldContainSpec extends AnyFunSpec {
         all (hiLists) should not (contain ("HI"))
         all (hiLists) should not (contain ("HI "))
         intercept[TestFailedException] {
-          (all (hiLists) should not (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) should not (contain ("HI"))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) should not (contain ("HI "))) (using after being trimmed and lowerCased)
+          (all (hiLists) should not (contain ("HI "))) (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -784,10 +784,10 @@ class EveryShouldContainSpec extends AnyFunSpec {
         all (hiLists) should (not contain "HI")
         all (hiLists) should (not contain "HI ")
         intercept[TestFailedException] {
-          (all (hiLists) should (not contain "HI")) (using decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) should (not contain "HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) should (not contain "HI ")) (using after being trimmed and lowerCased)
+          (all (hiLists) should (not contain "HI ")) (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -844,10 +844,10 @@ class EveryShouldContainSpec extends AnyFunSpec {
         all (hiLists) shouldNot contain ("HI")
         all (hiLists) shouldNot contain ("HI ")
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) shouldNot contain ("HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot contain ("HI ")) (using after being trimmed and lowerCased)
+          (all (hiLists) shouldNot contain ("HI ")) (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -903,10 +903,10 @@ class EveryShouldContainSpec extends AnyFunSpec {
         all (hiLists) shouldNot (contain ("HI"))
         all (hiLists) shouldNot (contain ("HI "))
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) shouldNot (contain ("HI"))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot (contain ("HI "))) (using after being trimmed and lowerCased)
+          (all (hiLists) shouldNot (contain ("HI "))) (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainSpec.scala
@@ -66,15 +66,15 @@ class EveryShouldContainSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           caseLists should contain ("HI")
         }
-        (caseLists should contain ("HI")) (decided by defaultEquality afterBeing lowerCased)
-        (caseLists should contain ("HI")) (after being lowerCased)
-        (caseLists should contain ("HI ")) (after being lowerCased and trimmed)
+        (caseLists should contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
+        (caseLists should contain ("HI")) (using after being lowerCased)
+        (caseLists should contain ("HI ")) (using after being lowerCased and trimmed)
 
         {
           implicit val e = new Equality[String] {
             def areEqual(a: String, b: Any): Boolean = a != b
           }
-          (xs should contain ("hi")) (decided by defaultEquality[String])
+          (xs should contain ("hi")) (using decided by defaultEquality[String])
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -153,13 +153,13 @@ class EveryShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists should not contain "HI"
         caseLists should not contain "HI "
-        (caseLists should not contain "HI ") (decided by defaultEquality afterBeing lowerCased)
-        (caseLists should not contain "HI ") (after being lowerCased)
+        (caseLists should not contain "HI ") (using decided by defaultEquality afterBeing lowerCased)
+        (caseLists should not contain "HI ") (using after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists should not contain "HI") (decided by defaultEquality afterBeing lowerCased)
+          (caseLists should not contain "HI") (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should not contain "HI ") (after being lowerCased and trimmed)
+          (caseLists should not contain "HI ") (using after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -231,16 +231,16 @@ class EveryShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists should not (contain ("HI"))
         caseLists should not (contain ("HI "))
-        (caseLists should not (contain ("HI "))) (decided by defaultEquality afterBeing lowerCased)
-        (caseLists should not (contain ("HI "))) (after being lowerCased)
+        (caseLists should not (contain ("HI "))) (using decided by defaultEquality afterBeing lowerCased)
+        (caseLists should not (contain ("HI "))) (using after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists should not (contain ("HI"))) (decided by defaultEquality afterBeing lowerCased)
+          (caseLists should not (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should not (contain ("HI"))) (after being lowerCased)
+          (caseLists should not (contain ("HI"))) (using after being lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should not (contain ("HI "))) (after being lowerCased and trimmed)
+          (caseLists should not (contain ("HI "))) (using after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -311,16 +311,16 @@ class EveryShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists should (not contain "HI")
         caseLists should (not contain "HI ")
-        (caseLists should (not contain "HI ")) (decided by defaultEquality afterBeing lowerCased)
-        (caseLists should (not contain "HI ")) (after being lowerCased)
+        (caseLists should (not contain "HI ")) (using decided by defaultEquality afterBeing lowerCased)
+        (caseLists should (not contain "HI ")) (using after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists should (not contain "HI")) (decided by defaultEquality afterBeing lowerCased)
+          (caseLists should (not contain "HI")) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should (not contain "HI")) (after being lowerCased)
+          (caseLists should (not contain "HI")) (using after being lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should (not contain "HI ")) (after being lowerCased and trimmed)
+          (caseLists should (not contain "HI ")) (using after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -391,13 +391,13 @@ class EveryShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists shouldNot contain ("HI")
         caseLists shouldNot contain ("HI ")
-        (caseLists shouldNot contain ("HI ")) (decided by defaultEquality afterBeing lowerCased)
-        (caseLists shouldNot contain ("HI ")) (after being lowerCased)
+        (caseLists shouldNot contain ("HI ")) (using decided by defaultEquality afterBeing lowerCased)
+        (caseLists shouldNot contain ("HI ")) (using after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists shouldNot contain ("HI")) (decided by defaultEquality afterBeing lowerCased)
+          (caseLists shouldNot contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists shouldNot contain ("HI ")) (after being lowerCased and trimmed)
+          (caseLists shouldNot contain ("HI ")) (using after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -469,16 +469,16 @@ class EveryShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists shouldNot (contain ("HI"))
         caseLists shouldNot (contain ("HI "))
-        (caseLists shouldNot (contain ("HI "))) (decided by defaultEquality afterBeing lowerCased)
-        (caseLists shouldNot (contain ("HI "))) (after being lowerCased)
+        (caseLists shouldNot (contain ("HI "))) (using decided by defaultEquality afterBeing lowerCased)
+        (caseLists shouldNot (contain ("HI "))) (using after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists shouldNot (contain ("HI"))) (decided by defaultEquality afterBeing lowerCased)
+          (caseLists shouldNot (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists shouldNot (contain ("HI"))) (after being lowerCased)
+          (caseLists shouldNot (contain ("HI"))) (using after being lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists shouldNot (contain ("HI "))) (after being lowerCased and trimmed)
+          (caseLists shouldNot (contain ("HI "))) (using after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -586,8 +586,8 @@ class EveryShouldContainSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           all (hiLists) should contain ("HI ")
         }
-        (all (hiLists) should contain ("HI")) (decided by defaultEquality afterBeing lowerCased)
-        (all (hiLists) should contain ("HI ")) (after being trimmed and lowerCased)
+        (all (hiLists) should contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
+        (all (hiLists) should contain ("HI ")) (using after being trimmed and lowerCased)
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
         val hiHeHoLists: List[List[String]] = List(List("hi", "he", "ho"), List("hi", "he", "ho"), List("hi", "he", "ho"))
@@ -666,10 +666,10 @@ class EveryShouldContainSpec extends AnyFunSpec {
         all (hiLists) should not contain "HI"
         all (hiLists) should not contain "HI "
         intercept[TestFailedException] {
-          (all (hiLists) should not contain "HI") (decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) should not contain "HI") (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) should not contain "HI ") (after being trimmed and lowerCased)
+          (all (hiLists) should not contain "HI ") (using after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -725,10 +725,10 @@ class EveryShouldContainSpec extends AnyFunSpec {
         all (hiLists) should not (contain ("HI"))
         all (hiLists) should not (contain ("HI "))
         intercept[TestFailedException] {
-          (all (hiLists) should not (contain ("HI"))) (decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) should not (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) should not (contain ("HI "))) (after being trimmed and lowerCased)
+          (all (hiLists) should not (contain ("HI "))) (using after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -784,10 +784,10 @@ class EveryShouldContainSpec extends AnyFunSpec {
         all (hiLists) should (not contain "HI")
         all (hiLists) should (not contain "HI ")
         intercept[TestFailedException] {
-          (all (hiLists) should (not contain "HI")) (decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) should (not contain "HI")) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) should (not contain "HI ")) (after being trimmed and lowerCased)
+          (all (hiLists) should (not contain "HI ")) (using after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -844,10 +844,10 @@ class EveryShouldContainSpec extends AnyFunSpec {
         all (hiLists) shouldNot contain ("HI")
         all (hiLists) shouldNot contain ("HI ")
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot contain ("HI")) (decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) shouldNot contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot contain ("HI ")) (after being trimmed and lowerCased)
+          (all (hiLists) shouldNot contain ("HI ")) (using after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -903,10 +903,10 @@ class EveryShouldContainSpec extends AnyFunSpec {
         all (hiLists) shouldNot (contain ("HI"))
         all (hiLists) shouldNot (contain ("HI "))
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot (contain ("HI"))) (decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) shouldNot (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot (contain ("HI "))) (after being trimmed and lowerCased)
+          (all (hiLists) shouldNot (contain ("HI "))) (using after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalAndSpec.scala
@@ -94,16 +94,16 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FUM"))) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -135,16 +135,16 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
 
@@ -176,16 +176,16 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
 
@@ -217,16 +217,16 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))) + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
 
@@ -258,16 +258,16 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -299,16 +299,16 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -340,16 +340,16 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -407,14 +407,14 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HO", "HELLO") and contain theSameElementsAs Set("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HO", "HELLO") and contain theSameElementsAs Set("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -466,14 +466,14 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -525,14 +525,14 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) and not contain theSameElementsAs (Set("HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) and not contain theSameElementsAs (Set("HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HI")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -584,14 +584,14 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalAndSpec.scala
@@ -94,16 +94,16 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FUM"))) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -135,16 +135,16 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
 
@@ -176,16 +176,16 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
     }
 
@@ -217,16 +217,16 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))) + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
     }
 
@@ -258,16 +258,16 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -299,16 +299,16 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -340,16 +340,16 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -407,14 +407,14 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HO", "HELLO") and contain theSameElementsAs Set("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HO", "HELLO") and contain theSameElementsAs Set("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HO", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -466,14 +466,14 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -525,14 +525,14 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) and not contain theSameElementsAs (Set("HO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) and not contain theSameElementsAs (Set("HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HI")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -584,14 +584,14 @@ class EveryShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalOrSpec.scala
@@ -89,14 +89,14 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -124,14 +124,14 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
 
@@ -159,14 +159,14 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
 
@@ -194,14 +194,14 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
 
@@ -229,14 +229,14 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -264,14 +264,14 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -299,14 +299,14 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -355,12 +355,12 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HO")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("hello", "ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -393,12 +393,12 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -431,12 +431,12 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "ho")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "ho")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("hello", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -469,12 +469,12 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsLogicalOrSpec.scala
@@ -89,14 +89,14 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -124,14 +124,14 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
 
@@ -159,14 +159,14 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
     }
 
@@ -194,14 +194,14 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
     }
 
@@ -229,14 +229,14 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -264,14 +264,14 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -299,14 +299,14 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -355,12 +355,12 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HO")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("hello", "ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -393,12 +393,12 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -431,12 +431,12 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "ho")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "ho")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("hello", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -469,12 +469,12 @@ class EveryShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsSpec.scala
@@ -74,14 +74,14 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList should contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain theSameElementsAs Set("fee", "fie", "foe")) (decided by upperCaseStringEquality)
+          (fumList should contain theSameElementsAs Set("fee", "fie", "foe")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -111,14 +111,14 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("fee", "fie", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("fee", "fie", "foe"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -177,13 +177,13 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (decided by upperCaseStringEquality)
+        (toList should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toList should (not contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList should (not contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -207,13 +207,13 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain theSameElementsAs (Set("happy", "birthday", "to"))) (decided by upperCaseStringEquality)
+        (toList shouldNot contain theSameElementsAs (Set("happy", "birthday", "to"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -237,13 +237,13 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -290,14 +290,14 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain theSameElementsAs Set("HE", "HI")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain theSameElementsAs Set("HE", "HI")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsAs Set("HO", "HI")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain theSameElementsAs Set("HO", "HI")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain theSameElementsAs Set("he", "hi")) (decided by defaultEquality[String])
+        (all (hiLists) should contain theSameElementsAs Set("he", "hi")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsAs Set("ho", "hi")) (decided by defaultEquality[String])
+          (all (hiLists) should contain theSameElementsAs Set("ho", "hi")) (using decided by defaultEquality[String])
         }
       }
     }
@@ -336,14 +336,14 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsAs Set("HE", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HE", "HI"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HO", "HI"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain theSameElementsAs Set("he", "hi"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain theSameElementsAs Set("he", "hi"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("ho", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain theSameElementsAs Set("ho", "hi"))) (using decided by defaultEquality[String])
         }
       }
     }
@@ -370,13 +370,13 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsAs (Set("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain theSameElementsAs (Set("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain theSameElementsAs (Set(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsAs (Set(" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) should not contain theSameElementsAs (Set(" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -403,13 +403,13 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsAs (Set("YOU", "TO")))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain theSameElementsAs (Set("YOU", "TO")))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain theSameElementsAs (Set(" YOU ", " TO ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsAs (Set(" YOU ", " TO ")))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain theSameElementsAs (Set(" YOU ", " TO ")))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -436,13 +436,13 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsAs (Set("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain theSameElementsAs (Set("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain theSameElementsAs (Set(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsAs (Set(" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain theSameElementsAs (Set(" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -469,13 +469,13 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsAs (Set("YOU", "TO")))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain theSameElementsAs (Set("YOU", "TO")))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain theSameElementsAs (Set(" YOU ", " TO ")))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsAs (Set(" YOU ", " TO ")))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain theSameElementsAs (Set(" YOU ", " TO ")))) (using after being lowerCased and trimmed)
         }
       }
     }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsAsSpec.scala
@@ -74,14 +74,14 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList should contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain theSameElementsAs Set("fee", "fie", "foe")) (using decided by upperCaseStringEquality)
+          (fumList should contain theSameElementsAs Set("fee", "fie", "foe")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -111,14 +111,14 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("fee", "fie", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("fee", "fie", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -177,13 +177,13 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
+        (toList should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toList should (not contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList should (not contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -207,13 +207,13 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain theSameElementsAs (Set("happy", "birthday", "to"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain theSameElementsAs (Set("happy", "birthday", "to"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -237,13 +237,13 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -290,14 +290,14 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain theSameElementsAs Set("HE", "HI")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain theSameElementsAs Set("HE", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsAs Set("HO", "HI")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain theSameElementsAs Set("HO", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain theSameElementsAs Set("he", "hi")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain theSameElementsAs Set("he", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsAs Set("ho", "hi")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain theSameElementsAs Set("ho", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
     }
@@ -336,14 +336,14 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsAs Set("HE", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain theSameElementsAs Set("he", "hi"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain theSameElementsAs Set("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("ho", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain theSameElementsAs Set("ho", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
     }
@@ -370,13 +370,13 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsAs (Set("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain theSameElementsAs (Set("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain theSameElementsAs (Set(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsAs (Set(" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain theSameElementsAs (Set(" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -403,13 +403,13 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsAs (Set("YOU", "TO")))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain theSameElementsAs (Set("YOU", "TO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain theSameElementsAs (Set(" YOU ", " TO ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsAs (Set(" YOU ", " TO ")))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain theSameElementsAs (Set(" YOU ", " TO ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -436,13 +436,13 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsAs (Set("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain theSameElementsAs (Set("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain theSameElementsAs (Set(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsAs (Set(" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain theSameElementsAs (Set(" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -469,13 +469,13 @@ class EveryShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsAs (Set("YOU", "TO")))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain theSameElementsAs (Set("YOU", "TO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain theSameElementsAs (Set(" YOU ", " TO ")))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsAs (Set(" YOU ", " TO ")))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain theSameElementsAs (Set(" YOU ", " TO ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
@@ -94,16 +94,16 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))) + ", but " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE ") and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE ") and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -135,16 +135,16 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
 
@@ -176,16 +176,16 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
 
@@ -217,16 +217,16 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))) + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
 
@@ -258,13 +258,13 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))) + ", but " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
@@ -298,13 +298,13 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
@@ -338,16 +338,16 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -405,14 +405,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HO", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HO", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -464,14 +464,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -523,14 +523,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) and not contain theSameElementsInOrderAs (ListBuffer("HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) and not contain theSameElementsInOrderAs (ListBuffer("HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -582,14 +582,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HO", "HELLO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HO", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
@@ -94,16 +94,16 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))) + ", but " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE ") and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE ") and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -135,16 +135,16 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
 
@@ -176,16 +176,16 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
     }
 
@@ -217,16 +217,16 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))) + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
       }
     }
 
@@ -258,13 +258,13 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))) + ", but " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
@@ -298,13 +298,13 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
@@ -338,16 +338,16 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -405,14 +405,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HO", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HO", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -464,14 +464,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("HI", "HELLO")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("HI", "HELLO")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -523,14 +523,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) and not contain theSameElementsInOrderAs (ListBuffer("HO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) and not contain theSameElementsInOrderAs (ListBuffer("HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -582,14 +582,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpe
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (One("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HO", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (One("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HO", "HELLO")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (One("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (One("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, One("ho")) + ", but " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
@@ -90,14 +90,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -125,14 +125,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
 
@@ -160,14 +160,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
 
@@ -195,14 +195,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
 
@@ -230,11 +230,11 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))) + ", and " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
@@ -264,11 +264,11 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
@@ -298,14 +298,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -354,12 +354,12 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HO")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("hello", "ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -392,12 +392,12 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -430,12 +430,12 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -468,12 +468,12 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
@@ -90,14 +90,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -125,14 +125,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
 
@@ -160,14 +160,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
     }
 
@@ -195,14 +195,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
       }
     }
 
@@ -230,11 +230,11 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))) + ", and " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
@@ -264,11 +264,11 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
@@ -298,14 +298,14 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -354,12 +354,12 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HO")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("hello", "ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -392,12 +392,12 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (Many("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (Many("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, Many("ho", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -430,12 +430,12 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -468,12 +468,12 @@ class EveryShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpe
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (Many("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (Many("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, Many("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, Many("hi", "hello")) + ", and " + decorateToStringValue(prettifier, Many("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsSpec.scala
@@ -74,14 +74,14 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
+        (fumList should contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
+          (fumList should contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
+        (fumList should contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -111,14 +111,14 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -147,13 +147,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList should not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -177,13 +177,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (using decided by upperCaseStringEquality)
+        (toList should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toList should (not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList should (not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -207,13 +207,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -237,13 +237,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -290,14 +290,14 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HE")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HO")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "ho")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "ho")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
     }
@@ -336,14 +336,14 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("he", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
     }
@@ -370,13 +370,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -403,13 +403,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -436,13 +436,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -469,13 +469,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/EveryShouldContainTheSameElementsInOrderAsSpec.scala
@@ -74,14 +74,14 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE")) (decided by upperCaseStringEquality)
+        (fumList should contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum")) (decided by upperCaseStringEquality)
+          (fumList should contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ")) (after being lowerCased and trimmed)
+        (fumList should contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -111,14 +111,14 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -147,13 +147,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList should not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList should not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -177,13 +177,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (decided by upperCaseStringEquality)
+        (toList should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toList should (not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList should (not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -207,13 +207,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -237,13 +237,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -290,14 +290,14 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HE")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HO")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HO")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "ho")) (decided by defaultEquality[String])
+          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "ho")) (using decided by defaultEquality[String])
         }
       }
     }
@@ -336,14 +336,14 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HO"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("he", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("he", "hi"))) (using decided by defaultEquality[String])
         }
       }
     }
@@ -370,13 +370,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -403,13 +403,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -436,13 +436,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -469,13 +469,13 @@ class EveryShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
     }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderContainMatcherDeciderSpec.scala
@@ -153,18 +153,18 @@ class InOrderContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
     }
     
     it("should take specified equality when 'should contain' is used") {
-      (List("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (using after being trimmed)
-      (Array("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (using after being trimmed)
+      (List("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Array("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", "2 ", "3") should contain inOrder ("1", "2 ", "3")) (using after being trimmed)
+      (javaList("1", "2 ", "3") should contain inOrder ("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified equality when 'should not contain' is used") {
-      (List("1 ", "2", "3 ") should not contain inOrder ("1", "2 ", "3")) (using after being appended)
-      (Array("1 ", "2", "3 ") should not contain inOrder ("1", "2 ", "3")) (using after being appended)
+      (List("1 ", "2", "3 ") should not contain inOrder ("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being appended)
+      (Array("1 ", "2", "3 ") should not contain inOrder ("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being appended)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should not contain inOrder ("1", "2 ", "3")) (using after being appended)
+      (javaList("1 ", "2", "3 ") should not contain inOrder ("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being appended)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -172,20 +172,20 @@ class InOrderContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("1 ", "2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrder ("1", "2 ", "3")) (using after being appended)
+        (left1 should contain inOrder ("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array("1", "2 ", "3")), thisLineNumber - 2)
         
       val left2 = Array("1 ", "2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrder ("1", "2 ", "3")) (using after being appended)
+        (left2 should contain inOrder ("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
         checkShouldContainStackDepth(e2, left2, deep(Array("1", "2 ", "3")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1 ", "2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrder ("1", "2 ", "3")) (using after being appended)
+        (left3 should contain inOrder ("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array("1", "2 ", "3")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -196,38 +196,38 @@ class InOrderContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("one", "two", "three")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrder ("eno", "two", "three")) (using after being translated)
+        (left1 should not contain inOrder ("eno", "two", "three")) (/* DOTTY-ONLY using */ after being translated)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array("eno", "two", "three")), thisLineNumber - 2)
         
       val left2 = Array("one", "two", "three")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrder ("eno", "two", "three")) (using after being translated)
+        (left2 should not contain inOrder ("eno", "two", "three")) (/* DOTTY-ONLY using */ after being translated)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array("eno", "two", "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("one", "two", "three")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrder ("eno", "two", "three")) (using after being translated)
+        (left3 should not contain inOrder ("eno", "two", "three")) (/* DOTTY-ONLY using */ after being translated)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array("eno", "two", "three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified equality and normalization when 'should contain' is used") {
-      (List("A ", "B", "C ") should contain inOrder ("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Array("A ", "B", "C ") should contain inOrder ("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (List("A ", "B", "C ") should contain inOrder ("a", "b ", "c")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Array("A ", "B", "C ") should contain inOrder ("a", "b ", "c")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("A ", "B", "C ") should contain inOrder ("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (javaList("A ", "B", "C ") should contain inOrder ("a", "b ", "c")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified equality and normalization when 'should not contain' is used") {
-      (List("one ", "two", "three ") should not contain inOrder ("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
-      (Array("one ", "two", "three ") should not contain inOrder ("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
+      (List("one ", "two", "three ") should not contain inOrder ("one", "two ", "three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Array("one ", "two", "three ") should not contain inOrder ("one", "two ", "three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", "two", "three ") should not contain inOrder ("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
+      (javaList("one ", "two", "three ") should not contain inOrder ("one", "two ", "three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -235,20 +235,20 @@ class InOrderContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("one ", "two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrder ("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
+        (left1 should contain inOrder ("one", "two ", "three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array("one", "two ", "three")), thisLineNumber - 2)
         
       val left2 = Array("one ", "two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrder ("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
+        (left2 should contain inOrder ("one", "two ", "three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array("one", "two ", "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("one ", "two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrder ("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
+        (left3 should contain inOrder ("one", "two ", "three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array("one", "two ", "three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -258,20 +258,20 @@ class InOrderContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("one ", "two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrder ("eno ", "owt", "eerht ")) (using decided by reverseEquality afterBeing trimmed)
+        (left1 should not contain inOrder ("eno ", "owt", "eerht ")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array("eno ", "owt", "eerht ")), thisLineNumber - 2)
         
       val left2 = Array("one ", "two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrder ("eno ", "owt", "eerht ")) (using decided by reverseEquality afterBeing trimmed)
+        (left2 should not contain inOrder ("eno ", "owt", "eerht ")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array("eno ", "owt", "eerht ")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("one ", "two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrder ("eno ", "owt", "eerht ")) (using decided by reverseEquality afterBeing trimmed)
+        (left3 should not contain inOrder ("eno ", "owt", "eerht ")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array("eno ", "owt", "eerht ")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderContainMatcherDeciderSpec.scala
@@ -153,18 +153,18 @@ class InOrderContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
     }
     
     it("should take specified equality when 'should contain' is used") {
-      (List("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (after being trimmed)
-      (Array("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (after being trimmed)
+      (List("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (using after being trimmed)
+      (Array("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (using after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", "2 ", "3") should contain inOrder ("1", "2 ", "3")) (after being trimmed)
+      (javaList("1", "2 ", "3") should contain inOrder ("1", "2 ", "3")) (using after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified equality when 'should not contain' is used") {
-      (List("1 ", "2", "3 ") should not contain inOrder ("1", "2 ", "3")) (after being appended)
-      (Array("1 ", "2", "3 ") should not contain inOrder ("1", "2 ", "3")) (after being appended)
+      (List("1 ", "2", "3 ") should not contain inOrder ("1", "2 ", "3")) (using after being appended)
+      (Array("1 ", "2", "3 ") should not contain inOrder ("1", "2 ", "3")) (using after being appended)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should not contain inOrder ("1", "2 ", "3")) (after being appended)
+      (javaList("1 ", "2", "3 ") should not contain inOrder ("1", "2 ", "3")) (using after being appended)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -172,20 +172,20 @@ class InOrderContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("1 ", "2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrder ("1", "2 ", "3")) (after being appended)
+        (left1 should contain inOrder ("1", "2 ", "3")) (using after being appended)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array("1", "2 ", "3")), thisLineNumber - 2)
         
       val left2 = Array("1 ", "2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrder ("1", "2 ", "3")) (after being appended)
+        (left2 should contain inOrder ("1", "2 ", "3")) (using after being appended)
       }
         checkShouldContainStackDepth(e2, left2, deep(Array("1", "2 ", "3")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1 ", "2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrder ("1", "2 ", "3")) (after being appended)
+        (left3 should contain inOrder ("1", "2 ", "3")) (using after being appended)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array("1", "2 ", "3")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -196,38 +196,38 @@ class InOrderContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("one", "two", "three")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrder ("eno", "two", "three")) (after being translated)
+        (left1 should not contain inOrder ("eno", "two", "three")) (using after being translated)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array("eno", "two", "three")), thisLineNumber - 2)
         
       val left2 = Array("one", "two", "three")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrder ("eno", "two", "three")) (after being translated)
+        (left2 should not contain inOrder ("eno", "two", "three")) (using after being translated)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array("eno", "two", "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("one", "two", "three")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrder ("eno", "two", "three")) (after being translated)
+        (left3 should not contain inOrder ("eno", "two", "three")) (using after being translated)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array("eno", "two", "three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified equality and normalization when 'should contain' is used") {
-      (List("A ", "B", "C ") should contain inOrder ("a", "b ", "c")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Array("A ", "B", "C ") should contain inOrder ("a", "b ", "c")) (decided by lowerCaseEquality afterBeing trimmed)
+      (List("A ", "B", "C ") should contain inOrder ("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Array("A ", "B", "C ") should contain inOrder ("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("A ", "B", "C ") should contain inOrder ("a", "b ", "c")) (decided by lowerCaseEquality afterBeing trimmed)
+      (javaList("A ", "B", "C ") should contain inOrder ("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified equality and normalization when 'should not contain' is used") {
-      (List("one ", "two", "three ") should not contain inOrder ("one", "two ", "three")) (decided by reverseEquality afterBeing trimmed)
-      (Array("one ", "two", "three ") should not contain inOrder ("one", "two ", "three")) (decided by reverseEquality afterBeing trimmed)
+      (List("one ", "two", "three ") should not contain inOrder ("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
+      (Array("one ", "two", "three ") should not contain inOrder ("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", "two", "three ") should not contain inOrder ("one", "two ", "three")) (decided by reverseEquality afterBeing trimmed)
+      (javaList("one ", "two", "three ") should not contain inOrder ("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -235,20 +235,20 @@ class InOrderContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("one ", "two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrder ("one", "two ", "three")) (decided by reverseEquality afterBeing trimmed)
+        (left1 should contain inOrder ("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array("one", "two ", "three")), thisLineNumber - 2)
         
       val left2 = Array("one ", "two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrder ("one", "two ", "three")) (decided by reverseEquality afterBeing trimmed)
+        (left2 should contain inOrder ("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array("one", "two ", "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("one ", "two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrder ("one", "two ", "three")) (decided by reverseEquality afterBeing trimmed)
+        (left3 should contain inOrder ("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array("one", "two ", "three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -258,20 +258,20 @@ class InOrderContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("one ", "two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrder ("eno ", "owt", "eerht ")) (decided by reverseEquality afterBeing trimmed)
+        (left1 should not contain inOrder ("eno ", "owt", "eerht ")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array("eno ", "owt", "eerht ")), thisLineNumber - 2)
         
       val left2 = Array("one ", "two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrder ("eno ", "owt", "eerht ")) (decided by reverseEquality afterBeing trimmed)
+        (left2 should not contain inOrder ("eno ", "owt", "eerht ")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array("eno ", "owt", "eerht ")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("one ", "two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrder ("eno ", "owt", "eerht ")) (decided by reverseEquality afterBeing trimmed)
+        (left3 should not contain inOrder ("eno ", "owt", "eerht ")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array("eno ", "owt", "eerht ")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderContainMatcherEqualitySpec.scala
@@ -118,18 +118,18 @@ class InOrderContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
     }
     
     it("should take passed in custom explicit equality when 'should contain' is used") {
-      (List("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (using equality)
-      (Array("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (using equality)
+      (List("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (/* DOTTY-ONLY using */ equality)
+      (Array("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (using equality)
+      (javaList("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take passed in custom explicit equality when 'should not contain' is used") {
-      (List("1 ", "2", "3 ") should not contain inOrder ("3", "2 ", "1")) (using equality)
-      (Array("1 ", "2", "3 ") should not contain inOrder ("3", "2 ", "1")) (using equality)
+      (List("1 ", "2", "3 ") should not contain inOrder ("3", "2 ", "1")) (/* DOTTY-ONLY using */ equality)
+      (Array("1 ", "2", "3 ") should not contain inOrder ("3", "2 ", "1")) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should not contain inOrder ("3", "2 ", "1")) (using equality)
+      (javaList("1 ", "2", "3 ") should not contain inOrder ("3", "2 ", "1")) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -137,20 +137,20 @@ class InOrderContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("1 ", "2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrder ("3", "2 ", "1")) (using equality)
+        (left1 should contain inOrder ("3", "2 ", "1")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array("3", "2 ", "1")), thisLineNumber - 2)
         
       val left2 = Array("1 ", "2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrder ("3", "2 ", "1")) (using equality)
+        (left2 should contain inOrder ("3", "2 ", "1")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array("3", "2 ", "1")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1 ", "2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrder ("3", "2 ", "1")) (using equality)
+        (left3 should contain inOrder ("3", "2 ", "1")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array("3", "2 ", "1")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -160,20 +160,20 @@ class InOrderContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("1 ", "2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrder ("1", "2 ", "3")) (using equality)
+        (left1 should not contain inOrder ("1", "2 ", "3")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array("1", "2 ", "3")), thisLineNumber - 2)
         
       val left2 = Array("1 ", "2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrder ("1", "2 ", "3")) (using equality)
+        (left2 should not contain inOrder ("1", "2 ", "3")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array("1", "2 ", "3")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1 ", "2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrder ("1", "2 ", "3")) (using equality)
+        (left3 should not contain inOrder ("1", "2 ", "3")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array("1", "2 ", "3")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderContainMatcherEqualitySpec.scala
@@ -118,18 +118,18 @@ class InOrderContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
     }
     
     it("should take passed in custom explicit equality when 'should contain' is used") {
-      (List("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (equality)
-      (Array("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (equality)
+      (List("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (using equality)
+      (Array("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (using equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (equality)
+      (javaList("1 ", "2", "3 ") should contain inOrder ("1", "2 ", "3")) (using equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take passed in custom explicit equality when 'should not contain' is used") {
-      (List("1 ", "2", "3 ") should not contain inOrder ("3", "2 ", "1")) (equality)
-      (Array("1 ", "2", "3 ") should not contain inOrder ("3", "2 ", "1")) (equality)
+      (List("1 ", "2", "3 ") should not contain inOrder ("3", "2 ", "1")) (using equality)
+      (Array("1 ", "2", "3 ") should not contain inOrder ("3", "2 ", "1")) (using equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should not contain inOrder ("3", "2 ", "1")) (equality)
+      (javaList("1 ", "2", "3 ") should not contain inOrder ("3", "2 ", "1")) (using equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -137,20 +137,20 @@ class InOrderContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("1 ", "2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrder ("3", "2 ", "1")) (equality)
+        (left1 should contain inOrder ("3", "2 ", "1")) (using equality)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array("3", "2 ", "1")), thisLineNumber - 2)
         
       val left2 = Array("1 ", "2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrder ("3", "2 ", "1")) (equality)
+        (left2 should contain inOrder ("3", "2 ", "1")) (using equality)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array("3", "2 ", "1")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1 ", "2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrder ("3", "2 ", "1")) (equality)
+        (left3 should contain inOrder ("3", "2 ", "1")) (using equality)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array("3", "2 ", "1")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -160,20 +160,20 @@ class InOrderContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("1 ", "2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrder ("1", "2 ", "3")) (equality)
+        (left1 should not contain inOrder ("1", "2 ", "3")) (using equality)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array("1", "2 ", "3")), thisLineNumber - 2)
         
       val left2 = Array("1 ", "2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrder ("1", "2 ", "3")) (equality)
+        (left2 should not contain inOrder ("1", "2 ", "3")) (using equality)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array("1", "2 ", "3")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1 ", "2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrder ("1", "2 ", "3")) (equality)
+        (left3 should not contain inOrder ("1", "2 ", "3")) (using equality)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array("1", "2 ", "3")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderElementsOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderElementsOfContainMatcherDeciderSpec.scala
@@ -153,18 +153,18 @@ class InOrderElementsOfContainMatcherDeciderSpec extends AnyFunSpec with Explici
     }
 
     it("should take specified equality when 'should contain' is used") {
-      (List("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (after being trimmed)
-      (Array("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (after being trimmed)
+      (List("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
+      (Array("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", "2 ", "3") should contain inOrderElementsOf Seq("1", "2 ", "3")) (after being trimmed)
+      (javaList("1", "2 ", "3") should contain inOrderElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take specified equality when 'should not contain' is used") {
-      (List("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (after being appended)
-      (Array("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (after being appended)
+      (List("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (using after being appended)
+      (Array("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (using after being appended)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (after being appended)
+      (javaList("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (using after being appended)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -172,20 +172,20 @@ class InOrderElementsOfContainMatcherDeciderSpec extends AnyFunSpec with Explici
 
       val left1 = List("1 ", "2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrderElementsOf Seq("1", "2 ", "3")) (after being appended)
+        (left1 should contain inOrderElementsOf Seq("1", "2 ", "3")) (using after being appended)
       }
       checkShouldContainStackDepth(e1, left1, Seq("1", "2 ", "3"), thisLineNumber - 2)
 
       val left2 = Array("1 ", "2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrderElementsOf Seq("1", "2 ", "3")) (after being appended)
+        (left2 should contain inOrderElementsOf Seq("1", "2 ", "3")) (using after being appended)
       }
       checkShouldContainStackDepth(e2, left2, Seq("1", "2 ", "3"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1 ", "2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrderElementsOf Seq("1", "2 ", "3")) (after being appended)
+        (left3 should contain inOrderElementsOf Seq("1", "2 ", "3")) (using after being appended)
       }
       checkShouldContainStackDepth(e3, left3, Seq("1", "2 ", "3"), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -196,38 +196,38 @@ class InOrderElementsOfContainMatcherDeciderSpec extends AnyFunSpec with Explici
 
       val left1 = List("one", "two", "three")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrderElementsOf (Seq("eno", "two", "three"))) (after being translated)
+        (left1 should not contain inOrderElementsOf (Seq("eno", "two", "three"))) (using after being translated)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq("eno", "two", "three"), thisLineNumber - 2)
 
       val left2 = Array("one", "two", "three")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrderElementsOf (Seq("eno", "two", "three"))) (after being translated)
+        (left2 should not contain inOrderElementsOf (Seq("eno", "two", "three"))) (using after being translated)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq("eno", "two", "three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("one", "two", "three")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrderElementsOf (Seq("eno", "two", "three"))) (after being translated)
+        (left3 should not contain inOrderElementsOf (Seq("eno", "two", "three"))) (using after being translated)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq("eno", "two", "three"), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take specified equality and normalization when 'should contain' is used") {
-      (List("A ", "B", "C ") should contain inOrderElementsOf Seq("a", "b ", "c")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Array("A ", "B", "C ") should contain inOrderElementsOf Seq("a", "b ", "c")) (decided by lowerCaseEquality afterBeing trimmed)
+      (List("A ", "B", "C ") should contain inOrderElementsOf Seq("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Array("A ", "B", "C ") should contain inOrderElementsOf Seq("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("A ", "B", "C ") should contain inOrderElementsOf Seq("a", "b ", "c")) (decided by lowerCaseEquality afterBeing trimmed)
+      (javaList("A ", "B", "C ") should contain inOrderElementsOf Seq("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take specified equality and normalization when 'should not contain' is used") {
-      (List("one ", "two", "three ") should not contain inOrderElementsOf (Seq("one", "two ", "three"))) (decided by reverseEquality afterBeing trimmed)
-      (Array("one ", "two", "three ") should not contain inOrderElementsOf (Seq("one", "two ", "three"))) (decided by reverseEquality afterBeing trimmed)
+      (List("one ", "two", "three ") should not contain inOrderElementsOf (Seq("one", "two ", "three"))) (using decided by reverseEquality afterBeing trimmed)
+      (Array("one ", "two", "three ") should not contain inOrderElementsOf (Seq("one", "two ", "three"))) (using decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", "two", "three ") should not contain inOrderElementsOf (Seq("one", "two ", "three"))) (decided by reverseEquality afterBeing trimmed)
+      (javaList("one ", "two", "three ") should not contain inOrderElementsOf (Seq("one", "two ", "three"))) (using decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -235,20 +235,20 @@ class InOrderElementsOfContainMatcherDeciderSpec extends AnyFunSpec with Explici
 
       val left1 = List("one ", "two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrderElementsOf Seq("one", "two ", "three")) (decided by reverseEquality afterBeing trimmed)
+        (left1 should contain inOrderElementsOf Seq("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, Seq("one", "two ", "three"), thisLineNumber - 2)
 
       val left2 = Array("one ", "two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrderElementsOf Seq("one", "two ", "three")) (decided by reverseEquality afterBeing trimmed)
+        (left2 should contain inOrderElementsOf Seq("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, Seq("one", "two ", "three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("one ", "two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrderElementsOf Seq("one", "two ", "three")) (decided by reverseEquality afterBeing trimmed)
+        (left3 should contain inOrderElementsOf Seq("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, Seq("one", "two ", "three"), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -258,20 +258,20 @@ class InOrderElementsOfContainMatcherDeciderSpec extends AnyFunSpec with Explici
 
       val left1 = List("one ", "two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrderElementsOf (Seq("eno ", "owt", "eerht "))) (decided by reverseEquality afterBeing trimmed)
+        (left1 should not contain inOrderElementsOf (Seq("eno ", "owt", "eerht "))) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq("eno ", "owt", "eerht "), thisLineNumber - 2)
 
       val left2 = Array("one ", "two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrderElementsOf (Seq("eno ", "owt", "eerht "))) (decided by reverseEquality afterBeing trimmed)
+        (left2 should not contain inOrderElementsOf (Seq("eno ", "owt", "eerht "))) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq("eno ", "owt", "eerht "), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("one ", "two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrderElementsOf (Seq("eno ", "owt", "eerht "))) (decided by reverseEquality afterBeing trimmed)
+        (left3 should not contain inOrderElementsOf (Seq("eno ", "owt", "eerht "))) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq("eno ", "owt", "eerht "), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderElementsOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderElementsOfContainMatcherDeciderSpec.scala
@@ -153,18 +153,18 @@ class InOrderElementsOfContainMatcherDeciderSpec extends AnyFunSpec with Explici
     }
 
     it("should take specified equality when 'should contain' is used") {
-      (List("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
-      (Array("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
+      (List("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Array("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", "2 ", "3") should contain inOrderElementsOf Seq("1", "2 ", "3")) (using after being trimmed)
+      (javaList("1", "2 ", "3") should contain inOrderElementsOf Seq("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take specified equality when 'should not contain' is used") {
-      (List("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (using after being appended)
-      (Array("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (using after being appended)
+      (List("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (/* DOTTY-ONLY using */ after being appended)
+      (Array("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (/* DOTTY-ONLY using */ after being appended)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (using after being appended)
+      (javaList("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (/* DOTTY-ONLY using */ after being appended)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -172,20 +172,20 @@ class InOrderElementsOfContainMatcherDeciderSpec extends AnyFunSpec with Explici
 
       val left1 = List("1 ", "2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrderElementsOf Seq("1", "2 ", "3")) (using after being appended)
+        (left1 should contain inOrderElementsOf Seq("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e1, left1, Seq("1", "2 ", "3"), thisLineNumber - 2)
 
       val left2 = Array("1 ", "2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrderElementsOf Seq("1", "2 ", "3")) (using after being appended)
+        (left2 should contain inOrderElementsOf Seq("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e2, left2, Seq("1", "2 ", "3"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1 ", "2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrderElementsOf Seq("1", "2 ", "3")) (using after being appended)
+        (left3 should contain inOrderElementsOf Seq("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e3, left3, Seq("1", "2 ", "3"), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -196,38 +196,38 @@ class InOrderElementsOfContainMatcherDeciderSpec extends AnyFunSpec with Explici
 
       val left1 = List("one", "two", "three")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrderElementsOf (Seq("eno", "two", "three"))) (using after being translated)
+        (left1 should not contain inOrderElementsOf (Seq("eno", "two", "three"))) (/* DOTTY-ONLY using */ after being translated)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq("eno", "two", "three"), thisLineNumber - 2)
 
       val left2 = Array("one", "two", "three")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrderElementsOf (Seq("eno", "two", "three"))) (using after being translated)
+        (left2 should not contain inOrderElementsOf (Seq("eno", "two", "three"))) (/* DOTTY-ONLY using */ after being translated)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq("eno", "two", "three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("one", "two", "three")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrderElementsOf (Seq("eno", "two", "three"))) (using after being translated)
+        (left3 should not contain inOrderElementsOf (Seq("eno", "two", "three"))) (/* DOTTY-ONLY using */ after being translated)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq("eno", "two", "three"), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take specified equality and normalization when 'should contain' is used") {
-      (List("A ", "B", "C ") should contain inOrderElementsOf Seq("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Array("A ", "B", "C ") should contain inOrderElementsOf Seq("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (List("A ", "B", "C ") should contain inOrderElementsOf Seq("a", "b ", "c")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Array("A ", "B", "C ") should contain inOrderElementsOf Seq("a", "b ", "c")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("A ", "B", "C ") should contain inOrderElementsOf Seq("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (javaList("A ", "B", "C ") should contain inOrderElementsOf Seq("a", "b ", "c")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take specified equality and normalization when 'should not contain' is used") {
-      (List("one ", "two", "three ") should not contain inOrderElementsOf (Seq("one", "two ", "three"))) (using decided by reverseEquality afterBeing trimmed)
-      (Array("one ", "two", "three ") should not contain inOrderElementsOf (Seq("one", "two ", "three"))) (using decided by reverseEquality afterBeing trimmed)
+      (List("one ", "two", "three ") should not contain inOrderElementsOf (Seq("one", "two ", "three"))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Array("one ", "two", "three ") should not contain inOrderElementsOf (Seq("one", "two ", "three"))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", "two", "three ") should not contain inOrderElementsOf (Seq("one", "two ", "three"))) (using decided by reverseEquality afterBeing trimmed)
+      (javaList("one ", "two", "three ") should not contain inOrderElementsOf (Seq("one", "two ", "three"))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -235,20 +235,20 @@ class InOrderElementsOfContainMatcherDeciderSpec extends AnyFunSpec with Explici
 
       val left1 = List("one ", "two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrderElementsOf Seq("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
+        (left1 should contain inOrderElementsOf Seq("one", "two ", "three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, Seq("one", "two ", "three"), thisLineNumber - 2)
 
       val left2 = Array("one ", "two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrderElementsOf Seq("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
+        (left2 should contain inOrderElementsOf Seq("one", "two ", "three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, Seq("one", "two ", "three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("one ", "two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrderElementsOf Seq("one", "two ", "three")) (using decided by reverseEquality afterBeing trimmed)
+        (left3 should contain inOrderElementsOf Seq("one", "two ", "three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, Seq("one", "two ", "three"), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -258,20 +258,20 @@ class InOrderElementsOfContainMatcherDeciderSpec extends AnyFunSpec with Explici
 
       val left1 = List("one ", "two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrderElementsOf (Seq("eno ", "owt", "eerht "))) (using decided by reverseEquality afterBeing trimmed)
+        (left1 should not contain inOrderElementsOf (Seq("eno ", "owt", "eerht "))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq("eno ", "owt", "eerht "), thisLineNumber - 2)
 
       val left2 = Array("one ", "two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrderElementsOf (Seq("eno ", "owt", "eerht "))) (using decided by reverseEquality afterBeing trimmed)
+        (left2 should not contain inOrderElementsOf (Seq("eno ", "owt", "eerht "))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq("eno ", "owt", "eerht "), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("one ", "two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrderElementsOf (Seq("eno ", "owt", "eerht "))) (using decided by reverseEquality afterBeing trimmed)
+        (left3 should not contain inOrderElementsOf (Seq("eno ", "owt", "eerht "))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq("eno ", "owt", "eerht "), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderElementsOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderElementsOfContainMatcherEqualitySpec.scala
@@ -118,18 +118,18 @@ class InOrderElementsOfContainMatcherEqualitySpec extends AnyFunSpec with Explic
     }
 
     it("should take passed in custom explicit equality when 'should contain' is used") {
-      (List("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (equality)
-      (Array("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (equality)
+      (List("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (using equality)
+      (Array("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (using equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (equality)
+      (javaList("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (using equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take passed in custom explicit equality when 'should not contain' is used") {
-      (List("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("3", "2 ", "1"))) (equality)
-      (Array("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("3", "2 ", "1"))) (equality)
+      (List("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("3", "2 ", "1"))) (using equality)
+      (Array("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("3", "2 ", "1"))) (using equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("3", "2 ", "1"))) (equality)
+      (javaList("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("3", "2 ", "1"))) (using equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -137,20 +137,20 @@ class InOrderElementsOfContainMatcherEqualitySpec extends AnyFunSpec with Explic
 
       val left1 = List("1 ", "2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrderElementsOf Seq("3", "2 ", "1")) (equality)
+        (left1 should contain inOrderElementsOf Seq("3", "2 ", "1")) (using equality)
       }
       checkShouldContainStackDepth(e1, left1, Seq("3", "2 ", "1"), thisLineNumber - 2)
 
       val left2 = Array("1 ", "2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrderElementsOf Seq("3", "2 ", "1")) (equality)
+        (left2 should contain inOrderElementsOf Seq("3", "2 ", "1")) (using equality)
       }
       checkShouldContainStackDepth(e2, left2, Seq("3", "2 ", "1"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1 ", "2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrderElementsOf Seq("3", "2 ", "1")) (equality)
+        (left3 should contain inOrderElementsOf Seq("3", "2 ", "1")) (using equality)
       }
       checkShouldContainStackDepth(e3, left3, Seq("3", "2 ", "1"), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -160,20 +160,20 @@ class InOrderElementsOfContainMatcherEqualitySpec extends AnyFunSpec with Explic
 
       val left1 = List("1 ", "2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (equality)
+        (left1 should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (using equality)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq("1", "2 ", "3"), thisLineNumber - 2)
 
       val left2 = Array("1 ", "2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (equality)
+        (left2 should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (using equality)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq("1", "2 ", "3"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1 ", "2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (equality)
+        (left3 should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (using equality)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq("1", "2 ", "3"), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderElementsOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderElementsOfContainMatcherEqualitySpec.scala
@@ -118,18 +118,18 @@ class InOrderElementsOfContainMatcherEqualitySpec extends AnyFunSpec with Explic
     }
 
     it("should take passed in custom explicit equality when 'should contain' is used") {
-      (List("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (using equality)
-      (Array("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (using equality)
+      (List("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (/* DOTTY-ONLY using */ equality)
+      (Array("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (using equality)
+      (javaList("1 ", "2", "3 ") should contain inOrderElementsOf Seq("1", "2 ", "3")) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take passed in custom explicit equality when 'should not contain' is used") {
-      (List("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("3", "2 ", "1"))) (using equality)
-      (Array("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("3", "2 ", "1"))) (using equality)
+      (List("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("3", "2 ", "1"))) (/* DOTTY-ONLY using */ equality)
+      (Array("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("3", "2 ", "1"))) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("3", "2 ", "1"))) (using equality)
+      (javaList("1 ", "2", "3 ") should not contain inOrderElementsOf (Seq("3", "2 ", "1"))) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -137,20 +137,20 @@ class InOrderElementsOfContainMatcherEqualitySpec extends AnyFunSpec with Explic
 
       val left1 = List("1 ", "2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrderElementsOf Seq("3", "2 ", "1")) (using equality)
+        (left1 should contain inOrderElementsOf Seq("3", "2 ", "1")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e1, left1, Seq("3", "2 ", "1"), thisLineNumber - 2)
 
       val left2 = Array("1 ", "2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrderElementsOf Seq("3", "2 ", "1")) (using equality)
+        (left2 should contain inOrderElementsOf Seq("3", "2 ", "1")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e2, left2, Seq("3", "2 ", "1"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1 ", "2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrderElementsOf Seq("3", "2 ", "1")) (using equality)
+        (left3 should contain inOrderElementsOf Seq("3", "2 ", "1")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e3, left3, Seq("3", "2 ", "1"), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -160,20 +160,20 @@ class InOrderElementsOfContainMatcherEqualitySpec extends AnyFunSpec with Explic
 
       val left1 = List("1 ", "2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (using equality)
+        (left1 should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq("1", "2 ", "3"), thisLineNumber - 2)
 
       val left2 = Array("1 ", "2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (using equality)
+        (left2 should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq("1", "2 ", "3"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1 ", "2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (using equality)
+        (left3 should not contain inOrderElementsOf (Seq("1", "2 ", "3"))) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq("1", "2 ", "3"), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderOnlyContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderOnlyContainMatcherDeciderSpec.scala
@@ -97,18 +97,18 @@ class InOrderOnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
     }
     
     it("should take specified normalization when 'should contain' is used") {
-      (List("1", " 2", "3") should contain inOrderOnly (" 1", "2 ", " 3")) (after being trimmed)
-      (Array("1", " 2", "3") should contain inOrderOnly (" 1", "2 ", " 3")) (after being trimmed)
+      (List("1", " 2", "3") should contain inOrderOnly (" 1", "2 ", " 3")) (using after being trimmed)
+      (Array("1", " 2", "3") should contain inOrderOnly (" 1", "2 ", " 3")) (using after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", " 2", "3") should contain inOrderOnly (" 1", "2 ", " 3")) (after being trimmed)
+      (javaList("1", " 2", "3") should contain inOrderOnly (" 1", "2 ", " 3")) (using after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified normalization when 'should not contain' is used") {
-      (List("1", "2", "3") should not contain inOrderOnly ("1", "2", "3")) (after being appended)
-      (Array("1", "2", "3") should not contain inOrderOnly ("1", "2", "3")) (after being appended)
+      (List("1", "2", "3") should not contain inOrderOnly ("1", "2", "3")) (using after being appended)
+      (Array("1", "2", "3") should not contain inOrderOnly ("1", "2", "3")) (using after being appended)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", "2", "3") should not contain inOrderOnly ("1", "2", "3")) (after being appended)
+      (javaList("1", "2", "3") should not contain inOrderOnly ("1", "2", "3")) (using after being appended)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -116,20 +116,20 @@ class InOrderOnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("1", "2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrderOnly ("1", "2", "3")) (after being appended)
+        (left1 should contain inOrderOnly ("1", "2", "3")) (using after being appended)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array("1", "2", "3")), thisLineNumber - 2)
         
       val left2 = Array("1", "2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrderOnly ("1", "2", "3")) (after being appended)
+        (left2 should contain inOrderOnly ("1", "2", "3")) (using after being appended)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array("1", "2", "3")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1", "2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrderOnly ("1", "2", "3")) (after being appended)
+        (left3 should contain inOrderOnly ("1", "2", "3")) (using after being appended)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array("1", "2", "3")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -139,38 +139,38 @@ class InOrderOnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
         
       val left1 = List("1", " 2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrderOnly (" 1", "2 ", " 3")) (after being trimmed)
+        (left1 should not contain inOrderOnly (" 1", "2 ", " 3")) (using after being trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
         
       val left2 = Array("1", " 2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrderOnly (" 1", "2 ", " 3")) (after being trimmed)
+        (left2 should not contain inOrderOnly (" 1", "2 ", " 3")) (using after being trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1", " 2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrderOnly (" 1", "2 ", " 3")) (after being trimmed)
+        (left3 should not contain inOrderOnly (" 1", "2 ", " 3")) (using after being trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified equality and normalization when 'should contain' is used") {
-      (List("ONE ", " TWO", "THREE ") should contain inOrderOnly (" one", "two ", " three")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Array("ONE ", " TWO", "THREE ") should contain inOrderOnly (" one", "two ", " three")) (decided by lowerCaseEquality afterBeing trimmed)
+      (List("ONE ", " TWO", "THREE ") should contain inOrderOnly (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Array("ONE ", " TWO", "THREE ") should contain inOrderOnly (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("ONE ", " TWO", "THREE ") should contain inOrderOnly (" one", "two ", " three")) (decided by lowerCaseEquality afterBeing trimmed)
+      (javaList("ONE ", " TWO", "THREE ") should contain inOrderOnly (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified equality and normalization when 'should not contain' is used") {
-      (List("one ", " two", "three ") should not contain inOrderOnly (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
-      (Array("one ", " two", "three ") should not contain inOrderOnly (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+      (List("one ", " two", "three ") should not contain inOrderOnly (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (Array("one ", " two", "three ") should not contain inOrderOnly (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", " two", "three ") should not contain inOrderOnly (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+      (javaList("one ", " two", "three ") should not contain inOrderOnly (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -178,20 +178,20 @@ class InOrderOnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrderOnly (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left1 should contain inOrderOnly (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left2 = Array("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrderOnly (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left2 should contain inOrderOnly (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrderOnly (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left3 should contain inOrderOnly (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -201,20 +201,20 @@ class InOrderOnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("ONE ", " TWO", "THREE ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrderOnly (" one", "two ", " three")) (decided by lowerCaseEquality afterBeing trimmed)
+        (left1 should not contain inOrderOnly (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left2 = Array("ONE ", " TWO", "THREE ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrderOnly (" one", "two ", " three")) (decided by lowerCaseEquality afterBeing trimmed)
+        (left2 should not contain inOrderOnly (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("ONE ", " TWO", "THREE ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrderOnly (" one", "two ", " three")) (decided by lowerCaseEquality afterBeing trimmed)
+        (left3 should not contain inOrderOnly (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderOnlyContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderOnlyContainMatcherDeciderSpec.scala
@@ -97,18 +97,18 @@ class InOrderOnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
     }
     
     it("should take specified normalization when 'should contain' is used") {
-      (List("1", " 2", "3") should contain inOrderOnly (" 1", "2 ", " 3")) (using after being trimmed)
-      (Array("1", " 2", "3") should contain inOrderOnly (" 1", "2 ", " 3")) (using after being trimmed)
+      (List("1", " 2", "3") should contain inOrderOnly (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Array("1", " 2", "3") should contain inOrderOnly (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", " 2", "3") should contain inOrderOnly (" 1", "2 ", " 3")) (using after being trimmed)
+      (javaList("1", " 2", "3") should contain inOrderOnly (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified normalization when 'should not contain' is used") {
-      (List("1", "2", "3") should not contain inOrderOnly ("1", "2", "3")) (using after being appended)
-      (Array("1", "2", "3") should not contain inOrderOnly ("1", "2", "3")) (using after being appended)
+      (List("1", "2", "3") should not contain inOrderOnly ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
+      (Array("1", "2", "3") should not contain inOrderOnly ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", "2", "3") should not contain inOrderOnly ("1", "2", "3")) (using after being appended)
+      (javaList("1", "2", "3") should not contain inOrderOnly ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -116,20 +116,20 @@ class InOrderOnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("1", "2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrderOnly ("1", "2", "3")) (using after being appended)
+        (left1 should contain inOrderOnly ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array("1", "2", "3")), thisLineNumber - 2)
         
       val left2 = Array("1", "2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrderOnly ("1", "2", "3")) (using after being appended)
+        (left2 should contain inOrderOnly ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array("1", "2", "3")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1", "2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrderOnly ("1", "2", "3")) (using after being appended)
+        (left3 should contain inOrderOnly ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array("1", "2", "3")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -139,38 +139,38 @@ class InOrderOnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
         
       val left1 = List("1", " 2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrderOnly (" 1", "2 ", " 3")) (using after being trimmed)
+        (left1 should not contain inOrderOnly (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
         
       val left2 = Array("1", " 2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrderOnly (" 1", "2 ", " 3")) (using after being trimmed)
+        (left2 should not contain inOrderOnly (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1", " 2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrderOnly (" 1", "2 ", " 3")) (using after being trimmed)
+        (left3 should not contain inOrderOnly (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified equality and normalization when 'should contain' is used") {
-      (List("ONE ", " TWO", "THREE ") should contain inOrderOnly (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Array("ONE ", " TWO", "THREE ") should contain inOrderOnly (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (List("ONE ", " TWO", "THREE ") should contain inOrderOnly (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Array("ONE ", " TWO", "THREE ") should contain inOrderOnly (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("ONE ", " TWO", "THREE ") should contain inOrderOnly (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (javaList("ONE ", " TWO", "THREE ") should contain inOrderOnly (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified equality and normalization when 'should not contain' is used") {
-      (List("one ", " two", "three ") should not contain inOrderOnly (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
-      (Array("one ", " two", "three ") should not contain inOrderOnly (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (List("one ", " two", "three ") should not contain inOrderOnly (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Array("one ", " two", "three ") should not contain inOrderOnly (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", " two", "three ") should not contain inOrderOnly (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (javaList("one ", " two", "three ") should not contain inOrderOnly (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -178,20 +178,20 @@ class InOrderOnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrderOnly (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left1 should contain inOrderOnly (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left2 = Array("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrderOnly (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left2 should contain inOrderOnly (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrderOnly (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left3 should contain inOrderOnly (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -201,20 +201,20 @@ class InOrderOnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("ONE ", " TWO", "THREE ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrderOnly (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left1 should not contain inOrderOnly (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left2 = Array("ONE ", " TWO", "THREE ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrderOnly (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left2 should not contain inOrderOnly (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("ONE ", " TWO", "THREE ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrderOnly (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left3 should not contain inOrderOnly (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderOnlyContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderOnlyContainMatcherEqualitySpec.scala
@@ -142,19 +142,19 @@ class InOrderOnlyContainMatcherEqualitySpec extends AnyFunSpec with Matchers wit
     
     it("should take passed in custom explicit equality when 'should contain' is used") {
       implicit val equality = new TrimEquality
-      (List("1 ", " 2", "3 ") should contain inOrderOnly (" 1", "2 ", " 3")) (using equality)
-      (Array("1 ", " 2", "3 ") should contain inOrderOnly (" 1", "2 ", " 3")) (using equality)
+      (List("1 ", " 2", "3 ") should contain inOrderOnly (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ equality)
+      (Array("1 ", " 2", "3 ") should contain inOrderOnly (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", " 2", "3 ") should contain inOrderOnly (" 1", "2 ", " 3")) (using equality)
+      (javaList("1 ", " 2", "3 ") should contain inOrderOnly (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take passed in custom explicit equality when 'should not contain' is used") {
       implicit val equality = new FalseEquality
-      (List(1, 2, 3) should not contain inOrderOnly (1, 2, 3)) (using equality)
-      (Array(1, 2, 3) should not contain inOrderOnly (1, 2, 3)) (using equality)
+      (List(1, 2, 3) should not contain inOrderOnly (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
+      (Array(1, 2, 3) should not contain inOrderOnly (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should not contain inOrderOnly (1, 2, 3)) (using equality)
+      (javaList(1, 2, 3) should not contain inOrderOnly (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -163,20 +163,20 @@ class InOrderOnlyContainMatcherEqualitySpec extends AnyFunSpec with Matchers wit
         
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrderOnly (1, 2, 3)) (using equality)
+        (left1 should contain inOrderOnly (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left2 = Array(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrderOnly (1, 2, 3)) (using equality)
+        (left2 should contain inOrderOnly (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(1, 2, 3)), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrderOnly (1, 2, 3)) (using equality)
+        (left3 should contain inOrderOnly (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(1, 2, 3)), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -187,20 +187,20 @@ class InOrderOnlyContainMatcherEqualitySpec extends AnyFunSpec with Matchers wit
         
       val left1 = List("1", " 2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrderOnly (" 1", "2 ", " 3")) (using equality)
+        (left1 should not contain inOrderOnly (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
         
       val left2 = Array("1", " 2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrderOnly (" 1", "2 ", " 3")) (using equality)
+        (left2 should not contain inOrderOnly (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1", " 2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrderOnly (" 1", "2 ", " 3")) (using equality)
+        (left3 should not contain inOrderOnly (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderOnlyContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/InOrderOnlyContainMatcherEqualitySpec.scala
@@ -142,19 +142,19 @@ class InOrderOnlyContainMatcherEqualitySpec extends AnyFunSpec with Matchers wit
     
     it("should take passed in custom explicit equality when 'should contain' is used") {
       implicit val equality = new TrimEquality
-      (List("1 ", " 2", "3 ") should contain inOrderOnly (" 1", "2 ", " 3")) (equality)
-      (Array("1 ", " 2", "3 ") should contain inOrderOnly (" 1", "2 ", " 3")) (equality)
+      (List("1 ", " 2", "3 ") should contain inOrderOnly (" 1", "2 ", " 3")) (using equality)
+      (Array("1 ", " 2", "3 ") should contain inOrderOnly (" 1", "2 ", " 3")) (using equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", " 2", "3 ") should contain inOrderOnly (" 1", "2 ", " 3")) (equality)
+      (javaList("1 ", " 2", "3 ") should contain inOrderOnly (" 1", "2 ", " 3")) (using equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take passed in custom explicit equality when 'should not contain' is used") {
       implicit val equality = new FalseEquality
-      (List(1, 2, 3) should not contain inOrderOnly (1, 2, 3)) (equality)
-      (Array(1, 2, 3) should not contain inOrderOnly (1, 2, 3)) (equality)
+      (List(1, 2, 3) should not contain inOrderOnly (1, 2, 3)) (using equality)
+      (Array(1, 2, 3) should not contain inOrderOnly (1, 2, 3)) (using equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should not contain inOrderOnly (1, 2, 3)) (equality)
+      (javaList(1, 2, 3) should not contain inOrderOnly (1, 2, 3)) (using equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -163,20 +163,20 @@ class InOrderOnlyContainMatcherEqualitySpec extends AnyFunSpec with Matchers wit
         
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain inOrderOnly (1, 2, 3)) (equality)
+        (left1 should contain inOrderOnly (1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left2 = Array(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain inOrderOnly (1, 2, 3)) (equality)
+        (left2 should contain inOrderOnly (1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(1, 2, 3)), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain inOrderOnly (1, 2, 3)) (equality)
+        (left3 should contain inOrderOnly (1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(1, 2, 3)), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -187,20 +187,20 @@ class InOrderOnlyContainMatcherEqualitySpec extends AnyFunSpec with Matchers wit
         
       val left1 = List("1", " 2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain inOrderOnly (" 1", "2 ", " 3")) (equality)
+        (left1 should not contain inOrderOnly (" 1", "2 ", " 3")) (using equality)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
         
       val left2 = Array("1", " 2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain inOrderOnly (" 1", "2 ", " 3")) (equality)
+        (left2 should not contain inOrderOnly (" 1", "2 ", " 3")) (using equality)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left3 = javaList("1", " 2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain inOrderOnly (" 1", "2 ", " 3")) (equality)
+        (left3 should not contain inOrderOnly (" 1", "2 ", " 3")) (using equality)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfLogicalAndSpec.scala
@@ -95,16 +95,16 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -141,16 +141,16 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -186,16 +186,16 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain allElementsOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain allElementsOf Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("happy", "birthday", "to", "you")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -231,16 +231,16 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -276,16 +276,16 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")) + ", but " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -322,16 +322,16 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -367,16 +367,16 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -440,14 +440,14 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HO", "HELLO") and contain allElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HO", "HELLO") and contain allElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -516,14 +516,14 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain allElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allElementsOf Seq("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allElementsOf Seq("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -579,14 +579,14 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allElementsOf (Seq("TO", "YOU")) and not contain allElementsOf (Seq("HO", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("TO", "YOU")) and not contain allElementsOf (Seq("HO", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) and not contain allElementsOf (Seq("HO", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) and not contain allElementsOf (Seq("HO", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allElementsOf (Seq("HO", "HE")) and not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allElementsOf (Seq("HO", "HE")) and not contain allElementsOf (Seq("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HO", "HE")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -643,14 +643,14 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain allElementsOf (Seq("HO", "HELLO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain allElementsOf (Seq("HO", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("howdy", "hi", "hello")) and not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("howdy", "hi", "hello")) and not contain allElementsOf (Seq("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain allElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain allElementsOf (Seq("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfLogicalAndSpec.scala
@@ -95,16 +95,16 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") and contain allElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain allElementsOf Seq("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -141,16 +141,16 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -186,16 +186,16 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain allElementsOf Seq("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain allElementsOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("happy", "birthday", "to", "you")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -231,16 +231,16 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -276,16 +276,16 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")) + ", but " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")) and not contain allElementsOf (Seq("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -322,16 +322,16 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -367,16 +367,16 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain allElementsOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -440,14 +440,14 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HO", "HELLO") and contain allElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HO", "HELLO") and contain allElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HO", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") and contain allElementsOf Seq("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -516,14 +516,14 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain allElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allElementsOf Seq("HO", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allElementsOf Seq("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -579,14 +579,14 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allElementsOf (Seq("TO", "YOU")) and not contain allElementsOf (Seq("HO", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("TO", "YOU")) and not contain allElementsOf (Seq("HO", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) and not contain allElementsOf (Seq("HO", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) and not contain allElementsOf (Seq("HO", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allElementsOf (Seq("HO", "HE")) and not contain allElementsOf (Seq("HELLO", "HI")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allElementsOf (Seq("HO", "HE")) and not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HO", "HE")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -643,14 +643,14 @@ class ListShouldContainAllElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain allElementsOf (Seq("HO", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain allElementsOf (Seq("HO", "HELLO")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("howdy", "hi", "hello")) and not contain allElementsOf (Seq("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("howdy", "hi", "hello")) and not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain allElementsOf (Seq("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain allElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfLogicalOrSpec.scala
@@ -91,14 +91,14 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", and " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -131,14 +131,14 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -170,14 +170,14 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -209,14 +209,14 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -248,14 +248,14 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -288,14 +288,14 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -327,14 +327,14 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -389,12 +389,12 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HO")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("hello", "ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -432,12 +432,12 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -474,12 +474,12 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "ho")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "ho")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("hello", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -517,12 +517,12 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("howdy", "hello", "hi")) or not contain allElementsOf (Seq("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HI")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("howdy", "hello", "hi")) or not contain allElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("howdy", "hi", "hello")) or not contain allElementsOf (Seq("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("howdy", "hi", "hello")) or not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfLogicalOrSpec.scala
@@ -91,14 +91,14 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", and " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -131,14 +131,14 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -170,14 +170,14 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -209,14 +209,14 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FAM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -248,14 +248,14 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -288,14 +288,14 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -327,14 +327,14 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain allElementsOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain allElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAllElementsOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain allElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -389,12 +389,12 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HELLO", "HI") or contain allElementsOf Seq("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HELLO", "HO") or contain allElementsOf Seq("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HO")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("hello", "ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -432,12 +432,12 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain allElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain allElementsOf Seq("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -474,12 +474,12 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "ho")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "ho")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HO")) or not contain allElementsOf (Seq("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allElementsOf (Seq("HELLO", "HI")) or not contain allElementsOf (Seq("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("hello", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -517,12 +517,12 @@ class ListShouldContainAllElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("howdy", "hello", "hi")) or not contain allElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("howdy", "hello", "hi")) or not contain allElementsOf (Seq("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain allElementsOf (Seq("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("howdy", "hi", "hello")) or not contain allElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("howdy", "hi", "hello")) or not contain allElementsOf (Seq("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfSpec.scala
@@ -75,14 +75,14 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList should contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain allElementsOf Seq("fee", "fie", "foe", "fam")) (decided by upperCaseStringEquality)
+          (fumList should contain allElementsOf Seq("fee", "fie", "foe", "fam")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain allElementsOf Seq("fee", "fie", "foe", "fie", "fum")
@@ -115,14 +115,14 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("fee", "fie", "foe", "fam"))) (decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("fee", "fie", "foe", "fam"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should (contain allElementsOf Seq("fee", "fie", "foe", "fie", "fum"))
@@ -187,13 +187,13 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain allElementsOf (Seq("NICE", "TO", "MEET", "YOU", "TOO")))) (decided by upperCaseStringEquality)
+        (toList should (not contain allElementsOf (Seq("NICE", "TO", "MEET", "YOU", "TOO")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain allElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toList should (not contain allElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain allElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain allElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList should (not contain allElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -220,13 +220,13 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain allElementsOf Seq("happy", "birthday", "to", "you", "dear")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain allElementsOf Seq("happy", "birthday", "to", "you", "dear")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -253,13 +253,13 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain allElementsOf Seq("NICE", "TO", "MEET", "YOU", "TOO"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain allElementsOf Seq("NICE", "TO", "MEET", "YOU", "TOO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -309,14 +309,14 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain allElementsOf Seq("HE", "HI")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain allElementsOf Seq("HE", "HI")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain allElementsOf Seq("HO", "HI")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain allElementsOf Seq("HO", "HI")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain allElementsOf Seq("he", "hi")) (decided by defaultEquality[String])
+        (all (hiLists) should contain allElementsOf Seq("he", "hi")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain allElementsOf Seq("ho", "hi")) (decided by defaultEquality[String])
+          (all (hiLists) should contain allElementsOf Seq("ho", "hi")) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -357,14 +357,14 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allElementsOf Seq("HE", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HE", "HI"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain allElementsOf Seq("he", "hi"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain allElementsOf Seq("he", "hi"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("ho", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain allElementsOf Seq("ho", "hi"))) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -393,13 +393,13 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain allElementsOf (Seq("NICE", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain allElementsOf (Seq("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain allElementsOf (Seq("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain allElementsOf (Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain allElementsOf (Seq(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain allElementsOf (Seq(" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) should not contain allElementsOf (Seq(" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -428,13 +428,13 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain allElementsOf (Seq("NICE", "MEET", "YOU")))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain allElementsOf (Seq("NICE", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allElementsOf (Seq("YOU", "TO")))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain allElementsOf (Seq("YOU", "TO")))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain allElementsOf (Seq(" YOU ", " TO ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allElementsOf (Seq(" YOU ", " TO ")))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain allElementsOf (Seq(" YOU ", " TO ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -463,13 +463,13 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain allElementsOf Seq("NICE", "MEET", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain allElementsOf Seq("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allElementsOf Seq("YOU", "TO")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain allElementsOf Seq("YOU", "TO")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain allElementsOf Seq(" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allElementsOf Seq(" YOU ", " TO ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain allElementsOf Seq(" YOU ", " TO ")) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -498,13 +498,13 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain allElementsOf Seq("NICE", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain allElementsOf Seq("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allElementsOf Seq("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain allElementsOf Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain allElementsOf Seq(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allElementsOf Seq(" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain allElementsOf Seq(" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllElementsOfSpec.scala
@@ -75,14 +75,14 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList should contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain allElementsOf Seq("fee", "fie", "foe", "fam")) (using decided by upperCaseStringEquality)
+          (fumList should contain allElementsOf Seq("fee", "fie", "foe", "fam")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain allElementsOf Seq("fee", "fie", "foe", "fie", "fum")
@@ -115,14 +115,14 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain allElementsOf Seq("fee", "fie", "foe", "fam"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allElementsOf Seq("fee", "fie", "foe", "fam"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain allElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should (contain allElementsOf Seq("fee", "fie", "foe", "fie", "fum"))
@@ -187,13 +187,13 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain allElementsOf (Seq("NICE", "TO", "MEET", "YOU", "TOO")))) (using decided by upperCaseStringEquality)
+        (toList should (not contain allElementsOf (Seq("NICE", "TO", "MEET", "YOU", "TOO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain allElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toList should (not contain allElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain allElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain allElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList should (not contain allElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -220,13 +220,13 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain allElementsOf Seq("happy", "birthday", "to", "you", "dear")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain allElementsOf Seq("happy", "birthday", "to", "you", "dear")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -253,13 +253,13 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain allElementsOf Seq("NICE", "TO", "MEET", "YOU", "TOO"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain allElementsOf Seq("NICE", "TO", "MEET", "YOU", "TOO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain allElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain allElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -309,14 +309,14 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain allElementsOf Seq("HE", "HI")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain allElementsOf Seq("HE", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain allElementsOf Seq("HO", "HI")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain allElementsOf Seq("HO", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain allElementsOf Seq("he", "hi")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain allElementsOf Seq("he", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain allElementsOf Seq("ho", "hi")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain allElementsOf Seq("ho", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -357,14 +357,14 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allElementsOf Seq("HE", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allElementsOf Seq("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allElementsOf Seq("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain allElementsOf Seq("he", "hi"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain allElementsOf Seq("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allElementsOf Seq("ho", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain allElementsOf Seq("ho", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -393,13 +393,13 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain allElementsOf (Seq("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain allElementsOf (Seq("NICE", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain allElementsOf (Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain allElementsOf (Seq("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain allElementsOf (Seq(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain allElementsOf (Seq(" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain allElementsOf (Seq(" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -428,13 +428,13 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain allElementsOf (Seq("NICE", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain allElementsOf (Seq("NICE", "MEET", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allElementsOf (Seq("YOU", "TO")))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain allElementsOf (Seq("YOU", "TO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain allElementsOf (Seq(" YOU ", " TO ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allElementsOf (Seq(" YOU ", " TO ")))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain allElementsOf (Seq(" YOU ", " TO ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -463,13 +463,13 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain allElementsOf Seq("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain allElementsOf Seq("NICE", "MEET", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allElementsOf Seq("YOU", "TO")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain allElementsOf Seq("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain allElementsOf Seq(" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allElementsOf Seq(" YOU ", " TO ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain allElementsOf Seq(" YOU ", " TO ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -498,13 +498,13 @@ class ListShouldContainAllElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain allElementsOf Seq("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain allElementsOf Seq("NICE", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allElementsOf Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain allElementsOf Seq("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain allElementsOf Seq(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allElementsOf Seq(" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain allElementsOf Seq(" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalAndSpec.scala
@@ -95,16 +95,16 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -152,16 +152,16 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FAM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -202,16 +202,16 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain allOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain allOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -252,16 +252,16 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -302,16 +302,16 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\"") + ", but " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain allOf ("FIE", "FEE", "FUM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allOf ("FIE", "FEE", "FUM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -359,16 +359,16 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -409,16 +409,16 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -487,14 +487,14 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HO", "HELLO") and contain allOf ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HO", "HELLO") and contain allOf ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HO", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")" + ", but " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -574,14 +574,14 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -642,14 +642,14 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allOf ("TO", "YOU") and not contain allOf ("HO", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("TO", "YOU") and not contain allOf ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allOf ("HELLO", "HI") and not contain allOf ("HO", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allOf ("HELLO", "HI") and not contain allOf ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allOf ("HO", "HE") and not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allOf ("HO", "HE") and not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HE\")" + ", but " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -717,14 +717,14 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain allOf ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain allOf ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain allOf ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain allOf ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " contained all of " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalAndSpec.scala
@@ -95,16 +95,16 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") and contain allOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") and contain allOf ("FEE", "FIE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -152,16 +152,16 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain allOf ("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -202,16 +202,16 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain allOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain allOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain allOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -252,16 +252,16 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -302,16 +302,16 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allOf ("FIE", "FEE", "FAM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\"") + ", but " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain allOf ("FIE", "FEE", "FUM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allOf ("FIE", "FEE", "FUM", "FOE") and not contain allOf ("FIE", "FEE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -359,16 +359,16 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -409,16 +409,16 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -487,14 +487,14 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HO", "HELLO") and contain allOf ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HO", "HELLO") and contain allOf ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HELLO", "HI") and contain allOf ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")" + ", but " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -574,14 +574,14 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("howdy", "hi", "hello")) and contain allOf ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -642,14 +642,14 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allOf ("TO", "YOU") and not contain allOf ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("TO", "YOU") and not contain allOf ("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allOf ("HELLO", "HI") and not contain allOf ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allOf ("HELLO", "HI") and not contain allOf ("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allOf ("HO", "HE") and not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allOf ("HO", "HE") and not contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HO\", \"HE\")" + ", but " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -717,14 +717,14 @@ class ListShouldContainAllOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain allOf ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain allOf ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("howdy", "hi", "hello")) and not contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain allOf ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain allOf ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " contained all of " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalOrSpec.scala
@@ -91,14 +91,14 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -142,14 +142,14 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -186,14 +186,14 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -230,14 +230,14 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -274,14 +274,14 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -325,14 +325,14 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -369,14 +369,14 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -436,12 +436,12 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HELLO\", \"HO\")" + ", and " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " did not contain all of " + "(\"hello\", \"ho\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -490,12 +490,12 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain allOf ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -537,12 +537,12 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")" + ", and " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " contained all of " + "(\"hello\", \"hi\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -591,12 +591,12 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain allOf ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfLogicalOrSpec.scala
@@ -91,14 +91,14 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -142,14 +142,14 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -186,14 +186,14 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain allOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -230,14 +230,14 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -274,14 +274,14 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUU") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain allOf ("FEE", "FIE", "FOE", "FUM") or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -325,14 +325,14 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain allOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -369,14 +369,14 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain allOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAllOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain allOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain allOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -436,12 +436,12 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HELLO", "HI") or contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HELLO", "HO") or contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HELLO\", \"HO\")" + ", and " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " did not contain all of " + "(\"hello\", \"ho\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -490,12 +490,12 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("howdy", "hi", "hello")) or contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " did not contain all of " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -537,12 +537,12 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain allOf ("HELLO", "HO") or not contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain allOf ("HELLO", "HI") or not contain allOf ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")" + ", and " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " contained all of " + "(\"hello\", \"hi\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -591,12 +591,12 @@ class ListShouldContainAllOfLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("howdy", "hello", "hi")) or not contain allOf ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("howdy", "hi", "hello")) or not contain allOf ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, List("howdy", "hi", "hello")) + " contained all of " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfSpec.scala
@@ -75,14 +75,14 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain allOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList should contain allOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain allOf ("fee", "fie", "foe", "fam")) (decided by upperCaseStringEquality)
+          (fumList should contain allOf ("fee", "fie", "foe", "fam")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain allOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain allOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain allOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -120,14 +120,14 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain allOf ("fee", "fie", "foe", "fam"))) (decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("fee", "fie", "foe", "fam"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -208,13 +208,13 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (decided by upperCaseStringEquality)
+        (toList should (not contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList should (not contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should (not contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -246,13 +246,13 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain allOf ("happy", "birthday", "to", "you", "dear")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain allOf ("happy", "birthday", "to", "you", "dear")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -284,13 +284,13 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -345,14 +345,14 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain allOf ("HE", "HI")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain allOf ("HE", "HI")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain allOf ("HO", "HI")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain allOf ("HO", "HI")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain allOf ("he", "hi")) (decided by defaultEquality[String])
+        (all (hiLists) should contain allOf ("he", "hi")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain allOf ("ho", "hi")) (decided by defaultEquality[String])
+          (all (hiLists) should contain allOf ("ho", "hi")) (using decided by defaultEquality[String])
         }
       }
     }
@@ -390,14 +390,14 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allOf ("HE", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HE", "HI"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HO", "HI"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain allOf ("he", "hi"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain allOf ("he", "hi"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("ho", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain allOf ("ho", "hi"))) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -431,13 +431,13 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain allOf ("NICE", "MEET", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain allOf ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain allOf ("YOU", "TO")) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain allOf ("YOU", "TO")) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain allOf (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain allOf (" YOU ", " TO ")) (after being lowerCased and trimmed)
+          (all (toLists) should not contain allOf (" YOU ", " TO ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -471,13 +471,13 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain allOf ("NICE", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain allOf ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allOf ("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain allOf ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain allOf (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allOf (" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain allOf (" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -511,13 +511,13 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain allOf ("NICE", "MEET", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain allOf ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allOf ("YOU", "TO")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain allOf ("YOU", "TO")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain allOf (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allOf (" YOU ", " TO ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain allOf (" YOU ", " TO ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -551,13 +551,13 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain allOf ("NICE", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain allOf ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allOf ("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain allOf ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain allOf (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allOf (" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain allOf (" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAllOfSpec.scala
@@ -75,14 +75,14 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain allOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList should contain allOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain allOf ("fee", "fie", "foe", "fam")) (using decided by upperCaseStringEquality)
+          (fumList should contain allOf ("fee", "fie", "foe", "fam")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain allOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain allOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain allOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -120,14 +120,14 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain allOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain allOf ("fee", "fie", "foe", "fam"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain allOf ("fee", "fie", "foe", "fam"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain allOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -208,13 +208,13 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (using decided by upperCaseStringEquality)
+        (toList should (not contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList should (not contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should (not contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -246,13 +246,13 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain allOf ("happy", "birthday", "to", "you", "dear")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain allOf ("happy", "birthday", "to", "you", "dear")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -284,13 +284,13 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain allOf ("NICE", "TO", "MEET", "YOU", "TOO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain allOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain allOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -345,14 +345,14 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain allOf ("HE", "HI")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain allOf ("HE", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain allOf ("HO", "HI")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain allOf ("HO", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain allOf ("he", "hi")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain allOf ("he", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain allOf ("ho", "hi")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain allOf ("ho", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
     }
@@ -390,14 +390,14 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain allOf ("HE", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain allOf ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("HO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain allOf ("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain allOf ("he", "hi"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain allOf ("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain allOf ("ho", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain allOf ("ho", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -431,13 +431,13 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain allOf ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain allOf ("NICE", "MEET", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain allOf ("YOU", "TO")) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain allOf ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain allOf (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain allOf (" YOU ", " TO ")) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain allOf (" YOU ", " TO ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -471,13 +471,13 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain allOf ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain allOf ("NICE", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allOf ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain allOf ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain allOf (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain allOf (" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain allOf (" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -511,13 +511,13 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain allOf ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain allOf ("NICE", "MEET", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allOf ("YOU", "TO")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain allOf ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain allOf (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain allOf (" YOU ", " TO ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain allOf (" YOU ", " TO ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -551,13 +551,13 @@ class ListShouldContainAllOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain allOf ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain allOf ("NICE", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allOf ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain allOf ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain allOf (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain allOf (" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain allOf (" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfLogicalAndSpec.scala
@@ -85,16 +85,16 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -131,16 +131,16 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by defaultEquality[List[String]], after being lowerCased and trimmed)
+        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality[List[String]], after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -176,16 +176,16 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -221,16 +221,16 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -266,16 +266,16 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -312,16 +312,16 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -357,16 +357,16 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -448,14 +448,14 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") and contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -524,14 +524,14 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) and contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi")) and contain atLeastOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi")) and contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -587,14 +587,14 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -651,14 +651,14 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfLogicalAndSpec.scala
@@ -85,16 +85,16 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -131,16 +131,16 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality[List[String]], after being lowerCased and trimmed)
+        (fumList should (equal (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -176,16 +176,16 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -221,16 +221,16 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -266,16 +266,16 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -312,16 +312,16 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -357,16 +357,16 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -448,14 +448,14 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") and contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") and contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -524,14 +524,14 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) and contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi")) and contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi")) and contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -587,14 +587,14 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -651,14 +651,14 @@ class ListShouldContainAtLeastOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) and not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain atLeastOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfLogicalOrSpec.scala
@@ -81,14 +81,14 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("fie", "fee", "fum", "foe") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("fie", "fee", "fum", "foe") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fie", "fee", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -121,14 +121,14 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (equal (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by defaultEquality[List[String]], after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality[List[String]], after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -160,14 +160,14 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -199,14 +199,14 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -238,14 +238,14 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -278,14 +278,14 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -317,14 +317,14 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -379,12 +379,12 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -422,12 +422,12 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (List("hi")) or contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho")) or contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi")) or contain atLeastOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho")) or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) or contain atLeastOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -464,12 +464,12 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", and " + decorateToStringValue(prettifier, List("hi")) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -507,12 +507,12 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfLogicalOrSpec.scala
@@ -81,14 +81,14 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("fie", "fee", "fum", "foe") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("fie", "fee", "fum", "foe") or contain atLeastOneElementOf Seq("FIE", "FEE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or contain atLeastOneElementOf Seq("fie", "fee", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fie", "fee", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -121,14 +121,14 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (equal (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality[List[String]], after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -160,14 +160,14 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -199,14 +199,14 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fum", "foe")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -238,14 +238,14 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneElementOf (Seq("fum", "foe")) or not contain atLeastOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -278,14 +278,14 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by defaultEquality[List[String]], decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -317,14 +317,14 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atLeastOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain atLeastOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should allow RHS to contain duplicated value" in {
@@ -379,12 +379,12 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE") or contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he") or contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -422,12 +422,12 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (List("hi")) or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho")) or contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi")) or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho")) or contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) or contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) or contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at least one element of " + decorateToStringValue(prettifier, Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -464,12 +464,12 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneElementOf (Seq("hi", "he")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneElementOf (Seq("HI", "HE")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", and " + decorateToStringValue(prettifier, List("hi")) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -507,12 +507,12 @@ class ListShouldContainAtLeastOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi")) or not contain atLeastOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) or not contain atLeastOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at least one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfSpec.scala
@@ -61,14 +61,14 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList should contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atLeastOneElementOf Seq("fum", "foe")) (using decided by upperCaseStringEquality)
+          (fumList should contain atLeastOneElementOf Seq("fum", "foe")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain atLeastOneElementOf Seq("fee", "fie", "foe", "fie", "fum")
@@ -101,14 +101,14 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should (contain atLeastOneElementOf Seq("fee", "fie", "foe", "fie", "fum"))
@@ -190,13 +190,13 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain atLeastOneElementOf (Seq("to", "you")))) (using decided by upperCaseStringEquality)
+        (toList should (not contain atLeastOneElementOf (Seq("to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toList should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
 
@@ -224,13 +224,13 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain atLeastOneElementOf Seq("to", "you")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain atLeastOneElementOf Seq("to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -257,13 +257,13 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
 
@@ -335,14 +335,14 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -403,14 +403,14 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -454,13 +454,13 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atLeastOneElementOf (Seq("to", "you"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain atLeastOneElementOf (Seq("to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneElementOf (Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain atLeastOneElementOf (Seq("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain atLeastOneElementOf (Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneElementOf (Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain atLeastOneElementOf (Seq(" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -506,13 +506,13 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atLeastOneElementOf (Seq("to", "you")))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atLeastOneElementOf (Seq("to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -541,13 +541,13 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atLeastOneElementOf Seq("to", "you")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atLeastOneElementOf Seq("to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -576,13 +576,13 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneElementOfSpec.scala
@@ -61,14 +61,14 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList should contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atLeastOneElementOf Seq("fum", "foe")) (decided by upperCaseStringEquality)
+          (fumList should contain atLeastOneElementOf Seq("fum", "foe")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain atLeastOneElementOf Seq("fee", "fie", "foe", "fie", "fum")
@@ -101,14 +101,14 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atLeastOneElementOf Seq("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneElementOf Seq("fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should (contain atLeastOneElementOf Seq("fee", "fie", "foe", "fie", "fum"))
@@ -190,13 +190,13 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain atLeastOneElementOf (Seq("to", "you")))) (decided by upperCaseStringEquality)
+        (toList should (not contain atLeastOneElementOf (Seq("to", "you")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toList should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
 
@@ -224,13 +224,13 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain atLeastOneElementOf Seq("to", "you")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain atLeastOneElementOf Seq("to", "you")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -257,13 +257,13 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
 
@@ -335,14 +335,14 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain atLeastOneElementOf Seq("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (decided by defaultEquality[String])
+          (all (hiLists) should contain atLeastOneElementOf Seq("HI", "HE")) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -403,14 +403,14 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain atLeastOneElementOf Seq("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain atLeastOneElementOf Seq("HI", "HE"))) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -454,13 +454,13 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atLeastOneElementOf (Seq("to", "you"))) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain atLeastOneElementOf (Seq("to", "you"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneElementOf (Seq("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain atLeastOneElementOf (Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain atLeastOneElementOf (Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneElementOf (Seq(" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should not contain atLeastOneElementOf (Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -506,13 +506,13 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atLeastOneElementOf (Seq("to", "you")))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atLeastOneElementOf (Seq("to", "you")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atLeastOneElementOf (Seq("TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain atLeastOneElementOf (Seq(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -541,13 +541,13 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atLeastOneElementOf Seq("to", "you")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atLeastOneElementOf Seq("to", "you")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atLeastOneElementOf Seq("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain atLeastOneElementOf Seq(" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -576,13 +576,13 @@ class ListShouldContainAtLeastOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atLeastOneElementOf Seq("to", "you"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atLeastOneElementOf Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain atLeastOneElementOf Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalAndSpec.scala
@@ -85,16 +85,16 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -142,16 +142,16 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atLeastOneOf ("fum", "foe"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by defaultEquality, after being lowerCased and trimmed)
+        (fumList should (equal (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -192,16 +192,16 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -242,16 +242,16 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -292,16 +292,16 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\"") + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -349,16 +349,16 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (toList) and not contain atLeastOneOf ("fum", "foe"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atLeastOneOf ("fum", "foe"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -399,16 +399,16 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -495,14 +495,14 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("hi", "he") and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("hi", "he") and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " contained at least one of (\"HI\", \"HE\"), but " + decorateToStringValue(prettifier, List("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -582,14 +582,14 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi")) and contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi")) and contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + decorateToStringValue(prettifier, List("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -650,14 +650,14 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " did not contain at least one of (\"hi\", \"he\"), but " + decorateToStringValue(prettifier, List("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -725,14 +725,14 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) and not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalAndSpec.scala
@@ -85,16 +85,16 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -142,16 +142,16 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality, after being lowerCased and trimmed)
+        (fumList should (equal (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by defaultEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -192,16 +192,16 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -242,16 +242,16 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -292,16 +292,16 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneOf ("fum", "foe") and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\"") + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -349,16 +349,16 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (toList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) and not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -399,16 +399,16 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -495,14 +495,14 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("hi", "he") and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("hi", "he") and contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("HI", "HE") and contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " contained at least one of (\"HI\", \"HE\"), but " + decorateToStringValue(prettifier, List("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -582,14 +582,14 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) and contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi")) and contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi")) and contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + decorateToStringValue(prettifier, List("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -650,14 +650,14 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") and not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneOf ("hi", "he") and not contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " did not contain at least one of (\"hi\", \"he\"), but " + decorateToStringValue(prettifier, List("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -725,14 +725,14 @@ class ListShouldContainAtLeastOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) and not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) and not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalOrSpec.scala
@@ -81,14 +81,14 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("fie", "fee", "fum", "foe") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("fie", "fee", "fum", "foe") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\"") + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -132,14 +132,14 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (fumList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) or contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) or contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by defaultEquality, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -176,14 +176,14 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -220,14 +220,14 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("fum", "foe") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -264,14 +264,14 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -315,14 +315,14 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (toList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -359,14 +359,14 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -426,12 +426,12 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " did not contain at least one of (\"hi\", \"he\"), and " + decorateToStringValue(prettifier, List("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -480,12 +480,12 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (List("hi")) or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho")) or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi")) or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho")) or contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) or contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + decorateToStringValue(prettifier, List("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -527,12 +527,12 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " contained at least one of (\"HI\", \"HE\"), and " + decorateToStringValue(prettifier, List("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -581,12 +581,12 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi")) or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi")) or not contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) or not contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + decorateToStringValue(prettifier, List("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfLogicalOrSpec.scala
@@ -81,14 +81,14 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("fie", "fee", "fum", "foe") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("fie", "fee", "fum", "foe") or contain atLeastOneOf ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") or contain atLeastOneOf ("fie", "fee", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\"") + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -132,14 +132,14 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (fumList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atLeastOneOf ("fum", "foe"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) or contain atLeastOneOf ("fum", "foe"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) or contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by defaultEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by defaultEquality, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -176,14 +176,14 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -220,14 +220,14 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("fum", "foe") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fum\", \"foe\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -264,14 +264,14 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE") or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atLeastOneOf ("fum", "foe") or not contain atLeastOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atLeastOneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -315,14 +315,14 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (toList) or not contain atLeastOneOf ("fum", "foe"))) (decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atLeastOneOf ("fum", "foe"))) (decided by defaultEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by defaultEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by defaultEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -359,14 +359,14 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -426,12 +426,12 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE") or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("hi", "he") or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " did not contain at least one of (\"hi\", \"he\"), and " + decorateToStringValue(prettifier, List("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -480,12 +480,12 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (List("hi")) or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho")) or contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi")) or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho")) or contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) or contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) or contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + decorateToStringValue(prettifier, List("hi")) + " did not contain at least one of (\"hi\", \"he\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -527,12 +527,12 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atLeastOneOf ("hi", "he") or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atLeastOneOf ("HI", "HE") or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " contained at least one of (\"HI\", \"HE\"), and " + decorateToStringValue(prettifier, List("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -581,12 +581,12 @@ class ListShouldContainAtLeastOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi")) or not contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi")) or not contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) or not contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) or not contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + decorateToStringValue(prettifier, List("hi")) + " contained at least one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfSpec.scala
@@ -61,14 +61,14 @@ class ListShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList should contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atLeastOneOf ("fum", "foe")) (decided by upperCaseStringEquality)
+          (fumList should contain atLeastOneOf ("fum", "foe")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -106,14 +106,14 @@ class ListShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -159,19 +159,19 @@ class ListShouldContainAtLeastOneOfSpec extends AnyFunSpec {
       }
       it("should use an explicitly provided Equality") {
         // SKIP-DOTTY-START
-        (toList should not contain atLeastOneOf ("to", "you")) (decided by upperCaseStringEquality)
+        (toList should not contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
         // SKIP-DOTTY-END
         //DOTTY-ONLY (toList should not contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
           // SKIP-DOTTY-START
-          (toList should not contain atLeastOneOf ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList should not contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
           // SKIP-DOTTY-END
           //DOTTY-ONLY (toList should not contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList should not contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
           // SKIP-DOTTY-START
-          (toList should not contain atLeastOneOf (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList should not contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
           // SKIP-DOTTY-END
           //DOTTY-ONLY (toList should not contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
@@ -214,13 +214,13 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain atLeastOneOf ("to", "you"))) (decided by upperCaseStringEquality)
+        (toList should (not contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneOf ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList should (not contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneOf (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should (not contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       
@@ -253,13 +253,13 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain atLeastOneOf ("to", "you")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneOf ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneOf (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -291,13 +291,13 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain atLeastOneOf ("to", "you"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneOf ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       
@@ -374,14 +374,14 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneOf ("hi", "he")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain atLeastOneOf ("hi", "he")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atLeastOneOf ("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain atLeastOneOf ("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (decided by defaultEquality[String])
+          (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -447,14 +447,14 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -503,13 +503,13 @@ scala> all (list1s) should (contain (atLeastOneOf (1, 3, 4)))
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atLeastOneOf ("to", "you")) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneOf ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneOf (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) should not contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -560,13 +560,13 @@ The top two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atLeastOneOf ("to", "you"))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneOf ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneOf (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -600,13 +600,13 @@ The top two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atLeastOneOf ("to", "you")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneOf ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneOf (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -640,13 +640,13 @@ The top two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atLeastOneOf ("to", "you"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneOf ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtLeastOneOfSpec.scala
@@ -61,14 +61,14 @@ class ListShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList should contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atLeastOneOf ("fum", "foe")) (using decided by upperCaseStringEquality)
+          (fumList should contain atLeastOneOf ("fum", "foe")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -106,14 +106,14 @@ class ListShouldContainAtLeastOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atLeastOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atLeastOneOf ("fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atLeastOneOf ("fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain atLeastOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -159,19 +159,19 @@ class ListShouldContainAtLeastOneOfSpec extends AnyFunSpec {
       }
       it("should use an explicitly provided Equality") {
         // SKIP-DOTTY-START
-        (toList should not contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
+        (toList should not contain atLeastOneOf ("to", "you")) (decided by upperCaseStringEquality)
         // SKIP-DOTTY-END
         //DOTTY-ONLY (toList should not contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
           // SKIP-DOTTY-START
-          (toList should not contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList should not contain atLeastOneOf ("TO", "YOU")) (decided by upperCaseStringEquality)
           // SKIP-DOTTY-END
           //DOTTY-ONLY (toList should not contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList should not contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
           // SKIP-DOTTY-START
-          (toList should not contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList should not contain atLeastOneOf (" TO ", " YOU ")) (after being lowerCased and trimmed)
           // SKIP-DOTTY-END
           //DOTTY-ONLY (toList should not contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
@@ -214,13 +214,13 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
+        (toList should (not contain atLeastOneOf ("to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList should (not contain atLeastOneOf ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should (not contain atLeastOneOf (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       
@@ -253,13 +253,13 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain atLeastOneOf ("to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain atLeastOneOf ("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain atLeastOneOf (" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -291,13 +291,13 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain atLeastOneOf ("to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain atLeastOneOf ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       
@@ -374,14 +374,14 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneOf ("hi", "he")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain atLeastOneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atLeastOneOf ("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain atLeastOneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain atLeastOneOf ("HI", "HE")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -447,14 +447,14 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain atLeastOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain atLeastOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -503,13 +503,13 @@ scala> all (list1s) should (contain (atLeastOneOf (1, 3, 4)))
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain atLeastOneOf ("to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain atLeastOneOf ("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain atLeastOneOf (" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -560,13 +560,13 @@ The top two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atLeastOneOf ("to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atLeastOneOf ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain atLeastOneOf (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -600,13 +600,13 @@ The top two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atLeastOneOf ("to", "you")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atLeastOneOf ("to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneOf ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atLeastOneOf ("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain atLeastOneOf (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atLeastOneOf (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain atLeastOneOf (" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -640,13 +640,13 @@ The top two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atLeastOneOf ("to", "you"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atLeastOneOf ("to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneOf ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atLeastOneOf ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain atLeastOneOf (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain atLeastOneOf (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfLogicalAndSpec.scala
@@ -90,16 +90,16 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", but " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -136,16 +136,16 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -181,16 +181,16 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -226,16 +226,16 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -271,16 +271,16 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -317,16 +317,16 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -362,16 +362,16 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -441,14 +441,14 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HE", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") and contain atMostOneElementOf Seq("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") and contain atMostOneElementOf Seq("HE", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -505,14 +505,14 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "he")) and contain atMostOneElementOf Seq("HO", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "he")) and contain atMostOneElementOf Seq("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain atMostOneElementOf Seq("HO", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain atMostOneElementOf Seq("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "he")) and contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi", "he")) and contain atMostOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("hi", "he")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -568,14 +568,14 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HO")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HO")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -632,14 +632,14 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("HI", "HO")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("HI", "HO")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "he")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "he")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "ho")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "ho")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("hi", "ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfLogicalAndSpec.scala
@@ -90,16 +90,16 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", but " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -136,16 +136,16 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -181,16 +181,16 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -226,16 +226,16 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -271,16 +271,16 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FAM")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -317,16 +317,16 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -362,16 +362,16 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -441,14 +441,14 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HE", "HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") and contain atMostOneElementOf Seq("HE", "HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") and contain atMostOneElementOf Seq("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") and contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -505,14 +505,14 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "he")) and contain atMostOneElementOf Seq("HO", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "he")) and contain atMostOneElementOf Seq("HO", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain atMostOneElementOf Seq("HO", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain atMostOneElementOf Seq("HO", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "he")) and contain atMostOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi", "he")) and contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("hi", "he")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -568,14 +568,14 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HO")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HO")) and not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -632,14 +632,14 @@ class ListShouldContainAtMostOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("HI", "HO")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("HI", "HO")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "he")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "he")) and not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "ho")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "ho")) and not contain atMostOneElementOf (Seq("HI", "HO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("hi", "ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfLogicalOrSpec.scala
@@ -86,14 +86,14 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -126,14 +126,14 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -165,14 +165,14 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -204,14 +204,14 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -243,14 +243,14 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")) + ", and " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -283,14 +283,14 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -322,14 +322,14 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -384,12 +384,12 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HE", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -427,12 +427,12 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneElementOf Seq("HI", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("HO")) or contain atMostOneElementOf Seq("HI", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneElementOf Seq("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("HO")) or contain atMostOneElementOf Seq("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HO")) or contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HO")) or contain atMostOneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("HO")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -469,12 +469,12 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")) or not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")) or not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HE", "HEY", "HOWDY")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HE", "HEY", "HOWDY")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -512,12 +512,12 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (List("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneElementOf (Seq("HI", "HO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneElementOf (Seq("HI", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("hi", "he")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfLogicalOrSpec.scala
@@ -86,14 +86,14 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -126,14 +126,14 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -165,14 +165,14 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FIE", "FEE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -204,14 +204,14 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FIE", "FEE", "FAM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -243,14 +243,14 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")) + ", and " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -283,14 +283,14 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -322,14 +322,14 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneElementOf (Seq("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUU")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtMostOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUU")), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       "should do nothing when RHS contain duplicated value" in {
@@ -384,12 +384,12 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HO") or contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HE", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("HI", "HE") or contain atMostOneElementOf Seq("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HE", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -427,12 +427,12 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneElementOf Seq("HI", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("HO")) or contain atMostOneElementOf Seq("HI", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneElementOf Seq("HI", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("HO")) or contain atMostOneElementOf Seq("HI", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HO")) or contain atMostOneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HO")) or contain atMostOneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("HO")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -469,12 +469,12 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneElementOf (Seq("HI", "HE")) or not contain atMostOneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")) or not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")) or not contain atMostOneElementOf (Seq("HE", "HEY", "HOWDY")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HE", "HEY", "HOWDY")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HE", "HEY", "HOWDY")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -512,12 +512,12 @@ class ListShouldContainAtMostOneElementOfLogicalOrSpec extends AnyFreeSpec {
       }
 
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (List("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneElementOf (Seq("HE", "HI")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atMostOneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneElementOf (Seq("HI", "HO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneElementOf (Seq("HI", "HO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("hi", "he")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one element of " + decorateToStringValue(prettifier, Seq("HI", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfSpec.scala
@@ -76,12 +76,12 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (decided by upperCaseStringEquality)
+        (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+          (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+          (fumList should contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
 
         }
         fumList should contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
@@ -117,12 +117,12 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+          (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         }
         fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
       }
@@ -189,11 +189,11 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")))) (decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")))) (using decided by upperCaseStringEquality)
         }
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))
         }
@@ -222,11 +222,11 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (decided by upperCaseStringEquality)
+          (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
         }
-        (fumList shouldNot contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList shouldNot contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -255,11 +255,11 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+          (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         }
-        (fumList shouldNot (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList shouldNot (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -313,14 +313,14 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atMostOneElementOf Seq("hi", "ho")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain atMostOneElementOf Seq("hi", "ho")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atMostOneElementOf Seq("hi", "HE")) (decided by defaultEquality[String])
+        (all (hiLists) should contain atMostOneElementOf Seq("hi", "HE")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (decided by defaultEquality[String])
+          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (using decided by defaultEquality[String])
         }
       }
 
@@ -363,14 +363,14 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "ho"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "ho"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "HE"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "HE"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (using decided by defaultEquality[String])
         }
       }
 
@@ -401,11 +401,11 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) should not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) should not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -437,11 +437,11 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) should (not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+        (all (toLists) should (not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         }
@@ -473,11 +473,11 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -509,11 +509,11 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot (contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot (contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneElementOfSpec.scala
@@ -76,12 +76,12 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
+        (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+          (fumList should contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+          (fumList should contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
 
         }
         fumList should contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
@@ -117,12 +117,12 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+          (fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
         fumList should (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
       }
@@ -189,11 +189,11 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FAM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should (not contain atMostOneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))
         }
@@ -222,11 +222,11 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
+          (fumList shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (fumList shouldNot contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList shouldNot contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -255,11 +255,11 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+          (fumList shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (fumList shouldNot (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList shouldNot (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot (contain atMostOneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -313,14 +313,14 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atMostOneElementOf Seq("hi", "ho")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain atMostOneElementOf Seq("hi", "ho")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atMostOneElementOf Seq("hi", "HE")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain atMostOneElementOf Seq("hi", "HE")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain atMostOneElementOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
 
@@ -363,14 +363,14 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "ho"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "HE"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain atMostOneElementOf Seq("hi", "HE"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain atMostOneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
 
@@ -401,11 +401,11 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) should not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) should not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -437,11 +437,11 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atMostOneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atMostOneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) should (not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+        (all (toLists) should (not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain atMostOneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         }
@@ -473,11 +473,11 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -509,11 +509,11 @@ class ListShouldContainAtMostOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atMostOneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atMostOneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot (contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot (contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain atMostOneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalAndSpec.scala
@@ -90,16 +90,16 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -147,16 +147,16 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -197,16 +197,16 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -247,16 +247,16 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -297,16 +297,16 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -354,16 +354,16 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -404,16 +404,16 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -488,14 +488,14 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HE", "HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("HI", "HE") and contain atMostOneOf ("HE", "HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("HI", "HE") and contain atMostOneOf ("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\"), but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -563,14 +563,14 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "he")) and contain atMostOneOf ("HO", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "he")) and contain atMostOneOf ("HO", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain atMostOneOf ("HO", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain atMostOneOf ("HO", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "he")) and contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi", "he")) and contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("hi", "he")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -631,14 +631,14 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneOf ("HI", "HO") and not contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneOf ("HI", "HO") and not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\"), but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -706,14 +706,14 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "he")) and not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "he")) and not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("hi", "ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalAndSpec.scala
@@ -90,16 +90,16 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -147,16 +147,16 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -197,16 +197,16 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -247,16 +247,16 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -297,16 +297,16 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -354,16 +354,16 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -404,16 +404,16 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -488,14 +488,14 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HE", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("HI", "HE") and contain atMostOneOf ("HE", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("HI", "HE") and contain atMostOneOf ("HE", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("HI", "HO") and contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\"), but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -563,14 +563,14 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "he")) and contain atMostOneOf ("HO", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "he")) and contain atMostOneOf ("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain atMostOneOf ("HO", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain atMostOneOf ("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "he")) and contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi", "he")) and contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("hi", "he")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -631,14 +631,14 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneOf ("HI", "HO") and not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneOf ("HI", "HO") and not contain atMostOneOf ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneOf ("HI", "HE") and not contain atMostOneOf ("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\"), but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -706,14 +706,14 @@ class ListShouldContainAtMostOneOfLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("HI", "HO")) and not contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "he")) and not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "he")) and not contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "ho")) and not contain atMostOneOf ("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("hi", "ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalOrSpec.scala
@@ -86,14 +86,14 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -137,14 +137,14 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -181,14 +181,14 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -225,14 +225,14 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -269,14 +269,14 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\"") + ", and " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -320,14 +320,14 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -364,14 +364,14 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -431,12 +431,12 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\"), and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HE\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -485,12 +485,12 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("HO")) or contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("HO")) or contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HO")) or contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HO")) or contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("HO")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -532,12 +532,12 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneOf ("hi", "he") or not contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("hi", "he") or not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneOf ("HE", "HEY", "HOWDY") or not contain atMostOneOf ("HE", "HEY", "HOWDY"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneOf ("HE", "HEY", "HOWDY") or not contain atMostOneOf ("HE", "HEY", "HOWDY"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HE\", \"HEY\", \"HOWDY\"), and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HE\", \"HEY\", \"HOWDY\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -586,12 +586,12 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (List("ho")) or not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneOf ("HE", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain atMostOneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneOf ("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("hi", "he")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfLogicalOrSpec.scala
@@ -86,14 +86,14 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -137,14 +137,14 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -181,14 +181,14 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -225,14 +225,14 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FIE", "FEE", "FAM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FaM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -269,14 +269,14 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM") or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU") or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\"") + ", and " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
-        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -320,14 +320,14 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -364,14 +364,14 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain atMostOneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain atMostOneOf ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain atMostOneOf ("FEE", "FIE", "FOE", "FUU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtMostOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUU\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       "should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value" in {
@@ -431,12 +431,12 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("HI", "HO") or contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("HI", "HE") or contain atMostOneOf ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\"), and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HE\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -485,12 +485,12 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("HO")) or contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneOf ("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("HO")) or contain atMostOneOf ("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "he")) or contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HO")) or contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HO")) or contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("HO")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain at most one of (\"HI\", \"HE\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -532,12 +532,12 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneOf ("hi", "he") or not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("hi", "he") or not contain atMostOneOf ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain atMostOneOf ("HI", "HE") or not contain atMostOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain atMostOneOf ("HE", "HEY", "HOWDY") or not contain atMostOneOf ("HE", "HEY", "HOWDY"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain atMostOneOf ("HE", "HEY", "HOWDY") or not contain atMostOneOf ("HE", "HEY", "HOWDY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HE\", \"HEY\", \"HOWDY\"), and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HE\", \"HEY\", \"HOWDY\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -586,12 +586,12 @@ class ListShouldContainAtMostOneOfLogicalOrSpec extends AnyFreeSpec {
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (List("ho")) or not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneOf ("HE", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain atMostOneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneOf ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain atMostOneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneOf ("HI", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "he")) or not contain atMostOneOf ("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("hi", "he")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained at most one of (\"HI\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfSpec.scala
@@ -75,12 +75,12 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
+        (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+          (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+          (fumList should contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
           
         }
         fumList should contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")
@@ -121,12 +121,12 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+          (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
         fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
       }
@@ -203,11 +203,11 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -241,11 +241,11 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
+          (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (fumList shouldNot contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList shouldNot contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -279,11 +279,11 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
+          (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (fumList shouldNot (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList shouldNot (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -342,14 +342,14 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atMostOneOf ("hi", "ho")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain atMostOneOf ("hi", "ho")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneOf ("hi", "he")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain atMostOneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atMostOneOf ("hi", "HE")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain atMostOneOf ("hi", "HE")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneOf ("hi", "he")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain atMostOneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
 
@@ -397,14 +397,14 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneOf ("hi", "ho"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("hi", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atMostOneOf ("hi", "HE"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain atMostOneOf ("hi", "HE"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       
@@ -440,11 +440,11 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) should not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+        (all (toLists) should not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -481,11 +481,11 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) should (not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) should (not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -522,11 +522,11 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -563,11 +563,11 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot (contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot (contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainAtMostOneOfSpec.scala
@@ -75,12 +75,12 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (decided by upperCaseStringEquality)
+        (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+          (fumList should contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+          (fumList should contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
           
         }
         fumList should contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")
@@ -121,12 +121,12 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
-          (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+          (fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         }
         fumList should (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
       }
@@ -203,11 +203,11 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+          (fumList should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         }
-        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should (not contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -241,11 +241,11 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (decided by upperCaseStringEquality)
+          (fumList shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FAM")) (using decided by upperCaseStringEquality)
         }
-        (fumList shouldNot contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList shouldNot contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -279,11 +279,11 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (decided by upperCaseStringEquality)
+          (fumList shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FAM"))) (using decided by upperCaseStringEquality)
         }
-        (fumList shouldNot (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList shouldNot (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot (contain atMostOneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -342,14 +342,14 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain atMostOneOf ("hi", "ho")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain atMostOneOf ("hi", "ho")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneOf ("hi", "he")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain atMostOneOf ("hi", "he")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain atMostOneOf ("hi", "HE")) (decided by defaultEquality[String])
+        (all (hiLists) should contain atMostOneOf ("hi", "HE")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain atMostOneOf ("hi", "he")) (decided by defaultEquality[String])
+          (all (hiLists) should contain atMostOneOf ("hi", "he")) (using decided by defaultEquality[String])
         }
       }
 
@@ -397,14 +397,14 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain atMostOneOf ("hi", "ho"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain atMostOneOf ("hi", "ho"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain atMostOneOf ("hi", "HE"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain atMostOneOf ("hi", "HE"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain atMostOneOf ("hi", "he"))) (using decided by defaultEquality[String])
         }
       }
       
@@ -440,11 +440,11 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) should not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+        (all (toLists) should not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -481,11 +481,11 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) should (not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) should (not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -522,11 +522,11 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain atMostOneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -563,11 +563,11 @@ class ListShouldContainAtMostOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain atMostOneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain atMostOneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
-        (all (toLists) shouldNot (contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot (contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain atMostOneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfLogicalAndSpec.scala
@@ -95,16 +95,16 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")) + ", but " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -141,16 +141,16 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -186,16 +186,16 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -231,16 +231,16 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -276,13 +276,13 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
       }
@@ -321,13 +321,13 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
       }
@@ -365,16 +365,16 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -444,14 +444,14 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HO", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HO", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HO", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -520,14 +520,14 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrderElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("he", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -583,14 +583,14 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) and not contain inOrderElementsOf (Seq("HO", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) and not contain inOrderElementsOf (Seq("HO", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -647,14 +647,14 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain inOrderElementsOf (Seq("HO", "HELLO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain inOrderElementsOf (Seq("HO", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("he", "hi", "hello")) and not contain inOrderElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("he", "hi", "hello")) and not contain inOrderElementsOf (Seq("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("he", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfLogicalAndSpec.scala
@@ -95,16 +95,16 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")) + ", but " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -141,16 +141,16 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -186,16 +186,16 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -231,16 +231,16 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -276,13 +276,13 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
       }
@@ -321,13 +321,13 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
       }
@@ -365,16 +365,16 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -444,14 +444,14 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HO", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HO", "HELLO") and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HO", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") and contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -520,14 +520,14 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrderElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("he", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -583,14 +583,14 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HELLO", "HO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) and not contain inOrderElementsOf (Seq("HO", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) and not contain inOrderElementsOf (Seq("HO", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -647,14 +647,14 @@ class ListShouldContainInOrderElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain inOrderElementsOf (Seq("HO", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain inOrderElementsOf (Seq("HO", "HELLO")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("he", "hi", "hello")) and not contain inOrderElementsOf (Seq("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("he", "hi", "hello")) and not contain inOrderElementsOf (Seq("HELLO", "HI")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("he", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfLogicalOrSpec.scala
@@ -91,14 +91,14 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -131,14 +131,14 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain inOrderElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain inOrderElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -170,14 +170,14 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -209,14 +209,14 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -248,11 +248,11 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")) + ", and " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
       }
@@ -287,11 +287,11 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
       }
@@ -325,14 +325,14 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -386,12 +386,12 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HO")) + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("hello", "ho")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -429,12 +429,12 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -471,12 +471,12 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("hi", "hello")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -514,12 +514,12 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("he", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfLogicalOrSpec.scala
@@ -91,14 +91,14 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain inOrderElementsOf Seq("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FIE", "FEE", "FAM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -131,14 +131,14 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain inOrderElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain inOrderElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -170,14 +170,14 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -209,14 +209,14 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAllElementsOfInOrder(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -248,11 +248,11 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")) + ", and " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
       }
@@ -287,11 +287,11 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
       }
@@ -325,14 +325,14 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain inOrderElementsOf (Seq("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAllElementsOfInOrder(prettifier, fumList, Seq("FUM", "FOE", "FIE", "FEE")), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain inOrderElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should do nothing when RHS contain duplicated value") {
@@ -386,12 +386,12 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HELLO") or contain inOrderElementsOf Seq("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HELLO", "HO") or contain inOrderElementsOf Seq("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HO")) + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("hello", "ho")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -429,12 +429,12 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain inOrderElementsOf Seq("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain inOrderElementsOf Seq("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all elements of " + decorateToStringValue(prettifier, Seq("HELLO", "HI")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -471,12 +471,12 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderElementsOf (Seq("HELLO", "HI")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderElementsOf (Seq("HI", "HELLO")) or not contain inOrderElementsOf (Seq("hi", "hello")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("hi", "hello")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -514,12 +514,12 @@ class ListShouldContainInOrderElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrderElementsOf (Seq("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("he", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all elements of " + decorateToStringValue(prettifier, Seq("HI", "HELLO")) + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfSpec.scala
@@ -76,14 +76,14 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
+        (fumList should contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain inOrderElementsOf Seq("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
+          (fumList should contain inOrderElementsOf Seq("fee", "fie", "foe", "fum")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
+        (fumList should contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should do nothing when RHS contain duplicated value") {
         fumList should contain inOrderElementsOf Seq("fum", "fum", "foe", "fie", "fee")
@@ -114,14 +114,14 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should do nothing when RHS contain duplicated value") {
         fumList should (contain inOrderElementsOf Seq("fum", "fum", "foe", "fie", "fum"))
@@ -153,13 +153,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList should not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList should not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -186,13 +186,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY")))) (using decided by upperCaseStringEquality)
+        (toList should (not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toList should (not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList should (not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -219,13 +219,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -252,13 +252,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -317,14 +317,14 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain inOrderElementsOf Seq("HI", "HE")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain inOrderElementsOf Seq("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderElementsOf Seq("HI", "HO")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain inOrderElementsOf Seq("HI", "HO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain inOrderElementsOf Seq("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain inOrderElementsOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderElementsOf Seq("hi", "ho")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain inOrderElementsOf Seq("hi", "ho")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -375,14 +375,14 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain inOrderElementsOf Seq("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain inOrderElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("he", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain inOrderElementsOf Seq("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -411,13 +411,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain inOrderElementsOf (Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain inOrderElementsOf (Seq("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderElementsOf (Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain inOrderElementsOf (Seq("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain inOrderElementsOf (Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderElementsOf (Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain inOrderElementsOf (Seq(" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -446,13 +446,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain inOrderElementsOf (Seq("YOU", "TO")))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain inOrderElementsOf (Seq("YOU", "TO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderElementsOf (Seq("TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain inOrderElementsOf (Seq("TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain inOrderElementsOf (Seq(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderElementsOf (Seq(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain inOrderElementsOf (Seq(" TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -481,13 +481,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain inOrderElementsOf Seq("YOU", "TO")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain inOrderElementsOf Seq("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderElementsOf Seq("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain inOrderElementsOf Seq("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain inOrderElementsOf Seq(" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderElementsOf Seq(" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain inOrderElementsOf Seq(" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -516,13 +516,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain inOrderElementsOf Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain inOrderElementsOf Seq("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderElementsOf Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain inOrderElementsOf Seq("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain inOrderElementsOf Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderElementsOf Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain inOrderElementsOf Seq(" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderElementsOfSpec.scala
@@ -76,14 +76,14 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE")) (decided by upperCaseStringEquality)
+        (fumList should contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain inOrderElementsOf Seq("fee", "fie", "foe", "fum")) (decided by upperCaseStringEquality)
+          (fumList should contain inOrderElementsOf Seq("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ")) (after being lowerCased and trimmed)
+        (fumList should contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
       }
       it("should do nothing when RHS contain duplicated value") {
         fumList should contain inOrderElementsOf Seq("fum", "fum", "foe", "fie", "fee")
@@ -114,14 +114,14 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderElementsOf Seq("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain inOrderElementsOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderElementsOf Seq(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
       it("should do nothing when RHS contain duplicated value") {
         fumList should (contain inOrderElementsOf Seq("fum", "fum", "foe", "fie", "fum"))
@@ -153,13 +153,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList should not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList should not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList should not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -186,13 +186,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY")))) (decided by upperCaseStringEquality)
+        (toList should (not contain inOrderElementsOf (Seq("YOU", "TO", "BIRTHDAY", "HAPPY")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toList should (not contain inOrderElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList should (not contain inOrderElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -219,13 +219,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -252,13 +252,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain inOrderElementsOf Seq("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain inOrderElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain inOrderElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -317,14 +317,14 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain inOrderElementsOf Seq("HI", "HE")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain inOrderElementsOf Seq("HI", "HE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderElementsOf Seq("HI", "HO")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain inOrderElementsOf Seq("HI", "HO")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain inOrderElementsOf Seq("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain inOrderElementsOf Seq("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderElementsOf Seq("hi", "ho")) (decided by defaultEquality[String])
+          (all (hiLists) should contain inOrderElementsOf Seq("hi", "ho")) (using decided by defaultEquality[String])
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -375,14 +375,14 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderElementsOf Seq("HI", "HO"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain inOrderElementsOf Seq("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain inOrderElementsOf Seq("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderElementsOf Seq("he", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain inOrderElementsOf Seq("he", "hi"))) (using decided by defaultEquality[String])
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -411,13 +411,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain inOrderElementsOf (Seq("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain inOrderElementsOf (Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderElementsOf (Seq("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain inOrderElementsOf (Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain inOrderElementsOf (Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderElementsOf (Seq(" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should not contain inOrderElementsOf (Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -446,13 +446,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain inOrderElementsOf (Seq("YOU", "TO")))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain inOrderElementsOf (Seq("YOU", "TO")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderElementsOf (Seq("TO", "YOU")))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain inOrderElementsOf (Seq("TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain inOrderElementsOf (Seq(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderElementsOf (Seq(" TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain inOrderElementsOf (Seq(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -481,13 +481,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain inOrderElementsOf Seq("YOU", "TO")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain inOrderElementsOf Seq("YOU", "TO")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderElementsOf Seq("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain inOrderElementsOf Seq("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain inOrderElementsOf Seq(" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderElementsOf Seq(" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain inOrderElementsOf Seq(" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {
@@ -516,13 +516,13 @@ class ListShouldContainInOrderElementsOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain inOrderElementsOf Seq("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain inOrderElementsOf Seq("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderElementsOf Seq("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain inOrderElementsOf Seq("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain inOrderElementsOf Seq(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderElementsOf Seq(" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain inOrderElementsOf Seq(" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalAndSpec.scala
@@ -95,16 +95,16 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -152,16 +152,16 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -202,16 +202,16 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -252,16 +252,16 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -302,13 +302,13 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -358,13 +358,13 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
@@ -407,16 +407,16 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -491,14 +491,14 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HO", "HELLO") and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HO", "HELLO") and contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HO\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -578,14 +578,14 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("he", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -646,14 +646,14 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HELLO", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrder ("HI", "HELLO") and not contain inOrder ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrder ("HI", "HELLO") and not contain inOrder ("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -721,14 +721,14 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain inOrder ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain inOrder ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("he", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalAndSpec.scala
@@ -95,16 +95,16 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -152,16 +152,16 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -202,16 +202,16 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -252,16 +252,16 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -302,13 +302,13 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -358,13 +358,13 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
@@ -407,16 +407,16 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -491,14 +491,14 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HO", "HELLO") and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HO", "HELLO") and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HO\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HI", "HELLO") and contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -578,14 +578,14 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("he", "hi", "hello")) and contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("he", "hi", "hello")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -646,14 +646,14 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HELLO", "HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HELLO", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrder ("HI", "HELLO") and not contain inOrder ("HO", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrder ("HI", "HELLO") and not contain inOrder ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrder ("HELLO", "HI") and not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order" + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -721,14 +721,14 @@ class ListShouldContainInOrderLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain inOrder ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain inOrder ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("he", "hi", "hello")) and not contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("he", "hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalOrSpec.scala
@@ -91,14 +91,14 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -142,14 +142,14 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain inOrder (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain inOrder (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -186,14 +186,14 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -230,14 +230,14 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -274,11 +274,11 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", and " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -324,11 +324,11 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -367,14 +367,14 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -433,12 +433,12 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HO\")" + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"hello\", \"ho\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -487,12 +487,12 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain inOrder ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -534,12 +534,12 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"hi\", \"hello\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -588,12 +588,12 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrder ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrder ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("he", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderLogicalOrSpec.scala
@@ -91,14 +91,14 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or contain inOrder ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -142,14 +142,14 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain inOrder (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain inOrder (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -186,14 +186,14 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -230,14 +230,14 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -274,11 +274,11 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrder ("FEE", "FIE", "FOE", "FUM") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrder ("FUM", "FOE", "FIE", "FEE") or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", and " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -324,11 +324,11 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -367,14 +367,14 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain inOrder ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAllOfElementsInOrder(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrder (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -433,12 +433,12 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HELLO") or contain inOrder ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HELLO", "HO") or contain inOrder ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HO\")" + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"hello\", \"ho\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -487,12 +487,12 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("he", "hi", "hello")) or contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain inOrder ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain inOrder ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " did not contain all of " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -534,12 +534,12 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrder ("HELLO", "HI") or not contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrder ("HI", "HELLO") or not contain inOrder ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order" + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"hi\", \"hello\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -588,12 +588,12 @@ class ListShouldContainInOrderLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrder ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrder ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrder ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("he", "hi", "hello")) or not contain inOrder ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, hiLists(0)) + " was equal to " + decorateToStringValue(prettifier, List("he", "hi", "hello")) + ", and " + decorateToStringValue(prettifier, hiLists(0)) + " contained all of " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalAndSpec.scala
@@ -95,16 +95,16 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -152,16 +152,16 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -202,16 +202,16 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -252,16 +252,16 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -302,13 +302,13 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -358,13 +358,13 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
@@ -407,16 +407,16 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -491,14 +491,14 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HO", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HO", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order" + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -578,14 +578,14 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -646,14 +646,14 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HELLO", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") and not contain inOrderOnly ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") and not contain inOrderOnly ("HO", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order" + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -721,14 +721,14 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain inOrderOnly ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain inOrderOnly ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalAndSpec.scala
@@ -95,16 +95,16 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -152,16 +152,16 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -202,16 +202,16 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -252,16 +252,16 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -302,13 +302,13 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -358,13 +358,13 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
@@ -407,16 +407,16 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") and not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -491,14 +491,14 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HO", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HO", "HELLO") and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") and contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order" + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -578,14 +578,14 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi", "hello")) and contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -646,14 +646,14 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HELLO", "HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HELLO", "HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") and not contain inOrderOnly ("HO", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") and not contain inOrderOnly ("HO", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") and not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order" + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -721,14 +721,14 @@ class ListShouldContainInOrderOnlyLogicalAndSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain inOrderOnly ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain inOrderOnly ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) and not contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalOrSpec.scala
@@ -91,14 +91,14 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -142,14 +142,14 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -186,14 +186,14 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -230,14 +230,14 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -274,11 +274,11 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", and " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -324,11 +324,11 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -367,14 +367,14 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -433,12 +433,12 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")" + " in order" + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"hello\", \"ho\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -487,12 +487,12 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -534,12 +534,12 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order" + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"hi\", \"hello\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -588,12 +588,12 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlyLogicalOrSpec.scala
@@ -91,14 +91,14 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or contain inOrderOnly ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -142,14 +142,14 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -186,14 +186,14 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -230,14 +230,14 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -274,11 +274,11 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE") or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\"") + ", and " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -324,11 +324,11 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
       }
@@ -367,14 +367,14 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain inOrderOnly ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedInOrderOnlyElements(decorateToStringValue(prettifier, fumList), "\"FUM\", \"FOE\", \"FIE\", \"FEE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU ") or not contain inOrderOnly (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -433,12 +433,12 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HELLO") or contain inOrderOnly ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HELLO", "HO") or contain inOrderOnly ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")" + " in order" + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"hello\", \"ho\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -487,12 +487,12 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain inOrderOnly ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HI\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -534,12 +534,12 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain inOrderOnly ("HELLO", "HI") or not contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain inOrderOnly ("HI", "HELLO") or not contain inOrderOnly ("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order" + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"hi\", \"hello\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -588,12 +588,12 @@ class ListShouldContainInOrderOnlyLogicalOrSpec extends AnyFunSpec with Matchers
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderOnly ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi", "hello")) or not contain inOrderOnly ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) or not contain inOrderOnly ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")" + " in order", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlySpec.scala
@@ -76,14 +76,14 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
+        (fumList should contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain inOrderOnly ("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
+          (fumList should contain inOrderOnly ("fee", "fie", "foe", "fum")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
+        (fumList should contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -119,14 +119,14 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -163,13 +163,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
+        (toList should not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList should not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList should not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList should not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -201,13 +201,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList should (not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList should (not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should (not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -239,13 +239,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -277,13 +277,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -347,14 +347,14 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain inOrderOnly ("HI", "HE")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain inOrderOnly ("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderOnly ("HI", "HO")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain inOrderOnly ("HI", "HO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain inOrderOnly ("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain inOrderOnly ("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderOnly ("hi", "ho")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain inOrderOnly ("hi", "ho")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -410,14 +410,14 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderOnly ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HI", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain inOrderOnly ("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain inOrderOnly ("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("he", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain inOrderOnly ("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -451,13 +451,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain inOrderOnly ("YOU", "TO")) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain inOrderOnly ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderOnly ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain inOrderOnly ("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain inOrderOnly (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderOnly (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain inOrderOnly (" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -491,13 +491,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain inOrderOnly ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain inOrderOnly ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderOnly ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain inOrderOnly ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain inOrderOnly (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderOnly (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain inOrderOnly (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -531,13 +531,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain inOrderOnly ("YOU", "TO")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain inOrderOnly ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderOnly ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain inOrderOnly ("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain inOrderOnly (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderOnly (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain inOrderOnly (" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -571,13 +571,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain inOrderOnly ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain inOrderOnly ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderOnly ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain inOrderOnly ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain inOrderOnly (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderOnly (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain inOrderOnly (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderOnlySpec.scala
@@ -76,14 +76,14 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")) (decided by upperCaseStringEquality)
+        (fumList should contain inOrderOnly ("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain inOrderOnly ("fee", "fie", "foe", "fum")) (decided by upperCaseStringEquality)
+          (fumList should contain inOrderOnly ("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ")) (after being lowerCased and trimmed)
+        (fumList should contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -119,14 +119,14 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrderOnly ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrderOnly ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrderOnly (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -163,13 +163,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (decided by upperCaseStringEquality)
+        (toList should not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList should not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList should not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList should not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList should not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -201,13 +201,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList should (not contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList should (not contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should (not contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -239,13 +239,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -277,13 +277,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain inOrderOnly ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain inOrderOnly ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain inOrderOnly (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -347,14 +347,14 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain inOrderOnly ("HI", "HE")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain inOrderOnly ("HI", "HE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderOnly ("HI", "HO")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain inOrderOnly ("HI", "HO")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain inOrderOnly ("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain inOrderOnly ("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrderOnly ("hi", "ho")) (decided by defaultEquality[String])
+          (all (hiLists) should contain inOrderOnly ("hi", "ho")) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -410,14 +410,14 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrderOnly ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrderOnly ("HI", "HE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrderOnly ("HI", "HO"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain inOrderOnly ("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain inOrderOnly ("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrderOnly ("he", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain inOrderOnly ("he", "hi"))) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -451,13 +451,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain inOrderOnly ("YOU", "TO")) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain inOrderOnly ("YOU", "TO")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderOnly ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain inOrderOnly ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain inOrderOnly (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrderOnly (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) should not contain inOrderOnly (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -491,13 +491,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain inOrderOnly ("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain inOrderOnly ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderOnly ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain inOrderOnly ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain inOrderOnly (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrderOnly (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain inOrderOnly (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -531,13 +531,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain inOrderOnly ("YOU", "TO")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain inOrderOnly ("YOU", "TO")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderOnly ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain inOrderOnly ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain inOrderOnly (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrderOnly (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain inOrderOnly (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -571,13 +571,13 @@ class ListShouldContainInOrderOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain inOrderOnly ("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain inOrderOnly ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderOnly ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain inOrderOnly ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain inOrderOnly (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrderOnly (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain inOrderOnly (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderSpec.scala
@@ -76,14 +76,14 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain inOrder ("FUM", "FOE", "FIE", "FEE")) (decided by upperCaseStringEquality)
+        (fumList should contain inOrder ("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain inOrder ("fee", "fie", "foe", "fum")) (decided by upperCaseStringEquality)
+          (fumList should contain inOrder ("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ")) (after being lowerCased and trimmed)
+        (fumList should contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -135,14 +135,14 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain inOrder ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -179,13 +179,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (decided by upperCaseStringEquality)
+        (toList should not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList should not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList should not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList should not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList should not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -217,13 +217,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList should (not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList should (not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should (not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -255,13 +255,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -293,13 +293,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -363,14 +363,14 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain inOrder ("HI", "HE")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain inOrder ("HI", "HE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrder ("HI", "HO")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain inOrder ("HI", "HO")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain inOrder ("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain inOrder ("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrder ("hi", "ho")) (decided by defaultEquality[String])
+          (all (hiLists) should contain inOrder ("hi", "ho")) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -426,14 +426,14 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrder ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HI", "HO"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain inOrder ("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain inOrder ("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("he", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain inOrder ("he", "hi"))) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -467,13 +467,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain inOrder ("YOU", "TO")) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain inOrder ("YOU", "TO")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrder ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain inOrder ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain inOrder (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrder (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) should not contain inOrder (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -507,13 +507,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain inOrder ("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain inOrder ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrder ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain inOrder ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain inOrder (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrder (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain inOrder (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -547,13 +547,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain inOrder ("YOU", "TO")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain inOrder ("YOU", "TO")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrder ("TO", "YOU")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain inOrder ("TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain inOrder (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrder (" TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain inOrder (" TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -587,13 +587,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain inOrder ("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain inOrder ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrder ("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain inOrder ("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain inOrder (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrder (" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain inOrder (" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainInOrderSpec.scala
@@ -76,14 +76,14 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain inOrder ("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
+        (fumList should contain inOrder ("FUM", "FOE", "FIE", "FEE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain inOrder ("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
+          (fumList should contain inOrder ("fee", "fie", "foe", "fum")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
+        (fumList should contain inOrder (" FUM ", " FOE ", " FIE ", " FEE ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -135,14 +135,14 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain inOrder ("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain inOrder ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain inOrder ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (contain inOrder (" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -179,13 +179,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
+        (toList should not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList should not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList should not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList should not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -217,13 +217,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList should (not contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList should (not contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should (not contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -255,13 +255,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -293,13 +293,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain inOrder ("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain inOrder ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain inOrder (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -363,14 +363,14 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain inOrder ("HI", "HE")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain inOrder ("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrder ("HI", "HO")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain inOrder ("HI", "HO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain inOrder ("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain inOrder ("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain inOrder ("hi", "ho")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain inOrder ("hi", "ho")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -426,14 +426,14 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain inOrder ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain inOrder ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("HI", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain inOrder ("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain inOrder ("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain inOrder ("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain inOrder ("he", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain inOrder ("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -467,13 +467,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain inOrder ("YOU", "TO")) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain inOrder ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrder ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain inOrder ("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain inOrder (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain inOrder (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain inOrder (" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -507,13 +507,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain inOrder ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain inOrder ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrder ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain inOrder ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain inOrder (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain inOrder (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain inOrder (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -547,13 +547,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain inOrder ("YOU", "TO")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain inOrder ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrder ("TO", "YOU")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain inOrder ("TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain inOrder (" TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain inOrder (" TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain inOrder (" TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -587,13 +587,13 @@ class ListShouldContainInOrderSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain inOrder ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain inOrder ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrder ("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain inOrder ("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain inOrder (" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain inOrder (" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain inOrder (" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalAndSpec.scala
@@ -100,16 +100,16 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -146,16 +146,16 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -191,16 +191,16 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -236,16 +236,16 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -282,16 +282,16 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -328,16 +328,16 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -373,16 +373,16 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -452,14 +452,14 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("ho", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") and contain noElementsOf Seq("ho", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") and contain noElementsOf Seq("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -516,14 +516,14 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) and contain noElementsOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) and contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain noElementsOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi")) and contain noElementsOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi")) and contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -579,14 +579,14 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) and not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, List("hi"), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedAtLeastOneElementOf(prettifier, List("hi"), Seq("HI", "HE")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -643,14 +643,14 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) and not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain noElementsOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalAndSpec.scala
@@ -100,16 +100,16 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -146,16 +146,16 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -191,16 +191,16 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -236,16 +236,16 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -282,16 +282,16 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) and not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") and contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -328,16 +328,16 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -373,16 +373,16 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) and not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -452,14 +452,14 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("ho", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") and contain noElementsOf Seq("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") and contain noElementsOf Seq("ho", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noElementsOf Seq("hi", "he") and contain noElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -516,14 +516,14 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) and contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) and contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi")) and contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi")) and contain noElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -579,14 +579,14 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) and not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, List("hi"), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) and not contain noElementsOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedAtLeastOneElementOf(prettifier, List("hi"), Seq("HI", "HE")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -643,14 +643,14 @@ class ListShouldContainNoElementsOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) and not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) and not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain noElementsOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalOrSpec.scala
@@ -96,14 +96,14 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -136,14 +136,14 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -175,14 +175,14 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -214,14 +214,14 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -253,11 +253,11 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
@@ -292,14 +292,14 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -331,14 +331,14 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -393,12 +393,12 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -436,12 +436,12 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho")) or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi")) or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho")) or contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain noElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) or contain noElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -478,12 +478,12 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -521,12 +521,12 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi")) or not contain noElementsOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain noElementsOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) or not contain noElementsOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfLogicalOrSpec.scala
@@ -96,14 +96,14 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or contain noElementsOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FUM", "FOE")), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ") or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -136,14 +136,14 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain noElementsOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -175,14 +175,14 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain noElementsOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -214,14 +214,14 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noElementsOf Seq("fee", "fie", "foe", "fum") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedAtLeastOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -253,11 +253,11 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("FEE", "FIE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noElementsOf (Seq("fee", "fie", "foe", "fum")) or not contain noElementsOf (Seq("fee", "fie", "fum", "foe")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
@@ -292,14 +292,14 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain noElementsOf (Seq("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain noElementsOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -331,14 +331,14 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain noElementsOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")) or not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -393,12 +393,12 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he") or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noElementsOf Seq("HI", "HE") or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -436,12 +436,12 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) or contain noElementsOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho")) or contain noElementsOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi")) or contain noElementsOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho")) or contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) or contain noElementsOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) or contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + FailureMessages.containedAtLeastOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -478,12 +478,12 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noElementsOf (Seq("HI", "HE")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noElementsOf (Seq("hi", "he")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -521,12 +521,12 @@ class ListShouldContainNoElementsOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) or not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi")) or not contain noElementsOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain noElementsOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi")) or not contain noElementsOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) or not contain noElementsOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) or not contain noElementsOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + FailureMessages.didNotContainAtLeastOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfSpec.scala
@@ -64,14 +64,14 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain noElementsOf Seq("FEE", "FAM", "FOE", "FU")) (decided by upperCaseEquality)
+        (fumList should contain noElementsOf Seq("FEE", "FAM", "FOE", "FU")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain noElementsOf Seq("FEE", "FUM", "FOE", "FU")) (decided by upperCaseEquality)
+          (fumList should contain noElementsOf Seq("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+          (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
         }
-        (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ")) (after being lowerCased and trimmed)
+        (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ")) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain noElementsOf Seq("fee", "fie", "foe", "fie", "fam")
@@ -104,13 +104,13 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("FEE", "FAM", "FOE", "FU"))) (decided by upperCaseEquality)
+        (fumList should (contain noElementsOf Seq("FEE", "FAM", "FOE", "FU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FUM", "FOE", "FU"))) (decided by upperCaseEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
         }
         fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+          (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -143,11 +143,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseEquality)
+        (fumList should not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (fumList should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
-        (fumList should not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -176,11 +176,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseEquality)
+        (toList should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseEquality)
+          (toList should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
         }
-        (toList should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+        (toList should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         }
@@ -209,11 +209,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseEquality)
+        (fumList shouldNot contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (fumList shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
-        (fumList shouldNot contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList shouldNot contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -242,11 +242,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+        (toList shouldNot (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+          (toList shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         }
-        (toList shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (toList shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -299,14 +299,14 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain noElementsOf Seq("hi", "he")) (decided by upperCaseEquality)
+        (all (hiLists) should contain noElementsOf Seq("hi", "he")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain noElementsOf Seq("HI", "HE")) (decided by upperCaseEquality)
+          (all (hiLists) should contain noElementsOf Seq("HI", "HE")) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain noElementsOf Seq("ho", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain noElementsOf Seq("ho", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain noElementsOf Seq("hi", "he")) (decided by defaultEquality[String])
+          (all (hiLists) should contain noElementsOf Seq("hi", "he")) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -347,14 +347,14 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (decided by upperCaseEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("HI", "HE"))) (decided by upperCaseEquality)
+          (all (hiLists) should (contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain noElementsOf Seq("ho", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain noElementsOf Seq("ho", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -383,11 +383,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+        (all (toLists) should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain noElementsOf (Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+          (all (toLists) should not contain noElementsOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         }
-        (all (toLists) should not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) should not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -418,11 +418,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseEquality)
+        (all (toLists) should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseEquality)
+          (all (toLists) should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
         }
-        (all (toLists) should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+        (all (toLists) should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         }
@@ -453,11 +453,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+        (all (toLists) shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain noElementsOf Seq("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+          (all (toLists) shouldNot contain noElementsOf Seq("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -488,11 +488,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot  (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+        (all (toLists) shouldNot  (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot  (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot  (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoElementsOfSpec.scala
@@ -64,14 +64,14 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain noElementsOf Seq("FEE", "FAM", "FOE", "FU")) (using decided by upperCaseEquality)
+        (fumList should contain noElementsOf Seq("FEE", "FAM", "FOE", "FU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain noElementsOf Seq("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
+          (fumList should contain noElementsOf Seq("FEE", "FUM", "FOE", "FU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+          (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
-        (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ")) (using after being lowerCased and trimmed)
+        (fumList should contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FAM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain noElementsOf Seq("fee", "fie", "foe", "fie", "fam")
@@ -104,13 +104,13 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noElementsOf Seq("FEE", "FAM", "FOE", "FU"))) (using decided by upperCaseEquality)
+        (fumList should (contain noElementsOf Seq("FEE", "FAM", "FOE", "FU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
+          (fumList should (contain noElementsOf Seq("FEE", "FUM", "FOE", "FU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         intercept[TestFailedException] {
-          (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+          (fumList should (contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -143,11 +143,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseEquality)
+        (fumList should not contain noElementsOf (Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (fumList should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (fumList should not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should not contain noElementsOf (Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
@@ -176,11 +176,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
+        (toList should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
+          (toList should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (toList should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+        (toList should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         }
@@ -209,11 +209,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
+        (fumList shouldNot contain noElementsOf Seq("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (fumList shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (fumList shouldNot contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList shouldNot contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain noElementsOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -242,11 +242,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+        (toList shouldNot (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+          (toList shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (toList shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (toList shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -299,14 +299,14 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain noElementsOf Seq("hi", "he")) (using decided by upperCaseEquality)
+        (all (hiLists) should contain noElementsOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain noElementsOf Seq("HI", "HE")) (using decided by upperCaseEquality)
+          (all (hiLists) should contain noElementsOf Seq("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain noElementsOf Seq("ho", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain noElementsOf Seq("ho", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain noElementsOf Seq("hi", "he")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain noElementsOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -347,14 +347,14 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (using decided by upperCaseEquality)
+        (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("HI", "HE"))) (using decided by upperCaseEquality)
+          (all (hiLists) should (contain noElementsOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain noElementsOf Seq("ho", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain noElementsOf Seq("ho", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain noElementsOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -383,11 +383,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+        (all (toLists) should not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain noElementsOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+          (all (toLists) should not contain noElementsOf (Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) should not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) should not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -418,11 +418,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
+        (all (toLists) should (not contain noElementsOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
+          (all (toLists) should (not contain noElementsOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+        (all (toLists) should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain noElementsOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         }
@@ -453,11 +453,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain noElementsOf Seq("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot contain noElementsOf Seq("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -488,11 +488,11 @@ class ListShouldContainNoElementsOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot  (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot  (contain noElementsOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain noElementsOf Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot  (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot  (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain noElementsOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalAndSpec.scala
@@ -100,16 +100,16 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and contain noneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -157,16 +157,16 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -207,16 +207,16 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -257,16 +257,16 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -308,16 +308,16 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -365,16 +365,16 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -415,16 +415,16 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -499,14 +499,14 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("ho", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("HI", "HE") and contain noneOf ("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noneOf ("HI", "HE") and contain noneOf ("ho", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -574,14 +574,14 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) and contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) and contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi")) and contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi")) and contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -642,14 +642,14 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noneOf ("hi", "he") and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noneOf ("hi", "he") and not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, List("hi"), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, List("hi"), UnquotedString("\"HI\", \"HE\"")) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -717,14 +717,14 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) and not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalAndSpec.scala
@@ -100,16 +100,16 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -157,16 +157,16 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -207,16 +207,16 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -257,16 +257,16 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("fee", "fie", "foe", "fum") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -308,16 +308,16 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") and not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") and not contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") and contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -365,16 +365,16 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -415,16 +415,16 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") and not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -499,14 +499,14 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("ho", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("HI", "HE") and contain noneOf ("ho", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noneOf ("HI", "HE") and contain noneOf ("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noneOf ("hi", "he") and contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -574,14 +574,14 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) and contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) and contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi")) and contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi")) and contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -642,14 +642,14 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noneOf ("hi", "he") and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noneOf ("hi", "he") and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, List("hi"), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noneOf ("HI", "HE") and not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, List("hi"), UnquotedString("\"HI\", \"HE\"")) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -717,14 +717,14 @@ class ListShouldContainNoneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) and not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) and not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalOrSpec.scala
@@ -96,14 +96,14 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -147,14 +147,14 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain noneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain noneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -191,14 +191,14 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -235,14 +235,14 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -279,11 +279,11 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
@@ -329,14 +329,14 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -373,14 +373,14 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -440,12 +440,12 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", and " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -494,12 +494,12 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho")) or contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi")) or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho")) or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) or contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -541,12 +541,12 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", and " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -595,12 +595,12 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi")) or not contain noneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi")) or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) or not contain noneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfLogicalOrSpec.scala
@@ -96,14 +96,14 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ") or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -147,14 +147,14 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain noneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -191,14 +191,14 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain noneOf (" FEE ", " FIE ", " FOE ", " FAM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -235,14 +235,14 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain noneOf ("fee", "fie", "foe", "fum") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain noneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -279,11 +279,11 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain noneOf ("FEE", "FIE", "FOE", "FUM") or not contain noneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain noneOf ("fee", "fie", "foe", "fum") or not contain noneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
@@ -329,14 +329,14 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain noneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain noneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -373,14 +373,14 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain noneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain noneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainAtLeastOneOf(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ") or not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -440,12 +440,12 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he") or contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain noneOf ("HI", "HE") or contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", and " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -494,12 +494,12 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho")) or contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi")) or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho")) or contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) or contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) or contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + FailureMessages.containedAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -541,12 +541,12 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain noneOf ("HI", "HE") or not contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain noneOf ("hi", "he") or not contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", and " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -595,12 +595,12 @@ class ListShouldContainNoneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi")) or not contain noneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi")) or not contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) or not contain noneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) or not contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + FailureMessages.didNotContainAtLeastOneOf(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfSpec.scala
@@ -67,14 +67,14 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain noneOf ("FEE", "FAM", "FOE", "FU")) (using decided by upperCaseEquality)
+        (fumList should contain noneOf ("FEE", "FAM", "FOE", "FU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain noneOf ("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
+          (fumList should contain noneOf ("FEE", "FUM", "FOE", "FU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+          (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
-        (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ")) (using after being lowerCased and trimmed)
+        (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -112,13 +112,13 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("FEE", "FAM", "FOE", "FU"))) (using decided by upperCaseEquality)
+        (fumList should (contain noneOf ("FEE", "FAM", "FOE", "FU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
+          (fumList should (contain noneOf ("FEE", "FUM", "FOE", "FU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         intercept[TestFailedException] {
-          (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+          (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -156,11 +156,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should not contain noneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
+        (fumList should not contain noneOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (fumList should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (fumList should not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -194,11 +194,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+        (toList should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+          (toList should (not contain noneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (toList should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (toList should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -232,11 +232,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain noneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
+        (fumList shouldNot contain noneOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (fumList shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (fumList shouldNot contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList shouldNot contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -270,11 +270,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+        (toList shouldNot (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+          (toList shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (toList shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (toList shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -332,14 +332,14 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain noneOf ("hi", "he")) (using decided by upperCaseEquality)
+        (all (hiLists) should contain noneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain noneOf ("HI", "HE")) (using decided by upperCaseEquality)
+          (all (hiLists) should contain noneOf ("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain noneOf ("ho", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain noneOf ("ho", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain noneOf ("hi", "he")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain noneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -385,14 +385,14 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noneOf ("hi", "he"))) (using decided by upperCaseEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("HI", "HE"))) (using decided by upperCaseEquality)
+          (all (hiLists) should (contain noneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain noneOf ("ho", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain noneOf ("ho", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("hi", "he"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain noneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -426,11 +426,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+        (all (toLists) should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain noneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+          (all (toLists) should not contain noneOf ("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) should not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+        (all (toLists) should not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -466,11 +466,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+        (all (toLists) should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+          (all (toLists) should (not contain noneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -506,11 +506,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain noneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot contain noneOf ("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -546,11 +546,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot  (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot  (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot  (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+        (all (toLists) shouldNot  (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainNoneOfSpec.scala
@@ -67,14 +67,14 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain noneOf ("FEE", "FAM", "FOE", "FU")) (decided by upperCaseEquality)
+        (fumList should contain noneOf ("FEE", "FAM", "FOE", "FU")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain noneOf ("FEE", "FUM", "FOE", "FU")) (decided by upperCaseEquality)
+          (fumList should contain noneOf ("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
-          (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+          (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
         }
-        (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ")) (after being lowerCased and trimmed)
+        (fumList should contain noneOf (" FEE ", " FIE ", " FOE ", " FAM ")) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -112,13 +112,13 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain noneOf ("FEE", "FAM", "FOE", "FU"))) (decided by upperCaseEquality)
+        (fumList should (contain noneOf ("FEE", "FAM", "FOE", "FU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain noneOf ("FEE", "FUM", "FOE", "FU"))) (decided by upperCaseEquality)
+          (fumList should (contain noneOf ("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
         }
         fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         intercept[TestFailedException] {
-          (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+          (fumList should (contain noneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -156,11 +156,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should not contain noneOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseEquality)
+        (fumList should not contain noneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (fumList should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
-        (fumList should not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList should not contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -194,11 +194,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+        (toList should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain noneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+          (toList should (not contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         }
-        (toList should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (toList should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -232,11 +232,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList shouldNot contain noneOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseEquality)
+        (fumList shouldNot contain noneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (fumList shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
-        (fumList shouldNot contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList shouldNot contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           fumList shouldNot contain noneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
@@ -270,11 +270,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+        (toList shouldNot (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+          (toList shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         }
-        (toList shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (toList shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           toList shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -332,14 +332,14 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain noneOf ("hi", "he")) (decided by upperCaseEquality)
+        (all (hiLists) should contain noneOf ("hi", "he")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain noneOf ("HI", "HE")) (decided by upperCaseEquality)
+          (all (hiLists) should contain noneOf ("HI", "HE")) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain noneOf ("ho", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain noneOf ("ho", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain noneOf ("hi", "he")) (decided by defaultEquality[String])
+          (all (hiLists) should contain noneOf ("hi", "he")) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -385,14 +385,14 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain noneOf ("hi", "he"))) (decided by upperCaseEquality)
+        (all (hiLists) should (contain noneOf ("hi", "he"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("HI", "HE"))) (decided by upperCaseEquality)
+          (all (hiLists) should (contain noneOf ("HI", "HE"))) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain noneOf ("ho", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain noneOf ("ho", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain noneOf ("hi", "he"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain noneOf ("hi", "he"))) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -426,11 +426,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+        (all (toLists) should not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain noneOf ("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+          (all (toLists) should not contain noneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         }
-        (all (toLists) should not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+        (all (toLists) should not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -466,11 +466,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+        (all (toLists) should (not contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain noneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+          (all (toLists) should (not contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         }
-        (all (toLists) should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) should (not contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }
@@ -506,11 +506,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+        (all (toLists) shouldNot contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain noneOf ("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+          (all (toLists) shouldNot contain noneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         }
@@ -546,11 +546,11 @@ class ListShouldContainNoneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot  (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+        (all (toLists) shouldNot  (contain noneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain noneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         }
-        (all (toLists) shouldNot  (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+        (all (toLists) shouldNot  (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         intercept[TestFailedException] {
           all (toLists) shouldNot (contain noneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalAndSpec.scala
@@ -100,16 +100,16 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fee", "fie", "foe", "fum") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fee", "fie", "foe", "fum") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -146,16 +146,16 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -191,16 +191,16 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -236,16 +236,16 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -281,16 +281,16 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", but " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -327,16 +327,16 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -372,16 +372,16 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -463,14 +463,14 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("hi", "he") and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneElementOf Seq("hi", "he") and contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -539,14 +539,14 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) and contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi")) and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi")) and contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -602,14 +602,14 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) and not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) and not contain oneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) and not contain oneElementOf (Seq("HO", "HEY", "HOWDY")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) and not contain oneElementOf (Seq("HO", "HEY", "HOWDY")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneElementOf (Seq("HO", "HEY", "HOWDY")) and not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneElementOf (Seq("HO", "HEY", "HOWDY")) and not contain oneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("HO", "HEY", "HOWDY")) + ", but " + FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -666,14 +666,14 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain oneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) and not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) and not contain oneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain oneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " +  FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalAndSpec.scala
@@ -100,16 +100,16 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fee", "fie", "foe", "fum") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fee", "fie", "foe", "fum") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -146,16 +146,16 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -191,16 +191,16 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -236,16 +236,16 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -281,16 +281,16 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fee", "fie", "foe", "fum")) + ", but " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") and contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -327,16 +327,16 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", but " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.equaled(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -372,16 +372,16 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", but " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumList, fumList), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -463,14 +463,14 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("hi", "he") and contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneElementOf Seq("hi", "he") and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -539,14 +539,14 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) and contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi")) and contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi")) and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -602,14 +602,14 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) and not contain oneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) and not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) and not contain oneElementOf (Seq("HO", "HEY", "HOWDY")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) and not contain oneElementOf (Seq("HO", "HEY", "HOWDY")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneElementOf (Seq("HO", "HEY", "HOWDY")) and not contain oneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneElementOf (Seq("HO", "HEY", "HOWDY")) and not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("HO", "HEY", "HOWDY")) + ", but " + FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -666,14 +666,14 @@ class ListShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain oneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) and not contain oneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) and not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain oneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " +  FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalOrSpec.scala
@@ -96,14 +96,14 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -136,14 +136,14 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -175,14 +175,14 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -214,14 +214,14 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -253,14 +253,14 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -293,14 +293,14 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -332,14 +332,14 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -394,12 +394,12 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("ho", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("ho", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("ho", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -437,12 +437,12 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho")) or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi")) or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho")) or contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) or contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -479,12 +479,12 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")) + ", and " + FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -522,12 +522,12 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain oneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi")) or not contain oneElementOf (Seq("hi", "he")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain oneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) or not contain oneElementOf (Seq("HI", "HE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfLogicalOrSpec.scala
@@ -96,14 +96,14 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -136,14 +136,14 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotEqual(prettifier, fumList, fumList) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -175,14 +175,14 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain oneElementOf Seq("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumList, toList) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -214,14 +214,14 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneElementOf Seq("fie", "fee", "fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumList, Seq("fie", "fee", "fum", "foe")) + ", and " + FailureMessages.wasNotEqualTo(prettifier, fumList, toList), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -253,14 +253,14 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("fee", "fie", "foe", "fum")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")) + ", and " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ") or contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -293,14 +293,14 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain oneElementOf (Seq("fie", "fee", "fum", "foe")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.equaled(prettifier, fumList, toList) + ", and " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -332,14 +332,14 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain oneElementOf (Seq("fee", "fie", "foe", "fum")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain oneElementOf (Seq("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, fumList, fumList) + ", and " + FailureMessages.containedOneElementOf(prettifier, fumList, Seq("FEE", "FIE", "FOE", "FUM")), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain oneElementOf (Seq(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should allow RHS to contain duplicated value") {
@@ -394,12 +394,12 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("ho", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("ho", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("ho", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -437,12 +437,12 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) or contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho")) or contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi")) or contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho")) or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) or contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, hiLists(0), Seq("hi", "he")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -479,12 +479,12 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneElementOf (Seq("hi", "he")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneElementOf (Seq("HI", "HE")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")) + ", and " + FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -522,12 +522,12 @@ class ListShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) or not contain oneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi")) or not contain oneElementOf (Seq("hi", "he")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain oneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi")) or not contain oneElementOf (Seq("hi", "he")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) or not contain oneElementOf (Seq("HI", "HE")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) or not contain oneElementOf (Seq("HI", "HE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + FailureMessages.containedOneElementOf(prettifier, hiLists(0), Seq("HI", "HE")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfSpec.scala
@@ -72,14 +72,14 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain oneElementOf Seq("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
+        (fumList should contain oneElementOf Seq("FEE", "FUM", "FOE", "FU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain oneElementOf Seq("fee", "fum", "foe", "fu")) (using decided by upperCaseEquality)
+          (fumList should contain oneElementOf Seq("fee", "fum", "foe", "fu")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain oneElementOf Seq("fee", "fie", "foe", "fie", "fum")
@@ -112,14 +112,14 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FUM", "FOE", "FU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fee", "fum", "foe", "fu"))) (using decided by upperCaseEquality)
+          (fumList should (contain oneElementOf Seq("fee", "fum", "foe", "fu"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should (contain oneElementOf Seq("fee", "fie", "foe", "fie", "fum"))
@@ -159,13 +159,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (toList should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (toList should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -201,13 +201,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
+        (toList should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
+          (toList should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -234,13 +234,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+        (toList shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (toList shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -267,13 +267,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (toList shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (toList shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -344,14 +344,14 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain oneElementOf Seq("HI", "HE")) (using decided by upperCaseEquality)
+        (all (hiLists) should contain oneElementOf Seq("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneElementOf Seq("hi", "he")) (using decided by upperCaseEquality)
+          (all (hiLists) should contain oneElementOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain oneElementOf Seq("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain oneElementOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneElementOf Seq("ho", "he")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain oneElementOf Seq("ho", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -412,14 +412,14 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseEquality)
+          (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("ho", "he"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain oneElementOf Seq("ho", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -463,13 +463,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (all (toLists) should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (all (toLists) should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -515,13 +515,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
+        (all (toLists) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
+          (all (toLists) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -550,13 +550,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -585,13 +585,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneElementOfSpec.scala
@@ -72,14 +72,14 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain oneElementOf Seq("FEE", "FUM", "FOE", "FU")) (decided by upperCaseEquality)
+        (fumList should contain oneElementOf Seq("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain oneElementOf Seq("fee", "fum", "foe", "fu")) (decided by upperCaseEquality)
+          (fumList should contain oneElementOf Seq("fee", "fum", "foe", "fu")) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should contain oneElementOf Seq("fee", "fie", "foe", "fie", "fum")
@@ -112,14 +112,14 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneElementOf Seq("FEE", "FUM", "FOE", "FU"))) (decided by upperCaseEquality)
+        (fumList should (contain oneElementOf Seq("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain oneElementOf Seq("fee", "fum", "foe", "fu"))) (decided by upperCaseEquality)
+          (fumList should (contain oneElementOf Seq("fee", "fum", "foe", "fu"))) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumList should (contain oneElementOf Seq("fee", "fie", "foe", "fie", "fum"))
@@ -159,13 +159,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (toList should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (toList should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         toList should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -201,13 +201,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseEquality)
+        (toList should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseEquality)
+          (toList should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
         }
         toList should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -234,13 +234,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+        (toList shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (toList shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
         toList shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -267,13 +267,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (toList shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (toList shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         toList shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -344,14 +344,14 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain oneElementOf Seq("HI", "HE")) (decided by upperCaseEquality)
+        (all (hiLists) should contain oneElementOf Seq("HI", "HE")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneElementOf Seq("hi", "he")) (decided by upperCaseEquality)
+          (all (hiLists) should contain oneElementOf Seq("hi", "he")) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain oneElementOf Seq("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain oneElementOf Seq("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneElementOf Seq("ho", "he")) (decided by defaultEquality[String])
+          (all (hiLists) should contain oneElementOf Seq("ho", "he")) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -412,14 +412,14 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseEquality)
+        (all (hiLists) should (contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (decided by upperCaseEquality)
+          (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain oneElementOf Seq("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneElementOf Seq("ho", "he"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain oneElementOf Seq("ho", "he"))) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -463,13 +463,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (all (toLists) should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (all (toLists) should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         all (toLists) should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -515,13 +515,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseEquality)
+        (all (toLists) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseEquality)
+          (all (toLists) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
         }
         all (toLists) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -550,13 +550,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+        (all (toLists) shouldNot contain oneElementOf Seq("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (all (toLists) shouldNot contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
         all (toLists) shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -585,13 +585,13 @@ class ListShouldContainOneElementOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (all (toLists) shouldNot (contain oneElementOf Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain oneElementOf Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         all (toLists) shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain oneElementOf Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalAndSpec.scala
@@ -100,16 +100,16 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fee", "fie", "foe", "fum") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fee", "fie", "foe", "fum") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -157,16 +157,16 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain oneOf ("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -207,16 +207,16 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -257,16 +257,16 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -307,16 +307,16 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -364,16 +364,16 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -414,16 +414,16 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -510,14 +510,14 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("hi", "he") and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneOf ("hi", "he") and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -597,14 +597,14 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi")) and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -665,14 +665,14 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneOf ("hi", "he") and not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("hi", "he") and not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneOf ("HI", "HE") and not contain oneOf ("HO", "HEY", "HOWDY"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneOf ("HI", "HE") and not contain oneOf ("HO", "HEY", "HOWDY"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneOf ("HO", "HEY", "HOWDY") and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneOf ("HO", "HEY", "HOWDY") and not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"HO\", \"HEY\", \"HOWDY\"")) + ", but " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -740,14 +740,14 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) and not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " +  FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalAndSpec.scala
@@ -100,16 +100,16 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fee", "fie", "foe", "fum") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fee", "fie", "foe", "fum") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -157,16 +157,16 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -207,16 +207,16 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -257,16 +257,16 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -307,16 +307,16 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") and not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") and contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -364,16 +364,16 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -414,16 +414,16 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") and not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -510,14 +510,14 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("hi", "he") and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneOf ("hi", "he") and contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneOf ("HI", "HE") and contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -597,14 +597,14 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) and contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) and contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi")) and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi")) and contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -665,14 +665,14 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneOf ("hi", "he") and not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("hi", "he") and not contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneOf ("HI", "HE") and not contain oneOf ("HO", "HEY", "HOWDY"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneOf ("HI", "HE") and not contain oneOf ("HO", "HEY", "HOWDY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneOf ("HO", "HEY", "HOWDY") and not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneOf ("HO", "HEY", "HOWDY") and not contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"HO\", \"HEY\", \"HOWDY\"")) + ", but " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -740,14 +740,14 @@ class ListShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) and not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) and not contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " +  FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalOrSpec.scala
@@ -96,14 +96,14 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -147,14 +147,14 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -191,14 +191,14 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -235,14 +235,14 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -279,14 +279,14 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -330,14 +330,14 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -374,14 +374,14 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -441,12 +441,12 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("HO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("ho", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("ho", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"ho\", \"hi\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -495,12 +495,12 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho")) or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -542,12 +542,12 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", and " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -596,12 +596,12 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi")) or not contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi")) or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) or not contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfLogicalOrSpec.scala
@@ -96,14 +96,14 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -147,14 +147,14 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -191,14 +191,14 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -235,14 +235,14 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain oneOf ("fie", "fee", "fum", "foe") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumList), "\"fie\", \"fee\", \"fum\", \"foe\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -279,14 +279,14 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("fee", "fie", "foe", "fum") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain oneOf ("FEE", "FIE", "FOE", "FUM") or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ") or contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -330,14 +330,14 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain oneOf ("fie", "fee", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -374,14 +374,14 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU ") or not contain oneOf (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -441,12 +441,12 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("HO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE") or contain oneOf ("ho", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("ho", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain oneOf ("hi", "he") or contain oneOf ("ho", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"ho\", \"hi\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -495,12 +495,12 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi")) or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho")) or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi")) or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho")) or contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi")) or contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho")) or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho")) or contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, hiLists(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -542,12 +542,12 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain oneOf ("hi", "he") or not contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain oneOf ("HI", "HE") or not contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")) + ", and " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -596,12 +596,12 @@ class ListShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi")) or not contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("ho")) or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi")) or not contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) or not contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi")) or not contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi")) or not contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi")) + " was equal to " + decorateToStringValue(prettifier, List("hi")) + ", and " + FailureMessages.containedOneOfElements(prettifier, hiLists(0), UnquotedString("\"HI\", \"HE\"")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfSpec.scala
@@ -74,14 +74,14 @@ class ListShouldContainOneOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain oneOf ("FEE", "FUM", "FOE", "FU")) (decided by upperCaseEquality)
+        (fumList should contain oneOf ("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain oneOf ("fee", "fum", "foe", "fu")) (decided by upperCaseEquality)
+          (fumList should contain oneOf ("fee", "fum", "foe", "fu")) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -119,14 +119,14 @@ class ListShouldContainOneOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FUM", "FOE", "FU"))) (decided by upperCaseEquality)
+        (fumList should (contain oneOf ("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fee", "fum", "foe", "fu"))) (decided by upperCaseEquality)
+          (fumList should (contain oneOf ("fee", "fum", "foe", "fu"))) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -171,13 +171,13 @@ class ListShouldContainOneOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain oneOf ("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+        (toList should not contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (toList should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
         toList should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -218,13 +218,13 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (toList should (not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (toList should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         toList should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -256,13 +256,13 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain oneOf ("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+        (toList shouldNot contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (toList shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
         toList shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -294,13 +294,13 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (toList shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (toList shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         toList shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -376,14 +376,14 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain oneOf ("HI", "HE")) (decided by upperCaseEquality)
+        (all (hiLists) should contain oneOf ("HI", "HE")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneOf ("hi", "he")) (decided by upperCaseEquality)
+          (all (hiLists) should contain oneOf ("hi", "he")) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain oneOf ("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain oneOf ("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneOf ("ho", "he")) (decided by defaultEquality[String])
+          (all (hiLists) should contain oneOf ("ho", "he")) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -449,14 +449,14 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneOf ("HI", "HE"))) (decided by upperCaseEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("hi", "he"))) (decided by upperCaseEquality)
+          (all (hiLists) should (contain oneOf ("hi", "he"))) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain oneOf ("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain oneOf ("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("ho", "he"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain oneOf ("ho", "he"))) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -505,13 +505,13 @@ scala> all (list1s) should (contain (oneOf (1, 3, 4)))
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain oneOf ("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+        (all (toLists) should not contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (all (toLists) should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
         all (toLists) should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -562,13 +562,13 @@ The top two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (all (toLists) should (not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (all (toLists) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         all (toLists) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -602,13 +602,13 @@ The top two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain oneOf ("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+        (all (toLists) shouldNot contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (all (toLists) shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
         all (toLists) shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -642,13 +642,13 @@ The top two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (all (toLists) shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         all (toLists) shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOneOfSpec.scala
@@ -74,14 +74,14 @@ class ListShouldContainOneOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain oneOf ("FEE", "FUM", "FOE", "FU")) (using decided by upperCaseEquality)
+        (fumList should contain oneOf ("FEE", "FUM", "FOE", "FU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should contain oneOf ("fee", "fum", "foe", "fu")) (using decided by upperCaseEquality)
+          (fumList should contain oneOf ("fee", "fum", "foe", "fu")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -119,14 +119,14 @@ class ListShouldContainOneOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain oneOf ("FEE", "FUM", "FOE", "FU"))) (using decided by upperCaseEquality)
+        (fumList should (contain oneOf ("FEE", "FUM", "FOE", "FU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumList should (contain oneOf ("fee", "fum", "foe", "fu"))) (using decided by upperCaseEquality)
+          (fumList should (contain oneOf ("fee", "fum", "foe", "fu"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -171,13 +171,13 @@ class ListShouldContainOneOfSpec extends AnyFunSpec with Matchers {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+        (toList should not contain oneOf ("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (toList should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -218,13 +218,13 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (toList should (not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (toList should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -256,13 +256,13 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+        (toList shouldNot contain oneOf ("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (toList shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -294,13 +294,13 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (toList shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (toList shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toList shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -376,14 +376,14 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain oneOf ("HI", "HE")) (using decided by upperCaseEquality)
+        (all (hiLists) should contain oneOf ("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneOf ("hi", "he")) (using decided by upperCaseEquality)
+          (all (hiLists) should contain oneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should contain oneOf ("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain oneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain oneOf ("ho", "he")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain oneOf ("ho", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -449,14 +449,14 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain oneOf ("HI", "HE"))) (using decided by upperCaseEquality)
+        (all (hiLists) should (contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("hi", "he"))) (using decided by upperCaseEquality)
+          (all (hiLists) should (contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiLists) should (contain oneOf ("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain oneOf ("ho", "he"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain oneOf ("ho", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -505,13 +505,13 @@ scala> all (list1s) should (contain (oneOf (1, 3, 4)))
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+        (all (toLists) should not contain oneOf ("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (all (toLists) should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -562,13 +562,13 @@ The top two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (all (toLists) should (not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (all (toLists) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -602,13 +602,13 @@ The top two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot contain oneOf ("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -642,13 +642,13 @@ The top two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (all (toLists) shouldNot (contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (all (toLists) shouldNot (contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toLists) shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalAndSpec.scala
@@ -95,16 +95,16 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -195,16 +195,16 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FAM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -270,16 +270,16 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain only ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain only ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -345,16 +345,16 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -420,16 +420,16 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\"") + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain only ("FIE", "FEE", "FUM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain only ("FIE", "FEE", "FUM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -504,16 +504,16 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -570,16 +570,16 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -664,14 +664,14 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HO", "HELLO") and contain only ("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HO", "HELLO") and contain only ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")" + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -800,14 +800,14 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "hello")) and contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) and contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "hello")) and contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi", "hello")) and contain only ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -903,14 +903,14 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain only ("HI") and not contain only ("HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HI") and not contain only ("HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain only ("HELLO", "HI") and not contain only ("HO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain only ("HELLO", "HI") and not contain only ("HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain only ("HI") and not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain only ("HI") and not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HI\")" + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -1016,14 +1016,14 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain only ("HO", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain only ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) and not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) and not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain only ("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain only ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalAndSpec.scala
@@ -95,16 +95,16 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") and contain only ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") and contain only ("FEE", "FIE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -195,16 +195,16 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain only ("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -270,16 +270,16 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain only ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain only ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"happy\", \"birthday\", \"to\", \"you\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain only ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -345,16 +345,16 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\"") + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -420,16 +420,16 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain only ("FIE", "FEE", "FAM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\"") + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain only ("FIE", "FEE", "FUM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain only ("FIE", "FEE", "FUM", "FOE") and not contain only ("FIE", "FEE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") and contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -504,16 +504,16 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -570,16 +570,16 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") and not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
 
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -664,14 +664,14 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HO", "HELLO") and contain only ("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HO", "HELLO") and contain only ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HELLO", "HI") and contain only ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")" + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -800,14 +800,14 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "hello")) and contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) and contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "hello")) and contain only ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi", "hello")) and contain only ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HO\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -903,14 +903,14 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain only ("HI") and not contain only ("HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HI") and not contain only ("HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain only ("HELLO", "HI") and not contain only ("HO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain only ("HELLO", "HI") and not contain only ("HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain only ("HI") and not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain only ("HI") and not contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HI\")" + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -1016,14 +1016,14 @@ class ListShouldContainOnlyLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain only ("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain only ("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) and not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) and not contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain only ("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain only ("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HI\", \"HELLO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalOrSpec.scala
@@ -91,14 +91,14 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -181,14 +181,14 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain only Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain only Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -250,14 +250,14 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -319,14 +319,14 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -388,14 +388,14 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -462,14 +462,14 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -522,14 +522,14 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -605,12 +605,12 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")" + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"hello\", \"ho\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -698,12 +698,12 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "hello")) or contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "hello")) or contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain only ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain only ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -770,12 +770,12 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")" + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"hello\", \"hi\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -847,12 +847,12 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "hi")) or not contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain only ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "hi")) or not contain only ("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) or not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) or not contain only ("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlyLogicalOrSpec.scala
@@ -91,14 +91,14 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -181,14 +181,14 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain only Set(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain only Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -250,14 +250,14 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain only ("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FAM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -319,14 +319,14 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain only ("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FAM\"") + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -388,14 +388,14 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain only ("FEE", "FIE", "FOE", "FUU") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain only ("FEE", "FIE", "FOE", "FUM") or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", and " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM ") or contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -462,14 +462,14 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain only ("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FIE\", \"FEE\", \"FUM\", \"FOE\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -522,14 +522,14 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain only ("FIE", "FEE", "FUU", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedOnlyElements(decorateToStringValue(prettifier, fumList), "\"FEE\", \"FIE\", \"FOE\", \"FUM\""), fileName, thisLineNumber - 2)
-        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain only (" FEE ", " FIE ", " FOE ", " FUU ") or not contain only (" FEE ", " FIE ", " FOE ", " FUU "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
       
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -605,12 +605,12 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HELLO", "HI") or contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HELLO", "HO") or contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")" + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"hello\", \"ho\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -698,12 +698,12 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "hello")) or contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "hello")) or contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain only " + "(\"HELLO\", \"HO\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -770,12 +770,12 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain only ("HELLO", "HO") or not contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain only ("HELLO", "HI") or not contain only ("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")" + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"hello\", \"hi\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -847,12 +847,12 @@ class ListShouldContainOnlyLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "hi")) or not contain only ("HELLO", "HO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "hi")) or not contain only ("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) or not contain only ("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) or not contain only ("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained only " + "(\"HELLO\", \"HI\")", thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlySpec.scala
@@ -75,14 +75,14 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain only ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList should contain only ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain only ("fee", "fie", "foe")) (decided by upperCaseStringEquality)
+          (fumList should contain only ("fee", "fie", "foe")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain only (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain only (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain only (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         if (ScalaTestVersions.BuiltForScalaVersion != "2.13" && !ScalaTestVersions.BuiltForScalaVersion.startsWith("3.")) {  // For 2.13 and 3.x, the compiler will pass in args with single argument ().
@@ -166,14 +166,14 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain only ("fee", "fie", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (contain only ("fee", "fie", "foe"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         if (ScalaTestVersions.BuiltForScalaVersion != "2.13" && !ScalaTestVersions.BuiltForScalaVersion.startsWith("3.")) { // For 2.13 and 3.x, the compiler will pass in args with single argument ().
@@ -289,13 +289,13 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain only ("NICE", "TO", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (toList should (not contain only ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList should (not contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should (not contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -343,13 +343,13 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain only ("happy", "birthday", "to")) (decided by upperCaseStringEquality)
+        (toList shouldNot contain only ("happy", "birthday", "to")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain only ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseStringEquality)
+          (toList shouldNot contain only ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toList shouldNot contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -407,13 +407,13 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain only ("NICE", "TO", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain only ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -502,14 +502,14 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain only ("HE", "HI")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain only ("HE", "HI")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain only ("HO", "HI")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain only ("HO", "HI")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain only ("he", "hi")) (decided by defaultEquality[String])
+        (all (hiLists) should contain only ("he", "hi")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain only ("ho", "hi")) (decided by defaultEquality[String])
+          (all (hiLists) should contain only ("ho", "hi")) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -591,14 +591,14 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain only ("HE", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HE", "HI"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HO", "HI"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain only ("he", "hi"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain only ("he", "hi"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("ho", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain only ("ho", "hi"))) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -659,13 +659,13 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain only ("NICE", "MEET", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain only ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain only ("YOU", "TO")) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain only ("YOU", "TO")) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain only (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain only (" YOU ", " TO ")) (after being lowerCased and trimmed)
+          (all (toLists) should not contain only (" YOU ", " TO ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -717,13 +717,13 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain only ("NICE", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain only ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain only ("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain only ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain only (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain only (" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain only (" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -775,13 +775,13 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain only ("NICE", "MEET", "YOU")) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain only ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain only ("YOU", "TO")) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain only ("YOU", "TO")) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain only (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain only (" YOU ", " TO ")) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain only (" YOU ", " TO ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -842,13 +842,13 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain only ("NICE", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain only ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain only ("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain only ("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain only (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain only (" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain only (" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainOnlySpec.scala
@@ -75,14 +75,14 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain only ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList should contain only ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain only ("fee", "fie", "foe")) (using decided by upperCaseStringEquality)
+          (fumList should contain only ("fee", "fie", "foe")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain only (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain only (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain only (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         if (ScalaTestVersions.BuiltForScalaVersion != "2.13" && !ScalaTestVersions.BuiltForScalaVersion.startsWith("3.")) {  // For 2.13 and 3.x, the compiler will pass in args with single argument ().
@@ -166,14 +166,14 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain only ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain only ("fee", "fie", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain only ("fee", "fie", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain only (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
         if (ScalaTestVersions.BuiltForScalaVersion != "2.13" && !ScalaTestVersions.BuiltForScalaVersion.startsWith("3.")) { // For 2.13 and 3.x, the compiler will pass in args with single argument ().
@@ -289,13 +289,13 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain only ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (toList should (not contain only ("NICE", "TO", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList should (not contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should (not contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should (not contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -343,13 +343,13 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain only ("happy", "birthday", "to")) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain only ("happy", "birthday", "to")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain only ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain only ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toList shouldNot contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toList shouldNot contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -407,13 +407,13 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain only ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain only ("NICE", "TO", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain only ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot (contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain only (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -502,14 +502,14 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain only ("HE", "HI")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain only ("HE", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain only ("HO", "HI")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain only ("HO", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain only ("he", "hi")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain only ("he", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain only ("ho", "hi")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain only ("ho", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -591,14 +591,14 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain only ("HE", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain only ("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("HO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain only ("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain only ("he", "hi"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain only ("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain only ("ho", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain only ("ho", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -659,13 +659,13 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain only ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain only ("NICE", "MEET", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain only ("YOU", "TO")) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain only ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain only (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) should not contain only (" YOU ", " TO ")) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain only (" YOU ", " TO ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -717,13 +717,13 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain only ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain only ("NICE", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain only ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain only ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain only (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain only (" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain only (" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -775,13 +775,13 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain only ("NICE", "MEET", "YOU")) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain only ("NICE", "MEET", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain only ("YOU", "TO")) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain only ("YOU", "TO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain only (" YOU ", " TO ")
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain only (" YOU ", " TO ")) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain only (" YOU ", " TO ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {
@@ -842,13 +842,13 @@ class ListShouldContainOnlySpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain only ("NICE", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain only ("NICE", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain only ("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain only ("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain only (" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain only (" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain only (" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS is empty") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainSpec.scala
@@ -77,15 +77,15 @@ class ListShouldContainSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           caseLists should contain ("HI")
         }
-        (caseLists should contain ("HI")) (decided by defaultEquality afterBeing lowerCased)
-        (caseLists should contain ("HI")) (after being lowerCased)
-        (caseLists should contain ("HI ")) (after being lowerCased and trimmed)
+        (caseLists should contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
+        (caseLists should contain ("HI")) (using after being lowerCased)
+        (caseLists should contain ("HI ")) (using after being lowerCased and trimmed)
         
         {
           implicit val e = new Equality[String] {
             def areEqual(a: String, b: Any): Boolean = a != b
           }
-          (xs should contain ("hi")) (decided by defaultEquality[String])
+          (xs should contain ("hi")) (using decided by defaultEquality[String])
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -165,13 +165,13 @@ class ListShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists should not contain "HI"
         caseLists should not contain "HI "
-        (caseLists should not contain "HI ") (decided by defaultEquality afterBeing lowerCased)
-        (caseLists should not contain "HI ") (after being lowerCased)
+        (caseLists should not contain "HI ") (using decided by defaultEquality afterBeing lowerCased)
+        (caseLists should not contain "HI ") (using after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists should not contain "HI") (decided by defaultEquality afterBeing lowerCased)
+          (caseLists should not contain "HI") (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should not contain "HI ") (after being lowerCased and trimmed)
+          (caseLists should not contain "HI ") (using after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -244,16 +244,16 @@ class ListShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists should not (contain ("HI"))
         caseLists should not (contain ("HI "))
-        (caseLists should not (contain ("HI "))) (decided by defaultEquality afterBeing lowerCased)
-        (caseLists should not (contain ("HI "))) (after being lowerCased)
+        (caseLists should not (contain ("HI "))) (using decided by defaultEquality afterBeing lowerCased)
+        (caseLists should not (contain ("HI "))) (using after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists should not (contain ("HI"))) (decided by defaultEquality afterBeing lowerCased)
+          (caseLists should not (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should not (contain ("HI"))) (after being lowerCased)
+          (caseLists should not (contain ("HI"))) (using after being lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should not (contain ("HI "))) (after being lowerCased and trimmed)
+          (caseLists should not (contain ("HI "))) (using after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -325,16 +325,16 @@ class ListShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists should (not contain "HI")
         caseLists should (not contain "HI ")
-        (caseLists should (not contain "HI ")) (decided by defaultEquality afterBeing lowerCased)
-        (caseLists should (not contain "HI ")) (after being lowerCased)
+        (caseLists should (not contain "HI ")) (using decided by defaultEquality afterBeing lowerCased)
+        (caseLists should (not contain "HI ")) (using after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists should (not contain "HI")) (decided by defaultEquality afterBeing lowerCased)
+          (caseLists should (not contain "HI")) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should (not contain "HI")) (after being lowerCased)
+          (caseLists should (not contain "HI")) (using after being lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should (not contain "HI ")) (after being lowerCased and trimmed)
+          (caseLists should (not contain "HI ")) (using after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -406,13 +406,13 @@ class ListShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists shouldNot contain ("HI")
         caseLists shouldNot contain ("HI ")
-        (caseLists shouldNot contain ("HI ")) (decided by defaultEquality afterBeing lowerCased)
-        (caseLists shouldNot contain ("HI ")) (after being lowerCased)
+        (caseLists shouldNot contain ("HI ")) (using decided by defaultEquality afterBeing lowerCased)
+        (caseLists shouldNot contain ("HI ")) (using after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists shouldNot contain ("HI")) (decided by defaultEquality afterBeing lowerCased)
+          (caseLists shouldNot contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists shouldNot contain ("HI ")) (after being lowerCased and trimmed)
+          (caseLists shouldNot contain ("HI ")) (using after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -485,16 +485,16 @@ class ListShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists shouldNot (contain ("HI"))
         caseLists shouldNot (contain ("HI "))
-        (caseLists shouldNot (contain ("HI "))) (decided by defaultEquality afterBeing lowerCased)
-        (caseLists shouldNot (contain ("HI "))) (after being lowerCased)
+        (caseLists shouldNot (contain ("HI "))) (using decided by defaultEquality afterBeing lowerCased)
+        (caseLists shouldNot (contain ("HI "))) (using after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists shouldNot (contain ("HI"))) (decided by defaultEquality afterBeing lowerCased)
+          (caseLists shouldNot (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists shouldNot (contain ("HI"))) (after being lowerCased)
+          (caseLists shouldNot (contain ("HI"))) (using after being lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists shouldNot (contain ("HI "))) (after being lowerCased and trimmed)
+          (caseLists shouldNot (contain ("HI "))) (using after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -612,8 +612,8 @@ class ListShouldContainSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           all (hiLists) should contain ("HI ")
         }
-        (all (hiLists) should contain ("HI")) (decided by defaultEquality afterBeing lowerCased)
-        (all (hiLists) should contain ("HI ")) (after being trimmed and lowerCased)
+        (all (hiLists) should contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
+        (all (hiLists) should contain ("HI ")) (using after being trimmed and lowerCased)
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
         val hiHeHoLists: List[List[String]] = List(List("hi", "he", "ho"), List("hi", "he", "ho"), List("hi", "he", "ho"))
@@ -708,10 +708,10 @@ class ListShouldContainSpec extends AnyFunSpec {
         all (hiLists) should not contain "HI"
         all (hiLists) should not contain "HI "
         intercept[TestFailedException] {
-          (all (hiLists) should not contain "HI") (decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) should not contain "HI") (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) should not contain "HI ") (after being trimmed and lowerCased)
+          (all (hiLists) should not contain "HI ") (using after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -775,10 +775,10 @@ class ListShouldContainSpec extends AnyFunSpec {
         all (hiLists) should not (contain ("HI"))
         all (hiLists) should not (contain ("HI "))
         intercept[TestFailedException] {
-          (all (hiLists) should not (contain ("HI"))) (decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) should not (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) should not (contain ("HI "))) (after being trimmed and lowerCased)
+          (all (hiLists) should not (contain ("HI "))) (using after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -842,10 +842,10 @@ class ListShouldContainSpec extends AnyFunSpec {
         all (hiLists) should (not contain "HI")
         all (hiLists) should (not contain "HI ")
         intercept[TestFailedException] {
-          (all (hiLists) should (not contain "HI")) (decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) should (not contain "HI")) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) should (not contain "HI ")) (after being trimmed and lowerCased)
+          (all (hiLists) should (not contain "HI ")) (using after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -910,10 +910,10 @@ class ListShouldContainSpec extends AnyFunSpec {
         all (hiLists) shouldNot contain ("HI")
         all (hiLists) shouldNot contain ("HI ")
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot contain ("HI")) (decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) shouldNot contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot contain ("HI ")) (after being trimmed and lowerCased)
+          (all (hiLists) shouldNot contain ("HI ")) (using after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -977,10 +977,10 @@ class ListShouldContainSpec extends AnyFunSpec {
         all (hiLists) shouldNot (contain ("HI"))
         all (hiLists) shouldNot (contain ("HI "))
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot (contain ("HI"))) (decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) shouldNot (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot (contain ("HI "))) (after being trimmed and lowerCased)
+          (all (hiLists) shouldNot (contain ("HI "))) (using after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainSpec.scala
@@ -77,15 +77,15 @@ class ListShouldContainSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           caseLists should contain ("HI")
         }
-        (caseLists should contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
-        (caseLists should contain ("HI")) (using after being lowerCased)
-        (caseLists should contain ("HI ")) (using after being lowerCased and trimmed)
+        (caseLists should contain ("HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (caseLists should contain ("HI")) (/* DOTTY-ONLY using */ after being lowerCased)
+        (caseLists should contain ("HI ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         
         {
           implicit val e = new Equality[String] {
             def areEqual(a: String, b: Any): Boolean = a != b
           }
-          (xs should contain ("hi")) (using decided by defaultEquality[String])
+          (xs should contain ("hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -165,13 +165,13 @@ class ListShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists should not contain "HI"
         caseLists should not contain "HI "
-        (caseLists should not contain "HI ") (using decided by defaultEquality afterBeing lowerCased)
-        (caseLists should not contain "HI ") (using after being lowerCased)
+        (caseLists should not contain "HI ") (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (caseLists should not contain "HI ") (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists should not contain "HI") (using decided by defaultEquality afterBeing lowerCased)
+          (caseLists should not contain "HI") (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should not contain "HI ") (using after being lowerCased and trimmed)
+          (caseLists should not contain "HI ") (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -244,16 +244,16 @@ class ListShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists should not (contain ("HI"))
         caseLists should not (contain ("HI "))
-        (caseLists should not (contain ("HI "))) (using decided by defaultEquality afterBeing lowerCased)
-        (caseLists should not (contain ("HI "))) (using after being lowerCased)
+        (caseLists should not (contain ("HI "))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (caseLists should not (contain ("HI "))) (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists should not (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
+          (caseLists should not (contain ("HI"))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should not (contain ("HI"))) (using after being lowerCased)
+          (caseLists should not (contain ("HI"))) (/* DOTTY-ONLY using */ after being lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should not (contain ("HI "))) (using after being lowerCased and trimmed)
+          (caseLists should not (contain ("HI "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -325,16 +325,16 @@ class ListShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists should (not contain "HI")
         caseLists should (not contain "HI ")
-        (caseLists should (not contain "HI ")) (using decided by defaultEquality afterBeing lowerCased)
-        (caseLists should (not contain "HI ")) (using after being lowerCased)
+        (caseLists should (not contain "HI ")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (caseLists should (not contain "HI ")) (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists should (not contain "HI")) (using decided by defaultEquality afterBeing lowerCased)
+          (caseLists should (not contain "HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should (not contain "HI")) (using after being lowerCased)
+          (caseLists should (not contain "HI")) (/* DOTTY-ONLY using */ after being lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists should (not contain "HI ")) (using after being lowerCased and trimmed)
+          (caseLists should (not contain "HI ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -406,13 +406,13 @@ class ListShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists shouldNot contain ("HI")
         caseLists shouldNot contain ("HI ")
-        (caseLists shouldNot contain ("HI ")) (using decided by defaultEquality afterBeing lowerCased)
-        (caseLists shouldNot contain ("HI ")) (using after being lowerCased)
+        (caseLists shouldNot contain ("HI ")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (caseLists shouldNot contain ("HI ")) (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists shouldNot contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
+          (caseLists shouldNot contain ("HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists shouldNot contain ("HI ")) (using after being lowerCased and trimmed)
+          (caseLists shouldNot contain ("HI ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -485,16 +485,16 @@ class ListShouldContainSpec extends AnyFunSpec {
       it("should use an explicitly provided Equality") {
         caseLists shouldNot (contain ("HI"))
         caseLists shouldNot (contain ("HI "))
-        (caseLists shouldNot (contain ("HI "))) (using decided by defaultEquality afterBeing lowerCased)
-        (caseLists shouldNot (contain ("HI "))) (using after being lowerCased)
+        (caseLists shouldNot (contain ("HI "))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (caseLists shouldNot (contain ("HI "))) (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (caseLists shouldNot (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
+          (caseLists shouldNot (contain ("HI"))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists shouldNot (contain ("HI"))) (using after being lowerCased)
+          (caseLists shouldNot (contain ("HI"))) (/* DOTTY-ONLY using */ after being lowerCased)
         }
         intercept[TestFailedException] {
-          (caseLists shouldNot (contain ("HI "))) (using after being lowerCased and trimmed)
+          (caseLists shouldNot (contain ("HI "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -612,8 +612,8 @@ class ListShouldContainSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           all (hiLists) should contain ("HI ")
         }
-        (all (hiLists) should contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
-        (all (hiLists) should contain ("HI ")) (using after being trimmed and lowerCased)
+        (all (hiLists) should contain ("HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (all (hiLists) should contain ("HI ")) (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
         val hiHeHoLists: List[List[String]] = List(List("hi", "he", "ho"), List("hi", "he", "ho"), List("hi", "he", "ho"))
@@ -708,10 +708,10 @@ class ListShouldContainSpec extends AnyFunSpec {
         all (hiLists) should not contain "HI"
         all (hiLists) should not contain "HI "
         intercept[TestFailedException] {
-          (all (hiLists) should not contain "HI") (using decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) should not contain "HI") (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) should not contain "HI ") (using after being trimmed and lowerCased)
+          (all (hiLists) should not contain "HI ") (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -775,10 +775,10 @@ class ListShouldContainSpec extends AnyFunSpec {
         all (hiLists) should not (contain ("HI"))
         all (hiLists) should not (contain ("HI "))
         intercept[TestFailedException] {
-          (all (hiLists) should not (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) should not (contain ("HI"))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) should not (contain ("HI "))) (using after being trimmed and lowerCased)
+          (all (hiLists) should not (contain ("HI "))) (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -842,10 +842,10 @@ class ListShouldContainSpec extends AnyFunSpec {
         all (hiLists) should (not contain "HI")
         all (hiLists) should (not contain "HI ")
         intercept[TestFailedException] {
-          (all (hiLists) should (not contain "HI")) (using decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) should (not contain "HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) should (not contain "HI ")) (using after being trimmed and lowerCased)
+          (all (hiLists) should (not contain "HI ")) (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -910,10 +910,10 @@ class ListShouldContainSpec extends AnyFunSpec {
         all (hiLists) shouldNot contain ("HI")
         all (hiLists) shouldNot contain ("HI ")
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) shouldNot contain ("HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot contain ("HI ")) (using after being trimmed and lowerCased)
+          (all (hiLists) shouldNot contain ("HI ")) (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -977,10 +977,10 @@ class ListShouldContainSpec extends AnyFunSpec {
         all (hiLists) shouldNot (contain ("HI"))
         all (hiLists) shouldNot (contain ("HI "))
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
+          (all (hiLists) shouldNot (contain ("HI"))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiLists) shouldNot (contain ("HI "))) (using after being trimmed and lowerCased)
+          (all (hiLists) shouldNot (contain ("HI "))) (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalAndSpec.scala
@@ -95,16 +95,16 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FUM"))) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -136,16 +136,16 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
 
@@ -177,16 +177,16 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
 
@@ -218,16 +218,16 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))) + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
 
@@ -259,16 +259,16 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -300,16 +300,16 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -341,16 +341,16 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -417,14 +417,14 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HO", "HELLO") and contain theSameElementsAs Set("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HO", "HELLO") and contain theSameElementsAs Set("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -488,14 +488,14 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -547,14 +547,14 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) and not contain theSameElementsAs (Set("HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) and not contain theSameElementsAs (Set("HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HI")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -606,14 +606,14 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalAndSpec.scala
@@ -95,16 +95,16 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") and contain theSameElementsAs Set("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") and contain theSameElementsAs Set("FEE", "FIE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FUM"))) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -136,16 +136,16 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
 
@@ -177,16 +177,16 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain theSameElementsAs Set("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("happy", "birthday", "to", "you"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
     }
 
@@ -218,16 +218,16 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))) + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and be (fumList))) (using after being lowerCased and trimmed)
       }
     }
 
@@ -259,16 +259,16 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")) and not contain theSameElementsAs (Set("FIE", "FEE", "FOE", "FAM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") and contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -300,16 +300,16 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -341,16 +341,16 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
 
@@ -417,14 +417,14 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HO", "HELLO") and contain theSameElementsAs Set("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HO", "HELLO") and contain theSameElementsAs Set("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HO", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") and contain theSameElementsAs Set("HO", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -488,14 +488,14 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsAs Set("HO", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -547,14 +547,14 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) and not contain theSameElementsAs (Set("HO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) and not contain theSameElementsAs (Set("HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsAs (Set("HI")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HI")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -606,14 +606,14 @@ class ListShouldContainTheSameElementsAsLogicalAndSpec extends AnyFunSpec {
       }
 
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HO", "HELLO")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain theSameElementsAs (Set("HI", "HELLO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalOrSpec.scala
@@ -91,14 +91,14 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -126,14 +126,14 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
     
@@ -161,14 +161,14 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
 
@@ -196,14 +196,14 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
     
@@ -231,14 +231,14 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -266,14 +266,14 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -301,14 +301,14 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -359,12 +359,12 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "hi"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HO")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("hello", "ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -397,12 +397,12 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -435,12 +435,12 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "ho")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "ho")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("hello", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -473,12 +473,12 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsLogicalOrSpec.scala
@@ -91,14 +91,14 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -126,14 +126,14 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain theSameElementsAs (Set("FIE", "FEE", "FAM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
     
@@ -161,14 +161,14 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
     }
 
@@ -196,14 +196,14 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FAM", "FOE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FIE", "FEE", "FUM", "FOE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FAM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FAM"))) + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or be (fumList))) (using after being lowerCased and trimmed)
       }
     }
     
@@ -231,14 +231,14 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUU")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ") or contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -266,14 +266,14 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUM", "FOE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FIE", "FEE", "FUM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -301,14 +301,14 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FIE", "FEE", "FUU", "FOE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain theSameElementsAs (Set("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedSameElements(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, Set("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -359,12 +359,12 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "hi"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "hi"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HI") or contain theSameElementsAs Set("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HELLO", "HO") or contain theSameElementsAs Set("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HO")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("hello", "ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -397,12 +397,12 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsAs Set("HELLO", "HO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -435,12 +435,12 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "ho")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "ho")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "ho")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HO")) or not contain theSameElementsAs (Set("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsAs (Set("HELLO", "HI")) or not contain theSameElementsAs (Set("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("hello", "hi")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -473,12 +473,12 @@ class ListShouldContainTheSameElementsAsLogicalOrSpec extends AnyFunSpec {
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "hi")) or not contain theSameElementsAs (Set("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsAs (Set("HELLO", "HI")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements as " + decorateToStringValue(prettifier, Set("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsSpec.scala
@@ -75,14 +75,14 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseStringEquality)
+        (fumList should contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain theSameElementsAs Set("fee", "fie", "foe")) (decided by upperCaseStringEquality)
+          (fumList should contain theSameElementsAs Set("fee", "fie", "foe")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumList should contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -112,14 +112,14 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("fee", "fie", "foe"))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("fee", "fie", "foe"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -178,13 +178,13 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (decided by upperCaseStringEquality)
+        (toList should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toList should (not contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList should (not contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -208,13 +208,13 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain theSameElementsAs (Set("happy", "birthday", "to"))) (decided by upperCaseStringEquality)
+        (toList shouldNot contain theSameElementsAs (Set("happy", "birthday", "to"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -238,13 +238,13 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -300,14 +300,14 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain theSameElementsAs Set("HE", "HI")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain theSameElementsAs Set("HE", "HI")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsAs Set("HO", "HI")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain theSameElementsAs Set("HO", "HI")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain theSameElementsAs Set("he", "hi")) (decided by defaultEquality[String])
+        (all (hiLists) should contain theSameElementsAs Set("he", "hi")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsAs Set("ho", "hi")) (decided by defaultEquality[String])
+          (all (hiLists) should contain theSameElementsAs Set("ho", "hi")) (using decided by defaultEquality[String])
         }
       }
     }
@@ -355,14 +355,14 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsAs Set("HE", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HE", "HI"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HO", "HI"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain theSameElementsAs Set("he", "hi"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain theSameElementsAs Set("he", "hi"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("ho", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain theSameElementsAs Set("ho", "hi"))) (using decided by defaultEquality[String])
         }
       }
     }
@@ -388,13 +388,13 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsAs (Set("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain theSameElementsAs (Set("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain theSameElementsAs (Set(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsAs (Set(" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) should not contain theSameElementsAs (Set(" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -420,13 +420,13 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsAs (Set("YOU", "TO")))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain theSameElementsAs (Set("YOU", "TO")))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain theSameElementsAs (Set(" YOU ", " TO ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsAs (Set(" YOU ", " TO ")))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain theSameElementsAs (Set(" YOU ", " TO ")))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -452,13 +452,13 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsAs (Set("YOU", "TO"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain theSameElementsAs (Set("YOU", "TO"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain theSameElementsAs (Set(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsAs (Set(" YOU ", " TO "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain theSameElementsAs (Set(" YOU ", " TO "))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -484,13 +484,13 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsAs (Set("YOU", "TO")))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain theSameElementsAs (Set("YOU", "TO")))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain theSameElementsAs (Set(" YOU ", " TO ")))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsAs (Set(" YOU ", " TO ")))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain theSameElementsAs (Set(" YOU ", " TO ")))) (using after being lowerCased and trimmed)
         }
       }
     }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsAsSpec.scala
@@ -75,14 +75,14 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseStringEquality)
+        (fumList should contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain theSameElementsAs Set("fee", "fie", "foe")) (using decided by upperCaseStringEquality)
+          (fumList should contain theSameElementsAs Set("fee", "fie", "foe")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumList should contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumList should contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -112,14 +112,14 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsAs Set("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain theSameElementsAs Set("fee", "fie", "foe"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsAs Set("fee", "fie", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsAs Set(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -178,13 +178,13 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
+        (toList should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toList should (not contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList should (not contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -208,13 +208,13 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain theSameElementsAs (Set("happy", "birthday", "to"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain theSameElementsAs (Set("happy", "birthday", "to"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -238,13 +238,13 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain theSameElementsAs (Set("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain theSameElementsAs (Set(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -300,14 +300,14 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain theSameElementsAs Set("HE", "HI")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain theSameElementsAs Set("HE", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsAs Set("HO", "HI")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain theSameElementsAs Set("HO", "HI")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain theSameElementsAs Set("he", "hi")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain theSameElementsAs Set("he", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsAs Set("ho", "hi")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain theSameElementsAs Set("ho", "hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
     }
@@ -355,14 +355,14 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsAs Set("HE", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsAs Set("HE", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("HO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsAs Set("HO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain theSameElementsAs Set("he", "hi"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain theSameElementsAs Set("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsAs Set("ho", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain theSameElementsAs Set("ho", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
     }
@@ -388,13 +388,13 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsAs (Set("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain theSameElementsAs (Set("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain theSameElementsAs (Set(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsAs (Set(" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain theSameElementsAs (Set(" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -420,13 +420,13 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsAs (Set("YOU", "TO")))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain theSameElementsAs (Set("YOU", "TO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain theSameElementsAs (Set(" YOU ", " TO ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsAs (Set(" YOU ", " TO ")))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain theSameElementsAs (Set(" YOU ", " TO ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -452,13 +452,13 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsAs (Set("YOU", "TO"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain theSameElementsAs (Set("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain theSameElementsAs (Set(" YOU ", " TO "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsAs (Set(" YOU ", " TO "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain theSameElementsAs (Set(" YOU ", " TO "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -484,13 +484,13 @@ class ListShouldContainTheSameElementsAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain theSameElementsAs (Set("NICE", "TO", "MEET", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsAs (Set("YOU", "TO")))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain theSameElementsAs (Set("YOU", "TO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain theSameElementsAs (Set(" YOU ", " TO ")))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsAs (Set(" YOU ", " TO ")))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain theSameElementsAs (Set(" YOU ", " TO ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
@@ -96,16 +96,16 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))) + ", but " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE ") and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE ") and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -137,16 +137,16 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
     
@@ -178,16 +178,16 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
 
@@ -219,16 +219,16 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))) + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
     
@@ -260,13 +260,13 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))) + ", but " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
@@ -300,13 +300,13 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
@@ -340,16 +340,16 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -416,14 +416,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HO", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HO", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -487,14 +487,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -546,14 +546,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) and not contain theSameElementsInOrderAs (ListBuffer("HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) and not contain theSameElementsInOrderAs (ListBuffer("HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -605,14 +605,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HO", "HELLO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HO", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalAndSpec.scala
@@ -96,16 +96,16 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))) + ", but " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE ") and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE ") and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -137,16 +137,16 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (toList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) and contain theSameElementsInOrderAs Set(" FUM ", " FOE ", " FIE ", " FEE "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
     
@@ -178,16 +178,16 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (be (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) and contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) and contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
     }
 
@@ -219,16 +219,16 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (fumList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (fumList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and be (fumList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") and be (fumList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") and be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))) + ", but " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") and be (fumList))) (using after being lowerCased and trimmed)
       }
     }
     
@@ -260,13 +260,13 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))) + ", but " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
@@ -300,13 +300,13 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", but " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
       }
@@ -340,16 +340,16 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (toList) and not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", but " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) and not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")) and not contain theSameElementsInOrderAs (ListBuffer(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -416,14 +416,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HO", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HO", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HO", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -487,14 +487,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("HI", "HELLO")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("HI", "HELLO")) and contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("hi", "hello")) and contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -546,14 +546,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) and not contain theSameElementsInOrderAs (ListBuffer("HO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) and not contain theSameElementsInOrderAs (ListBuffer("HO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -605,14 +605,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalAndSpec extends AnyFunSpec
       }
       
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (not be (List("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HO", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HO", "HELLO")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) and not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("ho")) and not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho")) + ", but " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
@@ -92,14 +92,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FIE", "FEE", "FAM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -127,14 +127,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
     
@@ -162,14 +162,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
 
@@ -197,14 +197,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (fumList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (toList))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
     }
     
@@ -232,11 +232,11 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))) + ", and " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
@@ -266,11 +266,11 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
@@ -300,14 +300,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -358,12 +358,12 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HO")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("hello", "ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -396,12 +396,12 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -434,12 +434,12 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -472,12 +472,12 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (using decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsLogicalOrSpec.scala
@@ -92,14 +92,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FIE", "FEE", "FAM", "FOE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or contain theSameElementsInOrderAs ListBuffer("FIE", "FEE", "FAM", "FOE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FIE", "FEE", "FAM", "FOE"))), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -127,14 +127,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (equal (toList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (equal (toList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (equal (fumList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (equal (fumList) or contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotEqual(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer(" FEE ", " FIE ", " FOE ", " FUM "))) (decided by invertedListOfStringEquality, after being lowerCased and trimmed)
+        (fumList should (equal (toList) or contain theSameElementsInOrderAs ListBuffer(" FEE ", " FIE ", " FOE ", " FUM "))) (using decided by invertedListOfStringEquality, after being lowerCased and trimmed)
       }
     }
     
@@ -162,14 +162,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumList should (be (toList) or contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))), fileName, thisLineNumber - 2)
-        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (be (fumList) or contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
     }
 
@@ -197,14 +197,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (fumList))) (decided by upperCaseStringEquality)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (toList))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (fumList))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE") or be (toList))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (toList))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("FEE", "FIE", "FOE", "FUM") or be (toList))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FEE", "FIE", "FOE", "FUM"))) + ", and " + Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)), fileName, thisLineNumber - 2)
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ") or be (fumList))) (using after being lowerCased and trimmed)
       }
     }
     
@@ -232,11 +232,11 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))) + ", and " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
@@ -266,11 +266,11 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
-        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+        (fumList should (not equal (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
+          (fumList should (not equal (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by invertedListOfStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.equaled(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, toList)) + ", and " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
       }
@@ -300,14 +300,14 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (decided by upperCaseStringEquality)
-        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FEE", "FIE", "FOE", "FUM")))) (using decided by upperCaseStringEquality)
+        (fumList should (not be (toList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (decided by upperCaseStringEquality)
+          (fumList should (not be (fumList) or not contain theSameElementsInOrderAs (ListBuffer("FUM", "FOE", "FIE", "FEE")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, fumList)) + ", and " + Resources.containedSameElementsInOrder(decorateToStringValue(prettifier, fumList), decorateToStringValue(prettifier, ListBuffer("FUM", "FOE", "FIE", "FEE"))), fileName, thisLineNumber - 2)
-        (fumList should (not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (after being lowerCased and trimmed, after being lowerCased and trimmed)
+        (fumList should (not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")) or not contain theSameElementsInOrderAs (Set(" FEE ", " FIE ", " FOE ", " FUU ")))) (using after being lowerCased and trimmed, after being lowerCased and trimmed)
       }
     }
     
@@ -358,12 +358,12 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hi", "hello"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HELLO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HELLO", "HO") or contain theSameElementsInOrderAs ListBuffer("hello", "ho"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HO")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("hello", "ho")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -396,12 +396,12 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HI", "HELLO"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (be (List("hi", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (be (List("ho", "hello")) or contain theSameElementsInOrderAs ListBuffer("HELLO", "HI"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was not equal to " + decorateToStringValue(prettifier, List("ho", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " did not contain the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HELLO", "HI")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -434,12 +434,12 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hello", "hi")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HI")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiLists) should (not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")) or not contain theSameElementsInOrderAs (ListBuffer("hi", "hello")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("hi", "hello")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }
@@ -472,12 +472,12 @@ class ListShouldContainTheSameElementsInOrderAsLogicalOrSpec extends AnyFreeSpec
       }
       
       "should use an explicitly provided Equality" in {
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (decided by upperCaseStringEquality)
-        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HELLO", "HO")))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (not be (List("hello", "ho")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (not be (List("hi", "hello")) or not contain theSameElementsInOrderAs (ListBuffer("HI", "HELLO")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, decorateToStringValue(prettifier, List("hi", "hello")) + " was equal to " + decorateToStringValue(prettifier, List("hi", "hello")) + ", and " + decorateToStringValue(prettifier, List("hi", "hello")) + " contained the same elements in the same (iterated) order as " + decorateToStringValue(prettifier, ListBuffer("HI", "HELLO")), thisLineNumber - 2, hiLists), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsSpec.scala
@@ -76,14 +76,14 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE")) (decided by upperCaseStringEquality)
+        (fumList should contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum")) (decided by upperCaseStringEquality)
+          (fumList should contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ")) (after being lowerCased and trimmed)
+        (fumList should contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -113,14 +113,14 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -149,13 +149,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList should not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList should not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList should not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -179,13 +179,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (decided by upperCaseStringEquality)
+        (toList should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toList should (not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         toList should (not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList should (not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -209,13 +209,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (decided by upperCaseStringEquality)
+        (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -239,13 +239,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (decided by upperCaseStringEquality)
+        (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         toList shouldNot (contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -301,14 +301,14 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HE")) (decided by upperCaseStringEquality)
+        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HE")) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HO")) (decided by upperCaseStringEquality)
+          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HO")) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "he")) (decided by defaultEquality[String])
+        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "ho")) (decided by defaultEquality[String])
+          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "ho")) (using decided by defaultEquality[String])
         }
       }
     }
@@ -356,14 +356,14 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HE"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HO"))) (decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HO"))) (using decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("he", "hi"))) (decided by defaultEquality[String])
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("he", "hi"))) (using decided by defaultEquality[String])
         }
       }
     }
@@ -389,13 +389,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -421,13 +421,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (decided by upperCaseStringEquality)
+        (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (decided by upperCaseStringEquality)
+          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -453,13 +453,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
     }
@@ -485,13 +485,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (using decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
     }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ListShouldContainTheSameElementsInOrderAsSpec.scala
@@ -76,14 +76,14 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE")) (using decided by upperCaseStringEquality)
+        (fumList should contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum")) (using decided by upperCaseStringEquality)
+          (fumList should contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ")
         }
-        (fumList should contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ")) (using after being lowerCased and trimmed)
+        (fumList should contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -113,14 +113,14 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (using decided by upperCaseStringEquality)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer("FUM", "FOE", "FIE", "FEE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (fumList should (contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality)
+          (fumList should (contain theSameElementsInOrderAs ListBuffer("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         intercept[TestFailedException] {
           fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))
         }
-        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (using after being lowerCased and trimmed)
+        (fumList should (contain theSameElementsInOrderAs ListBuffer(" FUM ", " FOE ", " FIE ", " FEE "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw TestFailedException with analysis showing escaped string") {
         val e1 = intercept[exceptions.TestFailedException] {
@@ -149,13 +149,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList should not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList should not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList should not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -179,13 +179,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (using decided by upperCaseStringEquality)
+        (toList should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toList should (not contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList should (not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList should (not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList should (not contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -209,13 +209,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (using decided by upperCaseStringEquality)
+        (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toList shouldNot contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -239,13 +239,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (using decided by upperCaseStringEquality)
+        (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO", "BIRTHDAY", "HAPPY")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         toList shouldNot (contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toList shouldNot (contain theSameElementsInOrderAs (ListBuffer(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -301,14 +301,14 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HE")) (using decided by upperCaseStringEquality)
+        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HO")) (using decided by upperCaseStringEquality)
+          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("HI", "HO")) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "ho")) (using decided by defaultEquality[String])
+          (all (hiLists) should contain theSameElementsInOrderAs ListBuffer("hi", "ho")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
     }
@@ -356,14 +356,14 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HO"))) (using decided by upperCaseStringEquality)
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("HI", "HO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         implicit val ise = upperCaseStringEquality
-        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("he", "hi"))) (using decided by defaultEquality[String])
+          (all (hiLists) should (contain theSameElementsInOrderAs ListBuffer("he", "hi"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
     }
@@ -389,13 +389,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) should not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -421,13 +421,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (using decided by upperCaseStringEquality)
+        (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (all (toLists) should (not contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -453,13 +453,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("YOU", "TO"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer("TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }
@@ -485,13 +485,13 @@ class ListShouldContainTheSameElementsInOrderAsSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (using decided by upperCaseStringEquality)
+        (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("YOU", "TO")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer("TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))
         intercept[TestFailedException] {
-          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (all (toLists) shouldNot (contain theSameElementsInOrderAs (ListBuffer(" TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
     }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/MatcherStackDepthSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/MatcherStackDepthSpec.scala
@@ -436,9 +436,9 @@ class MatcherStackDepthSpec extends AnyFunSuite with Matchers {
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
   }
 
-  test("""(List("Hi", "Di", "Ho") should contain ("dee")) (using after being lowerCased)""") {
+  test("""(List("Hi", "Di", "Ho") should contain ("dee")) (/* DOTTY-ONLY using */ after being lowerCased)""") {
     val e = intercept[exceptions.TestFailedException] {
-      (List("Hi", "Di", "Ho") should contain ("dee")) (using after being lowerCased)
+      (List("Hi", "Di", "Ho") should contain ("dee")) (/* DOTTY-ONLY using */ after being lowerCased)
     }
     e.failedCodeFileName should be (Some("MatcherStackDepthSpec.scala"))
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
@@ -476,9 +476,9 @@ class MatcherStackDepthSpec extends AnyFunSuite with Matchers {
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
   }
 
-  test("""(Array("Doe", "Re", "Me") should contain oneOf ("X", "RAY", "BEAM")) (using after being lowerCased)""") {
+  test("""(Array("Doe", "Re", "Me") should contain oneOf ("X", "RAY", "BEAM")) (/* DOTTY-ONLY using */ after being lowerCased)""") {
     val e = intercept[exceptions.TestFailedException] {
-      (Array("Doe", "Re", "Me") should contain oneOf ("X", "RAY", "BEAM")) (using after being lowerCased)
+      (Array("Doe", "Re", "Me") should contain oneOf ("X", "RAY", "BEAM")) (/* DOTTY-ONLY using */ after being lowerCased)
     }
     e.failedCodeFileName should be (Some("MatcherStackDepthSpec.scala"))
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
@@ -508,9 +508,9 @@ class MatcherStackDepthSpec extends AnyFunSuite with Matchers {
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
   }
 
-  test("""(Array("Doe", "Ray", "Me") should contain oneElementOf List("X", "RAX", "BEAM")) (using after being lowerCased)""") {
+  test("""(Array("Doe", "Ray", "Me") should contain oneElementOf List("X", "RAX", "BEAM")) (/* DOTTY-ONLY using */ after being lowerCased)""") {
     val e = intercept[exceptions.TestFailedException] {
-      (Array("Doe", "Ray", "Me") should contain oneElementOf List("X", "RAX", "BEAM")) (using after being lowerCased)
+      (Array("Doe", "Ray", "Me") should contain oneElementOf List("X", "RAX", "BEAM")) (/* DOTTY-ONLY using */ after being lowerCased)
     }
     e.failedCodeFileName should be (Some("MatcherStackDepthSpec.scala"))
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
@@ -590,9 +590,9 @@ class MatcherStackDepthSpec extends AnyFunSuite with Matchers {
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
   }
 
-  test("""(Vector(" A", "B ") should contain atLeastOneOf ("d ", "o", "g")) (using after being lowerCased and trimmed)""") {
+  test("""(Vector(" A", "B ") should contain atLeastOneOf ("d ", "o", "g")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)""") {
     val e = intercept[exceptions.TestFailedException] {
-      (Vector(" A", "B ") should contain atLeastOneOf ("d ", "o", "g")) (using after being lowerCased and trimmed)
+      (Vector(" A", "B ") should contain atLeastOneOf ("d ", "o", "g")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
     }
     e.failedCodeFileName should be (Some("MatcherStackDepthSpec.scala"))
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
@@ -622,9 +622,9 @@ class MatcherStackDepthSpec extends AnyFunSuite with Matchers {
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
   }
 
-  test("""(Vector(" A", "B ") should contain atLeastOneElementOf List("d ", "o", "g")) (using after being lowerCased and trimmed)""") {
+  test("""(Vector(" A", "B ") should contain atLeastOneElementOf List("d ", "o", "g")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)""") {
     val e = intercept[exceptions.TestFailedException] {
-      (Vector(" A", "B ") should contain atLeastOneElementOf List("d ", "o", "g")) (using after being lowerCased and trimmed)
+      (Vector(" A", "B ") should contain atLeastOneElementOf List("d ", "o", "g")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
     }
     e.failedCodeFileName should be (Some("MatcherStackDepthSpec.scala"))
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/MatcherStackDepthSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/MatcherStackDepthSpec.scala
@@ -436,9 +436,9 @@ class MatcherStackDepthSpec extends AnyFunSuite with Matchers {
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
   }
 
-  test("""(List("Hi", "Di", "Ho") should contain ("dee")) (after being lowerCased)""") {
+  test("""(List("Hi", "Di", "Ho") should contain ("dee")) (using after being lowerCased)""") {
     val e = intercept[exceptions.TestFailedException] {
-      (List("Hi", "Di", "Ho") should contain ("dee")) (after being lowerCased)
+      (List("Hi", "Di", "Ho") should contain ("dee")) (using after being lowerCased)
     }
     e.failedCodeFileName should be (Some("MatcherStackDepthSpec.scala"))
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
@@ -476,9 +476,9 @@ class MatcherStackDepthSpec extends AnyFunSuite with Matchers {
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
   }
 
-  test("""(Array("Doe", "Re", "Me") should contain oneOf ("X", "RAY", "BEAM")) (after being lowerCased)""") {
+  test("""(Array("Doe", "Re", "Me") should contain oneOf ("X", "RAY", "BEAM")) (using after being lowerCased)""") {
     val e = intercept[exceptions.TestFailedException] {
-      (Array("Doe", "Re", "Me") should contain oneOf ("X", "RAY", "BEAM")) (after being lowerCased)
+      (Array("Doe", "Re", "Me") should contain oneOf ("X", "RAY", "BEAM")) (using after being lowerCased)
     }
     e.failedCodeFileName should be (Some("MatcherStackDepthSpec.scala"))
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
@@ -508,9 +508,9 @@ class MatcherStackDepthSpec extends AnyFunSuite with Matchers {
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
   }
 
-  test("""(Array("Doe", "Ray", "Me") should contain oneElementOf List("X", "RAX", "BEAM")) (after being lowerCased)""") {
+  test("""(Array("Doe", "Ray", "Me") should contain oneElementOf List("X", "RAX", "BEAM")) (using after being lowerCased)""") {
     val e = intercept[exceptions.TestFailedException] {
-      (Array("Doe", "Ray", "Me") should contain oneElementOf List("X", "RAX", "BEAM")) (after being lowerCased)
+      (Array("Doe", "Ray", "Me") should contain oneElementOf List("X", "RAX", "BEAM")) (using after being lowerCased)
     }
     e.failedCodeFileName should be (Some("MatcherStackDepthSpec.scala"))
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
@@ -590,9 +590,9 @@ class MatcherStackDepthSpec extends AnyFunSuite with Matchers {
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
   }
 
-  test("""(Vector(" A", "B ") should contain atLeastOneOf ("d ", "o", "g")) (after being lowerCased and trimmed)""") {
+  test("""(Vector(" A", "B ") should contain atLeastOneOf ("d ", "o", "g")) (using after being lowerCased and trimmed)""") {
     val e = intercept[exceptions.TestFailedException] {
-      (Vector(" A", "B ") should contain atLeastOneOf ("d ", "o", "g")) (after being lowerCased and trimmed)
+      (Vector(" A", "B ") should contain atLeastOneOf ("d ", "o", "g")) (using after being lowerCased and trimmed)
     }
     e.failedCodeFileName should be (Some("MatcherStackDepthSpec.scala"))
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
@@ -622,9 +622,9 @@ class MatcherStackDepthSpec extends AnyFunSuite with Matchers {
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))
   }
 
-  test("""(Vector(" A", "B ") should contain atLeastOneElementOf List("d ", "o", "g")) (after being lowerCased and trimmed)""") {
+  test("""(Vector(" A", "B ") should contain atLeastOneElementOf List("d ", "o", "g")) (using after being lowerCased and trimmed)""") {
     val e = intercept[exceptions.TestFailedException] {
-      (Vector(" A", "B ") should contain atLeastOneElementOf List("d ", "o", "g")) (after being lowerCased and trimmed)
+      (Vector(" A", "B ") should contain atLeastOneElementOf List("d ", "o", "g")) (using after being lowerCased and trimmed)
     }
     e.failedCodeFileName should be (Some("MatcherStackDepthSpec.scala"))
     e.failedCodeLineNumber should be (Some(thisLineNumber - 3))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NoElementsOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NoElementsOfContainMatcherDeciderSpec.scala
@@ -261,29 +261,29 @@ class NoElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
     it("should take specified normalization when 'should contain' is used") {
 
-      (List("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (using after being appended)
-      (Set("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (using after being appended)
-      (Array("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (using after being appended)
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noElementsOf Seq(1 -> "one", 2 -> " two", 3 -> "three")) (using after being mapAppended)
+      (List("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
+      (Set("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
+      (Array("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noElementsOf Seq(1 -> "one", 2 -> " two", 3 -> "three")) (/* DOTTY-ONLY using */ after being mapAppended)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (using after being appended)
-      (javaSet("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (using after being appended)
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noElementsOf Seq(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (using after being javaMapAppended)
+      (javaList("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
+      (javaSet("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noElementsOf Seq(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ after being javaMapAppended)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take specified normalization when 'should not contain' is used") {
 
-      (List("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (using after being trimmed)
-      (Set("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (using after being trimmed)
-      (Array("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (using after being trimmed)
-      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain noElementsOf (Seq(1 -> " one", 2 -> "two ", 3 -> " three"))) (using after being mapTrimmed)
+      (List("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (/* DOTTY-ONLY using */ after being trimmed)
+      (Set("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (/* DOTTY-ONLY using */ after being trimmed)
+      (Array("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (/* DOTTY-ONLY using */ after being trimmed)
+      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain noElementsOf (Seq(1 -> " one", 2 -> "two ", 3 -> " three"))) (/* DOTTY-ONLY using */ after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (using after being trimmed)
-      (javaSet("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (using after being trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain noElementsOf (Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")))) (using after being javaMapTrimmed)
+      (javaList("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaSet("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain noElementsOf (Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")))) (/* DOTTY-ONLY using */ after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -291,38 +291,38 @@ class NoElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List("1 ", " 2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain noElementsOf Seq(" 1", "2 ", " 3")) (using after being trimmed)
+        (left1 should contain noElementsOf Seq(" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldContainStackDepth(e1, left1, Seq(" 1", "2 ", " 3"), thisLineNumber - 2)
 
       val left2 = Set("1 ", " 2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain noElementsOf Seq(" 1", "2 ", " 3")) (using after being trimmed)
+        (left2 should contain noElementsOf Seq(" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldContainStackDepth(e2, left2, Seq(" 1", "2 ", " 3"), thisLineNumber - 2)
 
       val left3 = Array("1 ", " 2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain noElementsOf Seq(" 1", "2 ", " 3")) (using after being trimmed)
+        (left3 should contain noElementsOf Seq(" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldContainStackDepth(e3, left3, Seq(" 1", "2 ", " 3"), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain noElementsOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (using after being mapTrimmed)
+        (left4 should contain noElementsOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (/* DOTTY-ONLY using */ after being mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> " one", 2 -> "two ", 3 -> " three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1 ", " 2", "3 ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain noElementsOf Seq(" 1", "2 ", " 3")) (using after being trimmed)
+        (left5 should contain noElementsOf Seq(" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldContainStackDepth(e5, left5, Seq(" 1", "2 ", " 3"), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain noElementsOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using after being javaMapTrimmed)
+        (left6 should contain noElementsOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (/* DOTTY-ONLY using */ after being javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -332,38 +332,38 @@ class NoElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List("1", "2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain noElementsOf (Seq("1", "2", "3"))) (using after being appended)
+        (left1 should not contain noElementsOf (Seq("1", "2", "3"))) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq("1", "2", "3"), thisLineNumber - 2)
 
       val left2 = Set("1", "2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain noElementsOf (Seq("1", "2", "3"))) (using after being appended)
+        (left2 should not contain noElementsOf (Seq("1", "2", "3"))) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq("1", "2", "3"), thisLineNumber - 2)
 
       val left3 = Array("1", "2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain noElementsOf (Seq("1", "2", "3"))) (using after being appended)
+        (left3 should not contain noElementsOf (Seq("1", "2", "3"))) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq("1", "2", "3"), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain noElementsOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (using after being mapAppended)
+        (left4 should not contain noElementsOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (/* DOTTY-ONLY using */ after being mapAppended)
       }
       checkShouldNotContainStackDepth(e4, left4, Seq(1 -> "one", 2 -> "two", 3 -> "three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", "2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain noElementsOf (Seq("1", "2", "3"))) (using after being appended)
+        (left5 should not contain noElementsOf (Seq("1", "2", "3"))) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldNotContainStackDepth(e5, left5, Seq("1", "2", "3"), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain noElementsOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (using after being javaMapAppended)
+        (left6 should not contain noElementsOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (/* DOTTY-ONLY using */ after being javaMapAppended)
       }
       checkShouldNotContainStackDepth(e6, left6, Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -371,29 +371,29 @@ class NoElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
     it("should take specified equality and normalization when 'should contain' is used") {
 
-      (List("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
-      (Set("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
-      (Array("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
-      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should contain noElementsOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
+      (List("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Set("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Array("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should contain noElementsOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (/* DOTTY-ONLY using */ decided by mapReverseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
-      (javaSet("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should contain noElementsOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+      (javaList("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (javaSet("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should contain noElementsOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (/* DOTTY-ONLY using */ decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take specified equality and normalization when 'should not contain' is used") {
 
-      (List(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Set(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Array(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> " ONE", 2 -> "TWO ", 3 -> " THREE") should not contain noElementsOf (Seq(1 -> "one ", 2 -> " two", 3 -> "three "))) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Set(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Array(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> " ONE", 2 -> "TWO ", 3 -> " THREE") should not contain noElementsOf (Seq(1 -> "one ", 2 -> " two", 3 -> "three "))) (/* DOTTY-ONLY using */ decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (using decided by lowerCaseEquality afterBeing trimmed)
-      (javaSet(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (using decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, " ONE"), Entry(2, "TWO "), Entry(3, " THREE")) should not contain noElementsOf (Seq(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (javaSet(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, " ONE"), Entry(2, "TWO "), Entry(3, " THREE")) should not contain noElementsOf (Seq(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")))) (/* DOTTY-ONLY using */ decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -401,38 +401,38 @@ class NoElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List(" ONE", "TWO ", " THREE")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain noElementsOf Seq("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left1 should contain noElementsOf Seq("one ", " two", "three ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, Seq("one ", " two", "three "), thisLineNumber - 2)
 
       val left2 = Set(" ONE", "TWO ", " THREE")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain noElementsOf Seq("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left2 should contain noElementsOf Seq("one ", " two", "three ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, Seq("one ", " two", "three "), thisLineNumber - 2)
 
       val left3 = Array(" ONE", "TWO ", " THREE")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain noElementsOf Seq("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left3 should contain noElementsOf Seq("one ", " two", "three ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, Seq("one ", " two", "three "), thisLineNumber - 2)
 
       val left4 = Map(1 -> " ONE", 2 -> "TWO ", 3 -> " THREE")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain noElementsOf Seq(1 -> "one ", 2 -> " two", 3 -> "three ")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
+        (left4 should contain noElementsOf Seq(1 -> "one ", 2 -> " two", 3 -> "three ")) (/* DOTTY-ONLY using */ decided by mapLowerCaseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> "one ", 2 -> " two", 3 -> "three "), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(" ONE", "TWO ", " THREE")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain noElementsOf Seq("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left5 should contain noElementsOf Seq("one ", " two", "three ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, Seq("one ", " two", "three "), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, " ONE"), Entry(2, "TWO "), Entry(3, " THREE"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain noElementsOf Seq(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+        (left6 should contain noElementsOf Seq(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))) (/* DOTTY-ONLY using */ decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -442,38 +442,38 @@ class NoElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain noElementsOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
+        (left1 should not contain noElementsOf (Seq(" one", "two ", " three"))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left2 = Set("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain noElementsOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
+        (left2 should not contain noElementsOf (Seq(" one", "two ", " three"))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left3 = Array("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain noElementsOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
+        (left3 should not contain noElementsOf (Seq(" one", "two ", " three"))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain noElementsOf (Seq(1 -> " one", 2 -> "two ", 3 -> " three"))) (using decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should not contain noElementsOf (Seq(1 -> " one", 2 -> "two ", 3 -> " three"))) (/* DOTTY-ONLY using */ decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldNotContainStackDepth(e4, left4, Seq(1 -> " one", 2 -> "two ", 3 -> " three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("one ", " two", "three ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain noElementsOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
+        (left5 should not contain noElementsOf (Seq(" one", "two ", " three"))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e5, left5, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain noElementsOf (Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should not contain noElementsOf (Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")))) (/* DOTTY-ONLY using */ decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldNotContainStackDepth(e6, left6, Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NoElementsOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NoElementsOfContainMatcherDeciderSpec.scala
@@ -261,29 +261,29 @@ class NoElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
     it("should take specified normalization when 'should contain' is used") {
 
-      (List("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (after being appended)
-      (Set("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (after being appended)
-      (Array("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (after being appended)
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noElementsOf Seq(1 -> "one", 2 -> " two", 3 -> "three")) (after being mapAppended)
+      (List("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (using after being appended)
+      (Set("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (using after being appended)
+      (Array("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (using after being appended)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noElementsOf Seq(1 -> "one", 2 -> " two", 3 -> "three")) (using after being mapAppended)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (after being appended)
-      (javaSet("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (after being appended)
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noElementsOf Seq(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (after being javaMapAppended)
+      (javaList("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (using after being appended)
+      (javaSet("1", "2", "3") should contain noElementsOf Seq("1", "2", "3")) (using after being appended)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noElementsOf Seq(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (using after being javaMapAppended)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take specified normalization when 'should not contain' is used") {
 
-      (List("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (after being trimmed)
-      (Set("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (after being trimmed)
-      (Array("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (after being trimmed)
-      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain noElementsOf (Seq(1 -> " one", 2 -> "two ", 3 -> " three"))) (after being mapTrimmed)
+      (List("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (using after being trimmed)
+      (Set("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (using after being trimmed)
+      (Array("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (using after being trimmed)
+      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain noElementsOf (Seq(1 -> " one", 2 -> "two ", 3 -> " three"))) (using after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (after being trimmed)
-      (javaSet("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (after being trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain noElementsOf (Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")))) (after being javaMapTrimmed)
+      (javaList("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (using after being trimmed)
+      (javaSet("1 ", " 2", "3 ") should not contain noElementsOf (Seq(" 1", "2 ", " 3"))) (using after being trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain noElementsOf (Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")))) (using after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -291,38 +291,38 @@ class NoElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List("1 ", " 2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain noElementsOf Seq(" 1", "2 ", " 3")) (after being trimmed)
+        (left1 should contain noElementsOf Seq(" 1", "2 ", " 3")) (using after being trimmed)
       }
       checkShouldContainStackDepth(e1, left1, Seq(" 1", "2 ", " 3"), thisLineNumber - 2)
 
       val left2 = Set("1 ", " 2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain noElementsOf Seq(" 1", "2 ", " 3")) (after being trimmed)
+        (left2 should contain noElementsOf Seq(" 1", "2 ", " 3")) (using after being trimmed)
       }
       checkShouldContainStackDepth(e2, left2, Seq(" 1", "2 ", " 3"), thisLineNumber - 2)
 
       val left3 = Array("1 ", " 2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain noElementsOf Seq(" 1", "2 ", " 3")) (after being trimmed)
+        (left3 should contain noElementsOf Seq(" 1", "2 ", " 3")) (using after being trimmed)
       }
       checkShouldContainStackDepth(e3, left3, Seq(" 1", "2 ", " 3"), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain noElementsOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (after being mapTrimmed)
+        (left4 should contain noElementsOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (using after being mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> " one", 2 -> "two ", 3 -> " three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1 ", " 2", "3 ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain noElementsOf Seq(" 1", "2 ", " 3")) (after being trimmed)
+        (left5 should contain noElementsOf Seq(" 1", "2 ", " 3")) (using after being trimmed)
       }
       checkShouldContainStackDepth(e5, left5, Seq(" 1", "2 ", " 3"), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain noElementsOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (after being javaMapTrimmed)
+        (left6 should contain noElementsOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using after being javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -332,38 +332,38 @@ class NoElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List("1", "2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain noElementsOf (Seq("1", "2", "3"))) (after being appended)
+        (left1 should not contain noElementsOf (Seq("1", "2", "3"))) (using after being appended)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq("1", "2", "3"), thisLineNumber - 2)
 
       val left2 = Set("1", "2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain noElementsOf (Seq("1", "2", "3"))) (after being appended)
+        (left2 should not contain noElementsOf (Seq("1", "2", "3"))) (using after being appended)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq("1", "2", "3"), thisLineNumber - 2)
 
       val left3 = Array("1", "2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain noElementsOf (Seq("1", "2", "3"))) (after being appended)
+        (left3 should not contain noElementsOf (Seq("1", "2", "3"))) (using after being appended)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq("1", "2", "3"), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain noElementsOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (after being mapAppended)
+        (left4 should not contain noElementsOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (using after being mapAppended)
       }
       checkShouldNotContainStackDepth(e4, left4, Seq(1 -> "one", 2 -> "two", 3 -> "three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", "2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain noElementsOf (Seq("1", "2", "3"))) (after being appended)
+        (left5 should not contain noElementsOf (Seq("1", "2", "3"))) (using after being appended)
       }
       checkShouldNotContainStackDepth(e5, left5, Seq("1", "2", "3"), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain noElementsOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (after being javaMapAppended)
+        (left6 should not contain noElementsOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (using after being javaMapAppended)
       }
       checkShouldNotContainStackDepth(e6, left6, Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -371,29 +371,29 @@ class NoElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
     it("should take specified equality and normalization when 'should contain' is used") {
 
-      (List("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
-      (Set("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
-      (Array("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
-      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should contain noElementsOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (decided by mapReverseEquality afterBeing mapTrimmed)
+      (List("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (Set("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (Array("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should contain noElementsOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
-      (javaSet("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should contain noElementsOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+      (javaList("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (javaSet("one ", " two", "three ") should contain noElementsOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should contain noElementsOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take specified equality and normalization when 'should not contain' is used") {
 
-      (List(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (decided by lowerCaseEquality afterBeing trimmed)
-      (Set(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (decided by lowerCaseEquality afterBeing trimmed)
-      (Array(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> " ONE", 2 -> "TWO ", 3 -> " THREE") should not contain noElementsOf (Seq(1 -> "one ", 2 -> " two", 3 -> "three "))) (decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Set(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Array(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> " ONE", 2 -> "TWO ", 3 -> " THREE") should not contain noElementsOf (Seq(1 -> "one ", 2 -> " two", 3 -> "three "))) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (decided by lowerCaseEquality afterBeing trimmed)
-      (javaSet(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, " ONE"), Entry(2, "TWO "), Entry(3, " THREE")) should not contain noElementsOf (Seq(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")))) (decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (using decided by lowerCaseEquality afterBeing trimmed)
+      (javaSet(" ONE", "TWO ", " THREE") should not contain noElementsOf (Seq("one ", " two", "three "))) (using decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, " ONE"), Entry(2, "TWO "), Entry(3, " THREE")) should not contain noElementsOf (Seq(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -401,38 +401,38 @@ class NoElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List(" ONE", "TWO ", " THREE")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain noElementsOf Seq("one ", " two", "three ")) (decided by lowerCaseEquality afterBeing trimmed)
+        (left1 should contain noElementsOf Seq("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, Seq("one ", " two", "three "), thisLineNumber - 2)
 
       val left2 = Set(" ONE", "TWO ", " THREE")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain noElementsOf Seq("one ", " two", "three ")) (decided by lowerCaseEquality afterBeing trimmed)
+        (left2 should contain noElementsOf Seq("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, Seq("one ", " two", "three "), thisLineNumber - 2)
 
       val left3 = Array(" ONE", "TWO ", " THREE")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain noElementsOf Seq("one ", " two", "three ")) (decided by lowerCaseEquality afterBeing trimmed)
+        (left3 should contain noElementsOf Seq("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, Seq("one ", " two", "three "), thisLineNumber - 2)
 
       val left4 = Map(1 -> " ONE", 2 -> "TWO ", 3 -> " THREE")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain noElementsOf Seq(1 -> "one ", 2 -> " two", 3 -> "three ")) (decided by mapLowerCaseEquality afterBeing mapTrimmed)
+        (left4 should contain noElementsOf Seq(1 -> "one ", 2 -> " two", 3 -> "three ")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> "one ", 2 -> " two", 3 -> "three "), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(" ONE", "TWO ", " THREE")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain noElementsOf Seq("one ", " two", "three ")) (decided by lowerCaseEquality afterBeing trimmed)
+        (left5 should contain noElementsOf Seq("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, Seq("one ", " two", "three "), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, " ONE"), Entry(2, "TWO "), Entry(3, " THREE"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain noElementsOf Seq(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))) (decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+        (left6 should contain noElementsOf Seq(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -442,38 +442,38 @@ class NoElementsOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain noElementsOf (Seq(" one", "two ", " three"))) (decided by reverseEquality afterBeing trimmed)
+        (left1 should not contain noElementsOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left2 = Set("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain noElementsOf (Seq(" one", "two ", " three"))) (decided by reverseEquality afterBeing trimmed)
+        (left2 should not contain noElementsOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left3 = Array("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain noElementsOf (Seq(" one", "two ", " three"))) (decided by reverseEquality afterBeing trimmed)
+        (left3 should not contain noElementsOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain noElementsOf (Seq(1 -> " one", 2 -> "two ", 3 -> " three"))) (decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should not contain noElementsOf (Seq(1 -> " one", 2 -> "two ", 3 -> " three"))) (using decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldNotContainStackDepth(e4, left4, Seq(1 -> " one", 2 -> "two ", 3 -> " three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("one ", " two", "three ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain noElementsOf (Seq(" one", "two ", " three"))) (decided by reverseEquality afterBeing trimmed)
+        (left5 should not contain noElementsOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e5, left5, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain noElementsOf (Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")))) (decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should not contain noElementsOf (Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldNotContainStackDepth(e6, left6, Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NoElementsOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NoElementsOfContainMatcherEqualitySpec.scala
@@ -225,37 +225,37 @@ class NoElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
     it("should take custom explicit equality in scope when 'should contain' is used") {
       val equality = new FalseEquality
-      (List(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (using equality)
-      (Set(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (using equality)
-      (Array(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (using equality)
+      (List(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ equality)
+      (Set(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ equality)
+      (Array(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ equality)
 
       val mapEquality = new MapSetEquality(Set(1 -> "one", 2 -> " two", 3 -> "three"), Set(1 -> "one", 2 -> " two", 3 -> "three"), false)
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noElementsOf Seq(1 -> "one", 2 -> " two", 3 -> "three")) (using mapEquality)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noElementsOf Seq(1 -> "one", 2 -> " two", 3 -> "three")) (/* DOTTY-ONLY using */ mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (using equality)
-      (javaSet(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (using equality)
+      (javaList(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ equality)
+      (javaSet(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ equality)
 
       val javaMapEquality = new JavaMapSetEquality(Set(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")), Set(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")), false)
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noElementsOf Seq(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (using javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noElementsOf Seq(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take custom explicit equality in scope when 'should not contain' is used") {
       val equality = new SetEquality(Set(1, 2, 3), Set(7, 8, 9), true)
-      (List(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (using equality)
-      (Set(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (using equality)
-      (Array(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (using equality)
+      (List(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (/* DOTTY-ONLY using */ equality)
+      (Set(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (/* DOTTY-ONLY using */ equality)
+      (Array(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (/* DOTTY-ONLY using */ equality)
 
       val mapEquality = new MapSetEquality(Set(1 -> "one", 2 -> "two", 3 -> "three"), Set(7 -> "seven", 8 -> "eight", 9 -> "nine"), true)
-      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain noElementsOf (Seq(7 -> "seven", 8 -> "eight", 9 -> "nine"))) (using mapEquality)
+      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain noElementsOf (Seq(7 -> "seven", 8 -> "eight", 9 -> "nine"))) (/* DOTTY-ONLY using */ mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (using equality)
-      (javaSet(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (using equality)
+      (javaList(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (/* DOTTY-ONLY using */ equality)
+      (javaSet(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (/* DOTTY-ONLY using */ equality)
 
       val javaMapEquality = new JavaMapSetEquality(Set(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), Set(Entry(7, "seven"), Entry(8, "eight"), Entry(9, "nine")), true)
-      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain noElementsOf (Seq(Entry(7, "seven"), Entry(8, "eight"), Entry(9, "nine")))) (using javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain noElementsOf (Seq(Entry(7, "seven"), Entry(8, "eight"), Entry(9, "nine")))) (/* DOTTY-ONLY using */ javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -264,19 +264,19 @@ class NoElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain noElementsOf Seq(6, 7, 8)) (using equality)
+        (left1 should contain noElementsOf Seq(6, 7, 8)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e1, left1, Seq(6, 7, 8), thisLineNumber - 2)
 
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain noElementsOf Seq(6, 7, 8)) (using equality)
+        (left2 should contain noElementsOf Seq(6, 7, 8)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e2, left2, Seq(6, 7, 8), thisLineNumber - 2)
 
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain noElementsOf Seq(6, 7, 8)) (using equality)
+        (left3 should contain noElementsOf Seq(6, 7, 8)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e3, left3, Seq(6, 7, 8), thisLineNumber - 2)
 
@@ -284,21 +284,21 @@ class NoElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain noElementsOf Seq(6 -> "six", 7 -> "seven", 8 -> "eight")) (using mapEquality)
+        (left4 should contain noElementsOf Seq(6 -> "six", 7 -> "seven", 8 -> "eight")) (/* DOTTY-ONLY using */ mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, Seq(6 -> "six", 7 -> "seven", 8 -> "eight"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain noElementsOf Seq(6, 7, 8)) (using equality)
+        (left5 should contain noElementsOf Seq(6, 7, 8)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e5, left5, Seq(6, 7, 8), thisLineNumber - 2)
 
       val javaMapEquality = new JavaMapSetEquality(Set(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), Set(Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight")), true)
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain noElementsOf Seq(Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight"))) (using javaMapEquality)
+        (left6 should contain noElementsOf Seq(Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight"))) (/* DOTTY-ONLY using */ javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -309,19 +309,19 @@ class NoElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain noElementsOf (Seq(1, 2, 3))) (using equality)
+        (left1 should not contain noElementsOf (Seq(1, 2, 3))) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain noElementsOf (Seq(1, 2, 3))) (using equality)
+        (left2 should not contain noElementsOf (Seq(1, 2, 3))) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain noElementsOf (Seq(1, 2, 3))) (using equality)
+        (left3 should not contain noElementsOf (Seq(1, 2, 3))) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq(1, 2, 3), thisLineNumber - 2)
 
@@ -329,14 +329,14 @@ class NoElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain noElementsOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (using mapEquality)
+        (left4 should not contain noElementsOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (/* DOTTY-ONLY using */ mapEquality)
       }
       checkShouldNotContainStackDepth(e4, left4, Seq(1 -> "one", 2 -> "two", 3 -> "three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain noElementsOf (Seq(1, 2, 3))) (using equality)
+        (left5 should not contain noElementsOf (Seq(1, 2, 3))) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e5, left5, Seq(1, 2, 3), thisLineNumber - 2)
 
@@ -344,7 +344,7 @@ class NoElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain noElementsOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (using javaMapEquality)
+        (left6 should not contain noElementsOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (/* DOTTY-ONLY using */ javaMapEquality)
       }
       checkShouldNotContainStackDepth(e6, left6, Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NoElementsOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NoElementsOfContainMatcherEqualitySpec.scala
@@ -225,37 +225,37 @@ class NoElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
     it("should take custom explicit equality in scope when 'should contain' is used") {
       val equality = new FalseEquality
-      (List(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (equality)
-      (Set(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (equality)
-      (Array(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (equality)
+      (List(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (using equality)
+      (Set(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (using equality)
+      (Array(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (using equality)
 
       val mapEquality = new MapSetEquality(Set(1 -> "one", 2 -> " two", 3 -> "three"), Set(1 -> "one", 2 -> " two", 3 -> "three"), false)
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noElementsOf Seq(1 -> "one", 2 -> " two", 3 -> "three")) (mapEquality)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noElementsOf Seq(1 -> "one", 2 -> " two", 3 -> "three")) (using mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (equality)
-      (javaSet(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (equality)
+      (javaList(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (using equality)
+      (javaSet(1, 2, 3) should contain noElementsOf Seq(1, 2, 3)) (using equality)
 
       val javaMapEquality = new JavaMapSetEquality(Set(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")), Set(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")), false)
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noElementsOf Seq(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noElementsOf Seq(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (using javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take custom explicit equality in scope when 'should not contain' is used") {
       val equality = new SetEquality(Set(1, 2, 3), Set(7, 8, 9), true)
-      (List(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (equality)
-      (Set(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (equality)
-      (Array(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (equality)
+      (List(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (using equality)
+      (Set(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (using equality)
+      (Array(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (using equality)
 
       val mapEquality = new MapSetEquality(Set(1 -> "one", 2 -> "two", 3 -> "three"), Set(7 -> "seven", 8 -> "eight", 9 -> "nine"), true)
-      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain noElementsOf (Seq(7 -> "seven", 8 -> "eight", 9 -> "nine"))) (mapEquality)
+      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain noElementsOf (Seq(7 -> "seven", 8 -> "eight", 9 -> "nine"))) (using mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (equality)
-      (javaSet(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (equality)
+      (javaList(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (using equality)
+      (javaSet(1, 2, 3) should not contain noElementsOf (Seq(7, 8, 9))) (using equality)
 
       val javaMapEquality = new JavaMapSetEquality(Set(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), Set(Entry(7, "seven"), Entry(8, "eight"), Entry(9, "nine")), true)
-      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain noElementsOf (Seq(Entry(7, "seven"), Entry(8, "eight"), Entry(9, "nine")))) (javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain noElementsOf (Seq(Entry(7, "seven"), Entry(8, "eight"), Entry(9, "nine")))) (using javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -264,19 +264,19 @@ class NoElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain noElementsOf Seq(6, 7, 8)) (equality)
+        (left1 should contain noElementsOf Seq(6, 7, 8)) (using equality)
       }
       checkShouldContainStackDepth(e1, left1, Seq(6, 7, 8), thisLineNumber - 2)
 
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain noElementsOf Seq(6, 7, 8)) (equality)
+        (left2 should contain noElementsOf Seq(6, 7, 8)) (using equality)
       }
       checkShouldContainStackDepth(e2, left2, Seq(6, 7, 8), thisLineNumber - 2)
 
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain noElementsOf Seq(6, 7, 8)) (equality)
+        (left3 should contain noElementsOf Seq(6, 7, 8)) (using equality)
       }
       checkShouldContainStackDepth(e3, left3, Seq(6, 7, 8), thisLineNumber - 2)
 
@@ -284,21 +284,21 @@ class NoElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain noElementsOf Seq(6 -> "six", 7 -> "seven", 8 -> "eight")) (mapEquality)
+        (left4 should contain noElementsOf Seq(6 -> "six", 7 -> "seven", 8 -> "eight")) (using mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, Seq(6 -> "six", 7 -> "seven", 8 -> "eight"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain noElementsOf Seq(6, 7, 8)) (equality)
+        (left5 should contain noElementsOf Seq(6, 7, 8)) (using equality)
       }
       checkShouldContainStackDepth(e5, left5, Seq(6, 7, 8), thisLineNumber - 2)
 
       val javaMapEquality = new JavaMapSetEquality(Set(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), Set(Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight")), true)
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain noElementsOf Seq(Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight"))) (javaMapEquality)
+        (left6 should contain noElementsOf Seq(Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight"))) (using javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -309,19 +309,19 @@ class NoElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain noElementsOf (Seq(1, 2, 3))) (equality)
+        (left1 should not contain noElementsOf (Seq(1, 2, 3))) (using equality)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain noElementsOf (Seq(1, 2, 3))) (equality)
+        (left2 should not contain noElementsOf (Seq(1, 2, 3))) (using equality)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain noElementsOf (Seq(1, 2, 3))) (equality)
+        (left3 should not contain noElementsOf (Seq(1, 2, 3))) (using equality)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq(1, 2, 3), thisLineNumber - 2)
 
@@ -329,14 +329,14 @@ class NoElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain noElementsOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (mapEquality)
+        (left4 should not contain noElementsOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (using mapEquality)
       }
       checkShouldNotContainStackDepth(e4, left4, Seq(1 -> "one", 2 -> "two", 3 -> "three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain noElementsOf (Seq(1, 2, 3))) (equality)
+        (left5 should not contain noElementsOf (Seq(1, 2, 3))) (using equality)
       }
       checkShouldNotContainStackDepth(e5, left5, Seq(1, 2, 3), thisLineNumber - 2)
 
@@ -344,7 +344,7 @@ class NoElementsOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain noElementsOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (javaMapEquality)
+        (left6 should not contain noElementsOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (using javaMapEquality)
       }
       checkShouldNotContainStackDepth(e6, left6, Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NoneOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NoneOfContainMatcherDeciderSpec.scala
@@ -263,29 +263,29 @@ class NoneOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly
     
     it("should take specified normalization when 'should contain' is used") {
       
-      (List("1", "2", "3") should contain noneOf ("1", "2", "3")) (using after being appended)
-      (Set("1", "2", "3") should contain noneOf ("1", "2", "3")) (using after being appended)
-      (Array("1", "2", "3") should contain noneOf ("1", "2", "3")) (using after being appended)
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noneOf (1 -> "one", 2 -> " two", 3 -> "three")) (using after being mapAppended)
+      (List("1", "2", "3") should contain noneOf ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
+      (Set("1", "2", "3") should contain noneOf ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
+      (Array("1", "2", "3") should contain noneOf ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noneOf (1 -> "one", 2 -> " two", 3 -> "three")) (/* DOTTY-ONLY using */ after being mapAppended)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", "2", "3") should contain noneOf ("1", "2", "3")) (using after being appended)
-      (javaSet("1", "2", "3") should contain noneOf ("1", "2", "3")) (using after being appended)
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noneOf (Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (using after being javaMapAppended)
+      (javaList("1", "2", "3") should contain noneOf ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
+      (javaSet("1", "2", "3") should contain noneOf ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noneOf (Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ after being javaMapAppended)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified normalization when 'should not contain' is used") {
       
-      (List("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
-      (Set("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
-      (Array("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
-      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (using after being mapTrimmed)
+      (List("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Set("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Array("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (/* DOTTY-ONLY using */ after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
-      (javaSet("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using after being javaMapTrimmed)
+      (javaList("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaSet("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (/* DOTTY-ONLY using */ after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -293,38 +293,38 @@ class NoneOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly
       
       val left1 = List("1 ", " 2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
+        (left1 should contain noneOf (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
         
       val left2 = Set("1 ", " 2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
+        (left2 should contain noneOf (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
         
       val left3 = Array("1 ", " 2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
+        (left3 should contain noneOf (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
       }
         checkShouldContainStackDepth(e3, left3, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
       
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (using after being mapTrimmed)
+        (left4 should contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (/* DOTTY-ONLY using */ after being mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> " one", 2 -> "two ", 3 -> " three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1 ", " 2", "3 ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
+        (left5 should contain noneOf (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using after being javaMapTrimmed)
+        (left6 should contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (/* DOTTY-ONLY using */ after being javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -334,38 +334,38 @@ class NoneOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly
       
       val left1 = List("1", "2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain noneOf ("1", "2", "3")) (using after being appended)
+        (left1 should not contain noneOf ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array("1", "2", "3")), thisLineNumber - 2)
         
       val left2 = Set("1", "2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain noneOf ("1", "2", "3")) (using after being appended)
+        (left2 should not contain noneOf ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array("1", "2", "3")), thisLineNumber - 2)
         
       val left3 = Array("1", "2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain noneOf ("1", "2", "3")) (using after being appended)
+        (left3 should not contain noneOf ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array("1", "2", "3")), thisLineNumber - 2)
       
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain noneOf (1 -> "one", 2 -> "two", 3 -> "three")) (using after being mapAppended)
+        (left4 should not contain noneOf (1 -> "one", 2 -> "two", 3 -> "three")) (/* DOTTY-ONLY using */ after being mapAppended)
       }
       checkShouldNotContainStackDepth(e4, left4, deep(Array(1 -> "one", 2 -> "two", 3 -> "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", "2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain noneOf ("1", "2", "3")) (using after being appended)
+        (left5 should not contain noneOf ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldNotContainStackDepth(e5, left5, deep(Array("1", "2", "3")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain noneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using after being javaMapAppended)
+        (left6 should not contain noneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ after being javaMapAppended)
       }
       checkShouldNotContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -373,29 +373,29 @@ class NoneOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly
     
     it("should take specified equality and normalization when 'should contain' is used") {
       
-      (List("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
-      (Set("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
-      (Array("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
-      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
+      (List("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Set("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Array("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (/* DOTTY-ONLY using */ decided by mapReverseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
-      (javaSet("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+      (javaList("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (javaSet("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (/* DOTTY-ONLY using */ decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified equality and normalization when 'should not contain' is used") {
       
-      (List(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Set(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Array(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> " ONE", 2 -> "TWO ", 3 -> " THREE") should not contain noneOf (1 -> "one ", 2 -> " two", 3 -> "three ")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Set(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Array(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> " ONE", 2 -> "TWO ", 3 -> " THREE") should not contain noneOf (1 -> "one ", 2 -> " two", 3 -> "three ")) (/* DOTTY-ONLY using */ decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (javaSet(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, " ONE"), Entry(2, "TWO "), Entry(3, " THREE")) should not contain noneOf (Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (javaSet(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, " ONE"), Entry(2, "TWO "), Entry(3, " THREE")) should not contain noneOf (Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))) (/* DOTTY-ONLY using */ decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -403,38 +403,38 @@ class NoneOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly
       
       val left1 = List(" ONE", "TWO ", " THREE")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left1 should contain noneOf ("one ", " two", "three ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array("one ", " two", "three ")), thisLineNumber - 2)
         
       val left2 = Set(" ONE", "TWO ", " THREE")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left2 should contain noneOf ("one ", " two", "three ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array("one ", " two", "three ")), thisLineNumber - 2)
         
       val left3 = Array(" ONE", "TWO ", " THREE")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left3 should contain noneOf ("one ", " two", "three ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
         checkShouldContainStackDepth(e3, left3, deep(Array("one ", " two", "three ")), thisLineNumber - 2)
         
       val left4 = Map(1 -> " ONE", 2 -> "TWO ", 3 -> " THREE")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain noneOf (1 -> "one ", 2 -> " two", 3 -> "three ")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
+        (left4 should contain noneOf (1 -> "one ", 2 -> " two", 3 -> "three ")) (/* DOTTY-ONLY using */ decided by mapLowerCaseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> "one ", 2 -> " two", 3 -> "three ")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(" ONE", "TWO ", " THREE")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left5 should contain noneOf ("one ", " two", "three ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array("one ", " two", "three ")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, " ONE"), Entry(2, "TWO "), Entry(3, " THREE"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain noneOf (Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+        (left6 should contain noneOf (Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))) (/* DOTTY-ONLY using */ decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -444,38 +444,38 @@ class NoneOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly
       
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left1 should not contain noneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left2 = Set("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left2 should not contain noneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left3 = Array("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left3 should not contain noneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should not contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (/* DOTTY-ONLY using */ decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldNotContainStackDepth(e4, left4, deep(Array(1 -> " one", 2 -> "two ", 3 -> " three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("one ", " two", "three ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left5 should not contain noneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e5, left5, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should not contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (/* DOTTY-ONLY using */ decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldNotContainStackDepth(e6, left6, deep(Array(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NoneOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NoneOfContainMatcherDeciderSpec.scala
@@ -263,29 +263,29 @@ class NoneOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly
     
     it("should take specified normalization when 'should contain' is used") {
       
-      (List("1", "2", "3") should contain noneOf ("1", "2", "3")) (after being appended)
-      (Set("1", "2", "3") should contain noneOf ("1", "2", "3")) (after being appended)
-      (Array("1", "2", "3") should contain noneOf ("1", "2", "3")) (after being appended)
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noneOf (1 -> "one", 2 -> " two", 3 -> "three")) (after being mapAppended)
+      (List("1", "2", "3") should contain noneOf ("1", "2", "3")) (using after being appended)
+      (Set("1", "2", "3") should contain noneOf ("1", "2", "3")) (using after being appended)
+      (Array("1", "2", "3") should contain noneOf ("1", "2", "3")) (using after being appended)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noneOf (1 -> "one", 2 -> " two", 3 -> "three")) (using after being mapAppended)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", "2", "3") should contain noneOf ("1", "2", "3")) (after being appended)
-      (javaSet("1", "2", "3") should contain noneOf ("1", "2", "3")) (after being appended)
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noneOf (Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (after being javaMapAppended)
+      (javaList("1", "2", "3") should contain noneOf ("1", "2", "3")) (using after being appended)
+      (javaSet("1", "2", "3") should contain noneOf ("1", "2", "3")) (using after being appended)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noneOf (Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (using after being javaMapAppended)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified normalization when 'should not contain' is used") {
       
-      (List("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (after being trimmed)
-      (Set("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (after being trimmed)
-      (Array("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (after being trimmed)
-      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (after being mapTrimmed)
+      (List("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
+      (Set("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
+      (Array("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
+      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (using after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (after being trimmed)
-      (javaSet("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (after being trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (after being javaMapTrimmed)
+      (javaList("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
+      (javaSet("1 ", " 2", "3 ") should not contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -293,38 +293,38 @@ class NoneOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly
       
       val left1 = List("1 ", " 2", "3 ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain noneOf (" 1", "2 ", " 3")) (after being trimmed)
+        (left1 should contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
         
       val left2 = Set("1 ", " 2", "3 ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain noneOf (" 1", "2 ", " 3")) (after being trimmed)
+        (left2 should contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
         
       val left3 = Array("1 ", " 2", "3 ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain noneOf (" 1", "2 ", " 3")) (after being trimmed)
+        (left3 should contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
       }
         checkShouldContainStackDepth(e3, left3, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
       
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (after being mapTrimmed)
+        (left4 should contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (using after being mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> " one", 2 -> "two ", 3 -> " three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1 ", " 2", "3 ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain noneOf (" 1", "2 ", " 3")) (after being trimmed)
+        (left5 should contain noneOf (" 1", "2 ", " 3")) (using after being trimmed)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(" 1", "2 ", " 3")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (after being javaMapTrimmed)
+        (left6 should contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using after being javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -334,38 +334,38 @@ class NoneOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly
       
       val left1 = List("1", "2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain noneOf ("1", "2", "3")) (after being appended)
+        (left1 should not contain noneOf ("1", "2", "3")) (using after being appended)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array("1", "2", "3")), thisLineNumber - 2)
         
       val left2 = Set("1", "2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain noneOf ("1", "2", "3")) (after being appended)
+        (left2 should not contain noneOf ("1", "2", "3")) (using after being appended)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array("1", "2", "3")), thisLineNumber - 2)
         
       val left3 = Array("1", "2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain noneOf ("1", "2", "3")) (after being appended)
+        (left3 should not contain noneOf ("1", "2", "3")) (using after being appended)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array("1", "2", "3")), thisLineNumber - 2)
       
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain noneOf (1 -> "one", 2 -> "two", 3 -> "three")) (after being mapAppended)
+        (left4 should not contain noneOf (1 -> "one", 2 -> "two", 3 -> "three")) (using after being mapAppended)
       }
       checkShouldNotContainStackDepth(e4, left4, deep(Array(1 -> "one", 2 -> "two", 3 -> "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", "2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain noneOf ("1", "2", "3")) (after being appended)
+        (left5 should not contain noneOf ("1", "2", "3")) (using after being appended)
       }
       checkShouldNotContainStackDepth(e5, left5, deep(Array("1", "2", "3")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain noneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (after being javaMapAppended)
+        (left6 should not contain noneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using after being javaMapAppended)
       }
       checkShouldNotContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -373,29 +373,29 @@ class NoneOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly
     
     it("should take specified equality and normalization when 'should contain' is used") {
       
-      (List("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
-      (Set("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
-      (Array("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
-      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (decided by mapReverseEquality afterBeing mapTrimmed)
+      (List("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (Set("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (Array("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
-      (javaSet("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+      (javaList("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (javaSet("one ", " two", "three ") should contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified equality and normalization when 'should not contain' is used") {
       
-      (List(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Set(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Array(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> " ONE", 2 -> "TWO ", 3 -> " THREE") should not contain noneOf (1 -> "one ", 2 -> " two", 3 -> "three ")) (decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Set(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Array(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> " ONE", 2 -> "TWO ", 3 -> " THREE") should not contain noneOf (1 -> "one ", 2 -> " two", 3 -> "three ")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (decided by lowerCaseEquality afterBeing trimmed)
-      (javaSet(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, " ONE"), Entry(2, "TWO "), Entry(3, " THREE")) should not contain noneOf (Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))) (decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (javaSet(" ONE", "TWO ", " THREE") should not contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, " ONE"), Entry(2, "TWO "), Entry(3, " THREE")) should not contain noneOf (Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -403,38 +403,38 @@ class NoneOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly
       
       val left1 = List(" ONE", "TWO ", " THREE")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain noneOf ("one ", " two", "three ")) (decided by lowerCaseEquality afterBeing trimmed)
+        (left1 should contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array("one ", " two", "three ")), thisLineNumber - 2)
         
       val left2 = Set(" ONE", "TWO ", " THREE")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain noneOf ("one ", " two", "three ")) (decided by lowerCaseEquality afterBeing trimmed)
+        (left2 should contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array("one ", " two", "three ")), thisLineNumber - 2)
         
       val left3 = Array(" ONE", "TWO ", " THREE")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain noneOf ("one ", " two", "three ")) (decided by lowerCaseEquality afterBeing trimmed)
+        (left3 should contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
       }
         checkShouldContainStackDepth(e3, left3, deep(Array("one ", " two", "three ")), thisLineNumber - 2)
         
       val left4 = Map(1 -> " ONE", 2 -> "TWO ", 3 -> " THREE")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain noneOf (1 -> "one ", 2 -> " two", 3 -> "three ")) (decided by mapLowerCaseEquality afterBeing mapTrimmed)
+        (left4 should contain noneOf (1 -> "one ", 2 -> " two", 3 -> "three ")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> "one ", 2 -> " two", 3 -> "three ")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(" ONE", "TWO ", " THREE")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain noneOf ("one ", " two", "three ")) (decided by lowerCaseEquality afterBeing trimmed)
+        (left5 should contain noneOf ("one ", " two", "three ")) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array("one ", " two", "three ")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, " ONE"), Entry(2, "TWO "), Entry(3, " THREE"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain noneOf (Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))) (decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+        (left6 should contain noneOf (Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -444,38 +444,38 @@ class NoneOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Explicitly
       
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain noneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left1 should not contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left2 = Set("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain noneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left2 should not contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left3 = Array("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain noneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left3 should not contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should not contain noneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldNotContainStackDepth(e4, left4, deep(Array(1 -> " one", 2 -> "two ", 3 -> " three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("one ", " two", "three ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain noneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left5 should not contain noneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e5, left5, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should not contain noneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldNotContainStackDepth(e6, left6, deep(Array(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NoneOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NoneOfContainMatcherEqualitySpec.scala
@@ -229,37 +229,37 @@ class NoneOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Explicitl
     
     it("should take custom explicit equality in scope when 'should contain' is used") {
       val equality = new FalseEquality
-      (List(1, 2, 3) should contain noneOf (1, 2, 3)) (equality)
-      (Set(1, 2, 3) should contain noneOf (1, 2, 3)) (equality)
-      (Array(1, 2, 3) should contain noneOf (1, 2, 3)) (equality)
+      (List(1, 2, 3) should contain noneOf (1, 2, 3)) (using equality)
+      (Set(1, 2, 3) should contain noneOf (1, 2, 3)) (using equality)
+      (Array(1, 2, 3) should contain noneOf (1, 2, 3)) (using equality)
         
       val mapEquality = new MapSetEquality(Set(1 -> "one", 2 -> " two", 3 -> "three"), Set(1 -> "one", 2 -> " two", 3 -> "three"), false)
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noneOf (1 -> "one", 2 -> " two", 3 -> "three")) (mapEquality)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noneOf (1 -> "one", 2 -> " two", 3 -> "three")) (using mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should contain noneOf (1, 2, 3)) (equality)
-      (javaSet(1, 2, 3) should contain noneOf (1, 2, 3)) (equality)
+      (javaList(1, 2, 3) should contain noneOf (1, 2, 3)) (using equality)
+      (javaSet(1, 2, 3) should contain noneOf (1, 2, 3)) (using equality)
 
       val javaMapEquality = new JavaMapSetEquality(Set(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")), Set(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")), false)
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noneOf (Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noneOf (Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (using javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take custom explicit equality in scope when 'should not contain' is used") {
       val equality = new SetEquality(Set(1, 2, 3), Set(7, 8, 9), true)
-      (List(1, 2, 3) should not contain noneOf (7, 8, 9)) (equality)
-      (Set(1, 2, 3) should not contain noneOf (7, 8, 9)) (equality)
-      (Array(1, 2, 3) should not contain noneOf (7, 8, 9)) (equality)
+      (List(1, 2, 3) should not contain noneOf (7, 8, 9)) (using equality)
+      (Set(1, 2, 3) should not contain noneOf (7, 8, 9)) (using equality)
+      (Array(1, 2, 3) should not contain noneOf (7, 8, 9)) (using equality)
       
       val mapEquality = new MapSetEquality(Set(1 -> "one", 2 -> "two", 3 -> "three"), Set(7 -> "seven", 8 -> "eight", 9 -> "nine"), true)
-      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain noneOf (7 -> "seven", 8 -> "eight", 9 -> "nine")) (mapEquality)
+      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain noneOf (7 -> "seven", 8 -> "eight", 9 -> "nine")) (using mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should not contain noneOf (7, 8, 9)) (equality)
-      (javaSet(1, 2, 3) should not contain noneOf (7, 8, 9)) (equality)
+      (javaList(1, 2, 3) should not contain noneOf (7, 8, 9)) (using equality)
+      (javaSet(1, 2, 3) should not contain noneOf (7, 8, 9)) (using equality)
 
       val javaMapEquality = new JavaMapSetEquality(Set(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), Set(Entry(7, "seven"), Entry(8, "eight"), Entry(9, "nine")), true)
-      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain noneOf (Entry(7, "seven"), Entry(8, "eight"), Entry(9, "nine"))) (javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain noneOf (Entry(7, "seven"), Entry(8, "eight"), Entry(9, "nine"))) (using javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -268,19 +268,19 @@ class NoneOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Explicitl
       
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain noneOf (6, 7, 8)) (equality)
+        (left1 should contain noneOf (6, 7, 8)) (using equality)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(6, 7, 8)), thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain noneOf (6, 7, 8)) (equality)
+        (left2 should contain noneOf (6, 7, 8)) (using equality)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(6, 7, 8)), thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain noneOf (6, 7, 8)) (equality)
+        (left3 should contain noneOf (6, 7, 8)) (using equality)
       }
         checkShouldContainStackDepth(e3, left3, deep(Array(6, 7, 8)), thisLineNumber - 2)
         
@@ -288,21 +288,21 @@ class NoneOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Explicitl
         
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain noneOf (6 -> "six", 7 -> "seven", 8 -> "eight")) (mapEquality)
+        (left4 should contain noneOf (6 -> "six", 7 -> "seven", 8 -> "eight")) (using mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(6 -> "six", 7 -> "seven", 8 -> "eight")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain noneOf (6, 7, 8)) (equality)
+        (left5 should contain noneOf (6, 7, 8)) (using equality)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(6, 7, 8)), thisLineNumber - 2)
 
       val javaMapEquality = new JavaMapSetEquality(Set(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), Set(Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight")), true)
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain noneOf (Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight"))) (javaMapEquality)
+        (left6 should contain noneOf (Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight"))) (using javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -313,19 +313,19 @@ class NoneOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Explicitl
       
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain noneOf (1, 2, 3)) (equality)
+        (left1 should not contain noneOf (1, 2, 3)) (using equality)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain noneOf (1, 2, 3)) (equality)
+        (left2 should not contain noneOf (1, 2, 3)) (using equality)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain noneOf (1, 2, 3)) (equality)
+        (left3 should not contain noneOf (1, 2, 3)) (using equality)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array(1, 2, 3)), thisLineNumber - 2)
 
@@ -333,14 +333,14 @@ class NoneOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Explicitl
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain noneOf (1 -> "one", 2 -> "two", 3 -> "three")) (mapEquality)
+        (left4 should not contain noneOf (1 -> "one", 2 -> "two", 3 -> "three")) (using mapEquality)
       }
       checkShouldNotContainStackDepth(e4, left4, deep(Array(1 -> "one", 2 -> "two", 3 -> "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain noneOf (1, 2, 3)) (equality)
+        (left5 should not contain noneOf (1, 2, 3)) (using equality)
       }
       checkShouldNotContainStackDepth(e5, left5, deep(Array(1, 2, 3)), thisLineNumber - 2)
 
@@ -348,7 +348,7 @@ class NoneOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Explicitl
       
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain noneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (javaMapEquality)
+        (left6 should not contain noneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using javaMapEquality)
       }
       checkShouldNotContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/NoneOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/NoneOfContainMatcherEqualitySpec.scala
@@ -229,37 +229,37 @@ class NoneOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Explicitl
     
     it("should take custom explicit equality in scope when 'should contain' is used") {
       val equality = new FalseEquality
-      (List(1, 2, 3) should contain noneOf (1, 2, 3)) (using equality)
-      (Set(1, 2, 3) should contain noneOf (1, 2, 3)) (using equality)
-      (Array(1, 2, 3) should contain noneOf (1, 2, 3)) (using equality)
+      (List(1, 2, 3) should contain noneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
+      (Set(1, 2, 3) should contain noneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
+      (Array(1, 2, 3) should contain noneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
         
       val mapEquality = new MapSetEquality(Set(1 -> "one", 2 -> " two", 3 -> "three"), Set(1 -> "one", 2 -> " two", 3 -> "three"), false)
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noneOf (1 -> "one", 2 -> " two", 3 -> "three")) (using mapEquality)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain noneOf (1 -> "one", 2 -> " two", 3 -> "three")) (/* DOTTY-ONLY using */ mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should contain noneOf (1, 2, 3)) (using equality)
-      (javaSet(1, 2, 3) should contain noneOf (1, 2, 3)) (using equality)
+      (javaList(1, 2, 3) should contain noneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
+      (javaSet(1, 2, 3) should contain noneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
 
       val javaMapEquality = new JavaMapSetEquality(Set(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")), Set(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")), false)
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noneOf (Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (using javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain noneOf (Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take custom explicit equality in scope when 'should not contain' is used") {
       val equality = new SetEquality(Set(1, 2, 3), Set(7, 8, 9), true)
-      (List(1, 2, 3) should not contain noneOf (7, 8, 9)) (using equality)
-      (Set(1, 2, 3) should not contain noneOf (7, 8, 9)) (using equality)
-      (Array(1, 2, 3) should not contain noneOf (7, 8, 9)) (using equality)
+      (List(1, 2, 3) should not contain noneOf (7, 8, 9)) (/* DOTTY-ONLY using */ equality)
+      (Set(1, 2, 3) should not contain noneOf (7, 8, 9)) (/* DOTTY-ONLY using */ equality)
+      (Array(1, 2, 3) should not contain noneOf (7, 8, 9)) (/* DOTTY-ONLY using */ equality)
       
       val mapEquality = new MapSetEquality(Set(1 -> "one", 2 -> "two", 3 -> "three"), Set(7 -> "seven", 8 -> "eight", 9 -> "nine"), true)
-      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain noneOf (7 -> "seven", 8 -> "eight", 9 -> "nine")) (using mapEquality)
+      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain noneOf (7 -> "seven", 8 -> "eight", 9 -> "nine")) (/* DOTTY-ONLY using */ mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should not contain noneOf (7, 8, 9)) (using equality)
-      (javaSet(1, 2, 3) should not contain noneOf (7, 8, 9)) (using equality)
+      (javaList(1, 2, 3) should not contain noneOf (7, 8, 9)) (/* DOTTY-ONLY using */ equality)
+      (javaSet(1, 2, 3) should not contain noneOf (7, 8, 9)) (/* DOTTY-ONLY using */ equality)
 
       val javaMapEquality = new JavaMapSetEquality(Set(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), Set(Entry(7, "seven"), Entry(8, "eight"), Entry(9, "nine")), true)
-      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain noneOf (Entry(7, "seven"), Entry(8, "eight"), Entry(9, "nine"))) (using javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain noneOf (Entry(7, "seven"), Entry(8, "eight"), Entry(9, "nine"))) (/* DOTTY-ONLY using */ javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -268,19 +268,19 @@ class NoneOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Explicitl
       
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain noneOf (6, 7, 8)) (using equality)
+        (left1 should contain noneOf (6, 7, 8)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(6, 7, 8)), thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain noneOf (6, 7, 8)) (using equality)
+        (left2 should contain noneOf (6, 7, 8)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(6, 7, 8)), thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain noneOf (6, 7, 8)) (using equality)
+        (left3 should contain noneOf (6, 7, 8)) (/* DOTTY-ONLY using */ equality)
       }
         checkShouldContainStackDepth(e3, left3, deep(Array(6, 7, 8)), thisLineNumber - 2)
         
@@ -288,21 +288,21 @@ class NoneOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Explicitl
         
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain noneOf (6 -> "six", 7 -> "seven", 8 -> "eight")) (using mapEquality)
+        (left4 should contain noneOf (6 -> "six", 7 -> "seven", 8 -> "eight")) (/* DOTTY-ONLY using */ mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(6 -> "six", 7 -> "seven", 8 -> "eight")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain noneOf (6, 7, 8)) (using equality)
+        (left5 should contain noneOf (6, 7, 8)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(6, 7, 8)), thisLineNumber - 2)
 
       val javaMapEquality = new JavaMapSetEquality(Set(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), Set(Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight")), true)
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain noneOf (Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight"))) (using javaMapEquality)
+        (left6 should contain noneOf (Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight"))) (/* DOTTY-ONLY using */ javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(6, "six"), Entry(7, "seven"), Entry(8, "eight"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -313,19 +313,19 @@ class NoneOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Explicitl
       
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain noneOf (1, 2, 3)) (using equality)
+        (left1 should not contain noneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain noneOf (1, 2, 3)) (using equality)
+        (left2 should not contain noneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain noneOf (1, 2, 3)) (using equality)
+        (left3 should not contain noneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array(1, 2, 3)), thisLineNumber - 2)
 
@@ -333,14 +333,14 @@ class NoneOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Explicitl
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain noneOf (1 -> "one", 2 -> "two", 3 -> "three")) (using mapEquality)
+        (left4 should not contain noneOf (1 -> "one", 2 -> "two", 3 -> "three")) (/* DOTTY-ONLY using */ mapEquality)
       }
       checkShouldNotContainStackDepth(e4, left4, deep(Array(1 -> "one", 2 -> "two", 3 -> "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain noneOf (1, 2, 3)) (using equality)
+        (left5 should not contain noneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e5, left5, deep(Array(1, 2, 3)), thisLineNumber - 2)
 
@@ -348,7 +348,7 @@ class NoneOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Explicitl
       
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain noneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using javaMapEquality)
+        (left6 should not contain noneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ javaMapEquality)
       }
       checkShouldNotContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OneElementOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OneElementOfContainMatcherDeciderSpec.scala
@@ -262,29 +262,29 @@ class OneElementOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
     it("should take specified normalization when 'should contain' is used") {
 
-      (List("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using after being trimmed)
-      (Set("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using after being trimmed)
-      (Array("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using after being trimmed)
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneElementOf Seq(2 -> "two", 6 -> "six", 8 -> "eight")) (using after being mapTrimmed)
+      (List("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Set("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Array("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneElementOf Seq(2 -> "two", 6 -> "six", 8 -> "eight")) (/* DOTTY-ONLY using */ after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using after being trimmed)
-      (javaSet("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using after being trimmed)
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneElementOf Seq(Entry(2, "two"), Entry(6, "six"), Entry(8, "eight"))) (using after being javaMapTrimmed)
+      (javaList("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaSet("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneElementOf Seq(Entry(2, "two"), Entry(6, "six"), Entry(8, "eight"))) (/* DOTTY-ONLY using */ after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take specified normalization when 'should not contain' is used") {
 
-      (List("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (using after being appended)
-      (Set("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (using after being appended)
-      (Array("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (using after being appended)
-      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneElementOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (using after being mapAppended)
+      (List("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (/* DOTTY-ONLY using */ after being appended)
+      (Set("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (/* DOTTY-ONLY using */ after being appended)
+      (Array("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (/* DOTTY-ONLY using */ after being appended)
+      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneElementOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (/* DOTTY-ONLY using */ after being mapAppended)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (using after being appended)
-      (javaSet("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (using after being appended)
-      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneElementOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (using after being javaMapAppended)
+      (javaList("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (/* DOTTY-ONLY using */ after being appended)
+      (javaSet("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (/* DOTTY-ONLY using */ after being appended)
+      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneElementOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (/* DOTTY-ONLY using */ after being javaMapAppended)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -292,38 +292,38 @@ class OneElementOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List("1", "2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain oneElementOf Seq("1", "6", "8")) (using after being appended)
+        (left1 should contain oneElementOf Seq("1", "6", "8")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e1, left1, Seq("1", "6", "8"), thisLineNumber - 2)
 
       val left2 = Set("1", "2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain oneElementOf Seq("1", "6", "8")) (using after being appended)
+        (left2 should contain oneElementOf Seq("1", "6", "8")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e2, left2, Seq("1", "6", "8"), thisLineNumber - 2)
 
       val left3 = Array("1", "2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain oneElementOf Seq("1", "6", "8")) (using after being appended)
+        (left3 should contain oneElementOf Seq("1", "6", "8")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e3, left3, Seq("1", "6", "8"), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain oneElementOf Seq(1 -> "one", 6 -> "six", 8 -> "eight")) (using after being mapAppended)
+        (left4 should contain oneElementOf Seq(1 -> "one", 6 -> "six", 8 -> "eight")) (/* DOTTY-ONLY using */ after being mapAppended)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> "one", 6 -> "six", 8 -> "eight"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", "2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain oneElementOf Seq("1", "6", "8")) (using after being appended)
+        (left5 should contain oneElementOf Seq("1", "6", "8")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e5, left5, Seq("1", "6", "8"), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain oneElementOf Seq(Entry(1, "one"), Entry(6, "six"), Entry(8, "eight"))) (using after being javaMapAppended)
+        (left6 should contain oneElementOf Seq(Entry(1, "one"), Entry(6, "six"), Entry(8, "eight"))) (/* DOTTY-ONLY using */ after being javaMapAppended)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, "one"), Entry(6, "six"), Entry(8, "eight")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -333,38 +333,38 @@ class OneElementOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List("1", " 2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using after being trimmed)
+        (left1 should not contain oneElementOf (Seq("2 ", "6", "8"))) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
       val left2 = Set("1", " 2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using after being trimmed)
+        (left2 should not contain oneElementOf (Seq("2 ", "6", "8"))) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
       val left3 = Array("1", " 2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using after being trimmed)
+        (left3 should not contain oneElementOf (Seq("2 ", "6", "8"))) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one", 2 -> " two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain oneElementOf (Seq(2 -> "two ", 6 -> "six", 8 -> "eight"))) (using after being mapTrimmed)
+        (left4 should not contain oneElementOf (Seq(2 -> "two ", 6 -> "six", 8 -> "eight"))) (/* DOTTY-ONLY using */ after being mapTrimmed)
       }
       checkShouldNotContainStackDepth(e4, left4, Seq(2 -> "two ", 6 -> "six", 8 -> "eight"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", " 2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using after being trimmed)
+        (left5 should not contain oneElementOf (Seq("2 ", "6", "8"))) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldNotContainStackDepth(e5, left5, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain oneElementOf (Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight")))) (using after being javaMapTrimmed)
+        (left6 should not contain oneElementOf (Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight")))) (/* DOTTY-ONLY using */ after being javaMapTrimmed)
       }
       checkShouldNotContainStackDepth(e6, left6, Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -372,27 +372,27 @@ class OneElementOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
     it("should take specified equality and normalization equality when 'should contain' is used") {
 
-      (List("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Set("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Array("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> "ONE", 2 -> " TWO", 3 -> "THREE") should contain oneElementOf Seq(2 -> "two ", 6 -> "six", 8 -> "eight")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Set("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Array("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> "ONE", 2 -> " TWO", 3 -> "THREE") should contain oneElementOf Seq(2 -> "two ", 6 -> "six", 8 -> "eight")) (/* DOTTY-ONLY using */ decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "ONE"), Entry(2, " TWO"), Entry(3, "THREE")) should contain oneElementOf Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "ONE"), Entry(2, " TWO"), Entry(3, "THREE")) should contain oneElementOf Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (/* DOTTY-ONLY using */ decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take specified equality and normalization when 'should not contain' is used") {
 
-      (List("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
-      (Set("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
-      (Array("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
-      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain oneElementOf (Seq(1 -> " one", 2 -> "two ", 3 -> " three"))) (using decided by mapReverseEquality afterBeing mapTrimmed)
+      (List("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Set("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Array("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain oneElementOf (Seq(1 -> " one", 2 -> "two ", 3 -> " three"))) (/* DOTTY-ONLY using */ decided by mapReverseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain oneElementOf (Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+      (javaList("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain oneElementOf (Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")))) (/* DOTTY-ONLY using */ decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -400,38 +400,38 @@ class OneElementOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain oneElementOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left1 should contain oneElementOf Seq(" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left2 = Set("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain oneElementOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left2 should contain oneElementOf Seq(" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left3 = Array("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain oneElementOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left3 should contain oneElementOf Seq(" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain oneElementOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should contain oneElementOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (/* DOTTY-ONLY using */ decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> " one", 2 -> "two ", 3 -> " three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("one ", " two", "three ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain oneElementOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left5 should contain oneElementOf Seq(" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain oneElementOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should contain oneElementOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (/* DOTTY-ONLY using */ decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -441,38 +441,38 @@ class OneElementOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List("ONE ", " TWO", "THREE ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain oneElementOf (Seq("two ", " six", "eight "))) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left1 should not contain oneElementOf (Seq("two ", " six", "eight "))) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq("two ", " six", "eight "), thisLineNumber - 2)
 
       val left2 = Set("ONE ", " TWO", "THREE ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain oneElementOf (Seq("two ", " six", "eight "))) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left2 should not contain oneElementOf (Seq("two ", " six", "eight "))) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq("two ", " six", "eight "), thisLineNumber - 2)
 
       val left3 = Array("ONE ", " TWO", "THREE ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain oneElementOf (Seq("two ", " six", "eight "))) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left3 should not contain oneElementOf (Seq("two ", " six", "eight "))) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq("two ", " six", "eight "), thisLineNumber - 2)
 
       val left4 = Map(1 -> "ONE ", 2 -> " TWO", 3 -> "THREE ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain oneElementOf (Seq(2 -> "two ", 6 -> " six", 8 -> "eight "))) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
+        (left4 should not contain oneElementOf (Seq(2 -> "two ", 6 -> " six", 8 -> "eight "))) (/* DOTTY-ONLY using */ decided by mapLowerCaseEquality afterBeing mapTrimmed)
       }
       checkShouldNotContainStackDepth(e4, left4, Seq(2 -> "two ", 6 -> " six", 8 -> "eight "), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("ONE ", " TWO", "THREE ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain oneElementOf (Seq("two ", " six", "eight "))) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left5 should not contain oneElementOf (Seq("two ", " six", "eight "))) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e5, left5, Seq("two ", " six", "eight "), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "ONE "), Entry(2, " TWO"), Entry(3, "THREE "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain oneElementOf (Seq(Entry(2, "two "), Entry(6, " six"), Entry(8, "eight ")))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+        (left6 should not contain oneElementOf (Seq(Entry(2, "two "), Entry(6, " six"), Entry(8, "eight ")))) (/* DOTTY-ONLY using */ decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       }
       checkShouldNotContainStackDepth(e6, left6, Seq(Entry(2, "two "), Entry(6, " six"), Entry(8, "eight ")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OneElementOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OneElementOfContainMatcherDeciderSpec.scala
@@ -262,29 +262,29 @@ class OneElementOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
     it("should take specified normalization when 'should contain' is used") {
 
-      (List("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (after being trimmed)
-      (Set("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (after being trimmed)
-      (Array("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (after being trimmed)
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneElementOf Seq(2 -> "two", 6 -> "six", 8 -> "eight")) (after being mapTrimmed)
+      (List("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using after being trimmed)
+      (Set("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using after being trimmed)
+      (Array("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using after being trimmed)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneElementOf Seq(2 -> "two", 6 -> "six", 8 -> "eight")) (using after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (after being trimmed)
-      (javaSet("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (after being trimmed)
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneElementOf Seq(Entry(2, "two"), Entry(6, "six"), Entry(8, "eight"))) (after being javaMapTrimmed)
+      (javaList("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using after being trimmed)
+      (javaSet("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using after being trimmed)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneElementOf Seq(Entry(2, "two"), Entry(6, "six"), Entry(8, "eight"))) (using after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take specified normalization when 'should not contain' is used") {
 
-      (List("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (after being appended)
-      (Set("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (after being appended)
-      (Array("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (after being appended)
-      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneElementOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (after being mapAppended)
+      (List("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (using after being appended)
+      (Set("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (using after being appended)
+      (Array("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (using after being appended)
+      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneElementOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (using after being mapAppended)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (after being appended)
-      (javaSet("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (after being appended)
-      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneElementOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (after being javaMapAppended)
+      (javaList("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (using after being appended)
+      (javaSet("1", "2", "3") should not contain oneElementOf (Seq("1", "6", "8"))) (using after being appended)
+      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneElementOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (using after being javaMapAppended)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -292,38 +292,38 @@ class OneElementOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List("1", "2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain oneElementOf Seq("1", "6", "8")) (after being appended)
+        (left1 should contain oneElementOf Seq("1", "6", "8")) (using after being appended)
       }
       checkShouldContainStackDepth(e1, left1, Seq("1", "6", "8"), thisLineNumber - 2)
 
       val left2 = Set("1", "2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain oneElementOf Seq("1", "6", "8")) (after being appended)
+        (left2 should contain oneElementOf Seq("1", "6", "8")) (using after being appended)
       }
       checkShouldContainStackDepth(e2, left2, Seq("1", "6", "8"), thisLineNumber - 2)
 
       val left3 = Array("1", "2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain oneElementOf Seq("1", "6", "8")) (after being appended)
+        (left3 should contain oneElementOf Seq("1", "6", "8")) (using after being appended)
       }
       checkShouldContainStackDepth(e3, left3, Seq("1", "6", "8"), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain oneElementOf Seq(1 -> "one", 6 -> "six", 8 -> "eight")) (after being mapAppended)
+        (left4 should contain oneElementOf Seq(1 -> "one", 6 -> "six", 8 -> "eight")) (using after being mapAppended)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> "one", 6 -> "six", 8 -> "eight"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", "2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain oneElementOf Seq("1", "6", "8")) (after being appended)
+        (left5 should contain oneElementOf Seq("1", "6", "8")) (using after being appended)
       }
       checkShouldContainStackDepth(e5, left5, Seq("1", "6", "8"), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain oneElementOf Seq(Entry(1, "one"), Entry(6, "six"), Entry(8, "eight"))) (after being javaMapAppended)
+        (left6 should contain oneElementOf Seq(Entry(1, "one"), Entry(6, "six"), Entry(8, "eight"))) (using after being javaMapAppended)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, "one"), Entry(6, "six"), Entry(8, "eight")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -333,38 +333,38 @@ class OneElementOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List("1", " 2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain oneElementOf (Seq("2 ", "6", "8"))) (after being trimmed)
+        (left1 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using after being trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
       val left2 = Set("1", " 2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain oneElementOf (Seq("2 ", "6", "8"))) (after being trimmed)
+        (left2 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using after being trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
       val left3 = Array("1", " 2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain oneElementOf (Seq("2 ", "6", "8"))) (after being trimmed)
+        (left3 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using after being trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one", 2 -> " two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain oneElementOf (Seq(2 -> "two ", 6 -> "six", 8 -> "eight"))) (after being mapTrimmed)
+        (left4 should not contain oneElementOf (Seq(2 -> "two ", 6 -> "six", 8 -> "eight"))) (using after being mapTrimmed)
       }
       checkShouldNotContainStackDepth(e4, left4, Seq(2 -> "two ", 6 -> "six", 8 -> "eight"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", " 2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain oneElementOf (Seq("2 ", "6", "8"))) (after being trimmed)
+        (left5 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using after being trimmed)
       }
       checkShouldNotContainStackDepth(e5, left5, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain oneElementOf (Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight")))) (after being javaMapTrimmed)
+        (left6 should not contain oneElementOf (Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight")))) (using after being javaMapTrimmed)
       }
       checkShouldNotContainStackDepth(e6, left6, Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -372,27 +372,27 @@ class OneElementOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
     it("should take specified equality and normalization equality when 'should contain' is used") {
 
-      (List("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Set("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Array("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> "ONE", 2 -> " TWO", 3 -> "THREE") should contain oneElementOf Seq(2 -> "two ", 6 -> "six", 8 -> "eight")) (decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Set("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Array("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> "ONE", 2 -> " TWO", 3 -> "THREE") should contain oneElementOf Seq(2 -> "two ", 6 -> "six", 8 -> "eight")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "ONE"), Entry(2, " TWO"), Entry(3, "THREE")) should contain oneElementOf Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList("ONE", " TWO", "THREE") should contain oneElementOf Seq("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "ONE"), Entry(2, " TWO"), Entry(3, "THREE")) should contain oneElementOf Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take specified equality and normalization when 'should not contain' is used") {
 
-      (List("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (decided by reverseEquality afterBeing trimmed)
-      (Set("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (decided by reverseEquality afterBeing trimmed)
-      (Array("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (decided by reverseEquality afterBeing trimmed)
-      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain oneElementOf (Seq(1 -> " one", 2 -> "two ", 3 -> " three"))) (decided by mapReverseEquality afterBeing mapTrimmed)
+      (List("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
+      (Set("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
+      (Array("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
+      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain oneElementOf (Seq(1 -> " one", 2 -> "two ", 3 -> " three"))) (using decided by mapReverseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (decided by reverseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain oneElementOf (Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")))) (decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+      (javaList("one ", " two", "three ") should not contain oneElementOf (Seq(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain oneElementOf (Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -400,38 +400,38 @@ class OneElementOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain oneElementOf Seq(" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left1 should contain oneElementOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left2 = Set("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain oneElementOf Seq(" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left2 should contain oneElementOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left3 = Array("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain oneElementOf Seq(" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left3 should contain oneElementOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain oneElementOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should contain oneElementOf Seq(1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> " one", 2 -> "two ", 3 -> " three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("one ", " two", "three ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain oneElementOf Seq(" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left5 should contain oneElementOf Seq(" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, Seq(" one", "two ", " three"), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain oneElementOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should contain oneElementOf Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, " one"), Entry(2, "two "), Entry(3, " three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -441,38 +441,38 @@ class OneElementOfContainMatcherDeciderSpec extends funspec.AnyFunSpec with Expl
 
       val left1 = List("ONE ", " TWO", "THREE ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain oneElementOf (Seq("two ", " six", "eight "))) (decided by lowerCaseEquality afterBeing trimmed)
+        (left1 should not contain oneElementOf (Seq("two ", " six", "eight "))) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq("two ", " six", "eight "), thisLineNumber - 2)
 
       val left2 = Set("ONE ", " TWO", "THREE ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain oneElementOf (Seq("two ", " six", "eight "))) (decided by lowerCaseEquality afterBeing trimmed)
+        (left2 should not contain oneElementOf (Seq("two ", " six", "eight "))) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq("two ", " six", "eight "), thisLineNumber - 2)
 
       val left3 = Array("ONE ", " TWO", "THREE ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain oneElementOf (Seq("two ", " six", "eight "))) (decided by lowerCaseEquality afterBeing trimmed)
+        (left3 should not contain oneElementOf (Seq("two ", " six", "eight "))) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq("two ", " six", "eight "), thisLineNumber - 2)
 
       val left4 = Map(1 -> "ONE ", 2 -> " TWO", 3 -> "THREE ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain oneElementOf (Seq(2 -> "two ", 6 -> " six", 8 -> "eight "))) (decided by mapLowerCaseEquality afterBeing mapTrimmed)
+        (left4 should not contain oneElementOf (Seq(2 -> "two ", 6 -> " six", 8 -> "eight "))) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
       }
       checkShouldNotContainStackDepth(e4, left4, Seq(2 -> "two ", 6 -> " six", 8 -> "eight "), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("ONE ", " TWO", "THREE ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain oneElementOf (Seq("two ", " six", "eight "))) (decided by lowerCaseEquality afterBeing trimmed)
+        (left5 should not contain oneElementOf (Seq("two ", " six", "eight "))) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e5, left5, Seq("two ", " six", "eight "), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "ONE "), Entry(2, " TWO"), Entry(3, "THREE "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain oneElementOf (Seq(Entry(2, "two "), Entry(6, " six"), Entry(8, "eight ")))) (decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+        (left6 should not contain oneElementOf (Seq(Entry(2, "two "), Entry(6, " six"), Entry(8, "eight ")))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       }
       checkShouldNotContainStackDepth(e6, left6, Seq(Entry(2, "two "), Entry(6, " six"), Entry(8, "eight ")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OneElementOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OneElementOfContainMatcherEqualitySpec.scala
@@ -220,34 +220,34 @@ class OneElementOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
     it("should take passed in custom explicit equality when 'should contain' is used") {
       implicit val equality = new TrimEquality
-      (List("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using equality)
-      (Set("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using equality)
-      (Array("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using equality)
+      (List("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (/* DOTTY-ONLY using */ equality)
+      (Set("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (/* DOTTY-ONLY using */ equality)
+      (Array("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (/* DOTTY-ONLY using */ equality)
       implicit val mapEquality = new MapTrimEquality
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneElementOf Seq(2 -> "two ", 6 -> "six", 8 -> "eight")) (using mapEquality)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneElementOf Seq(2 -> "two ", 6 -> "six", 8 -> "eight")) (/* DOTTY-ONLY using */ mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using equality)
+      (javaList("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (/* DOTTY-ONLY using */ equality)
 
       implicit val javaMapEquality = new JavaMapTrimEquality
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneElementOf Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (using javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneElementOf Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (/* DOTTY-ONLY using */ javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take passed in custom explicit equality when 'should not contain' is used") {
       implicit val equality = new FalseEquality
-      (List(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (using equality)
-      (Set(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (using equality)
-      (Array(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (using equality)
+      (List(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (/* DOTTY-ONLY using */ equality)
+      (Set(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (/* DOTTY-ONLY using */ equality)
+      (Array(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (/* DOTTY-ONLY using */ equality)
 
       implicit val mapEquality = new MapFalseEquality
-      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneElementOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (using mapEquality)
+      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneElementOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (/* DOTTY-ONLY using */ mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (using equality)
+      (javaList(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (/* DOTTY-ONLY using */ equality)
 
       implicit val javaMapEquality = new JavaMapFalseEquality
-      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneElementOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (using javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneElementOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (/* DOTTY-ONLY using */ javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -256,19 +256,19 @@ class OneElementOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain oneElementOf Seq(1, 2, 3)) (using equality)
+        (left1 should contain oneElementOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e1, left1, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain oneElementOf Seq(1, 2, 3)) (using equality)
+        (left2 should contain oneElementOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e2, left2, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain oneElementOf Seq(1, 2, 3)) (using equality)
+        (left3 should contain oneElementOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e3, left3, Seq(1, 2, 3), thisLineNumber - 2)
 
@@ -276,14 +276,14 @@ class OneElementOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain oneElementOf Seq(1 -> "one", 2 -> "two", 3 -> "three")) (using mapEquality)
+        (left4 should contain oneElementOf Seq(1 -> "one", 2 -> "two", 3 -> "three")) (/* DOTTY-ONLY using */ mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> "one", 2 -> "two", 3 -> "three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain oneElementOf Seq(1, 2, 3)) (using equality)
+        (left5 should contain oneElementOf Seq(1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e5, left5, Seq(1, 2, 3), thisLineNumber - 2)
 
@@ -291,7 +291,7 @@ class OneElementOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain oneElementOf Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using javaMapEquality)
+        (left6 should contain oneElementOf Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -302,19 +302,19 @@ class OneElementOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left1 = List("1", " 2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using equality)
+        (left1 should not contain oneElementOf (Seq("2 ", "6", "8"))) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
       val left2 = Set("1", " 2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using equality)
+        (left2 should not contain oneElementOf (Seq("2 ", "6", "8"))) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
       val left3 = Array("1", " 2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using equality)
+        (left3 should not contain oneElementOf (Seq("2 ", "6", "8"))) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
@@ -322,14 +322,14 @@ class OneElementOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left4 = Map(1 -> "one", 2 -> " two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain oneElementOf (Seq(2 -> "two ", 6 -> "six", 8 -> "eight"))) (using mapEquality)
+        (left4 should not contain oneElementOf (Seq(2 -> "two ", 6 -> "six", 8 -> "eight"))) (/* DOTTY-ONLY using */ mapEquality)
       }
       checkShouldNotContainStackDepth(e4, left4, Seq(2 -> "two ", 6 -> "six", 8 -> "eight"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", " 2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using equality)
+        (left5 should not contain oneElementOf (Seq("2 ", "6", "8"))) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e5, left5, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
@@ -337,7 +337,7 @@ class OneElementOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain oneElementOf (Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight")))) (using javaMapEquality)
+        (left6 should not contain oneElementOf (Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight")))) (/* DOTTY-ONLY using */ javaMapEquality)
       }
       checkShouldNotContainStackDepth(e6, left6, Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OneElementOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OneElementOfContainMatcherEqualitySpec.scala
@@ -220,34 +220,34 @@ class OneElementOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
     it("should take passed in custom explicit equality when 'should contain' is used") {
       implicit val equality = new TrimEquality
-      (List("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (equality)
-      (Set("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (equality)
-      (Array("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (equality)
+      (List("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using equality)
+      (Set("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using equality)
+      (Array("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using equality)
       implicit val mapEquality = new MapTrimEquality
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneElementOf Seq(2 -> "two ", 6 -> "six", 8 -> "eight")) (mapEquality)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneElementOf Seq(2 -> "two ", 6 -> "six", 8 -> "eight")) (using mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (equality)
+      (javaList("1", " 2", "3") should contain oneElementOf Seq("2 ", "6", "8")) (using equality)
 
       implicit val javaMapEquality = new JavaMapTrimEquality
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneElementOf Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneElementOf Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (using javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
     it("should take passed in custom explicit equality when 'should not contain' is used") {
       implicit val equality = new FalseEquality
-      (List(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (equality)
-      (Set(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (equality)
-      (Array(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (equality)
+      (List(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (using equality)
+      (Set(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (using equality)
+      (Array(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (using equality)
 
       implicit val mapEquality = new MapFalseEquality
-      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneElementOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (mapEquality)
+      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneElementOf (Seq(1 -> "one", 2 -> "two", 3 -> "three"))) (using mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (equality)
+      (javaList(1, 2, 3) should not contain oneElementOf (Seq(1, 2, 3))) (using equality)
 
       implicit val javaMapEquality = new JavaMapFalseEquality
-      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneElementOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneElementOf (Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")))) (using javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
 
@@ -256,19 +256,19 @@ class OneElementOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain oneElementOf Seq(1, 2, 3)) (equality)
+        (left1 should contain oneElementOf Seq(1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e1, left1, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain oneElementOf Seq(1, 2, 3)) (equality)
+        (left2 should contain oneElementOf Seq(1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e2, left2, Seq(1, 2, 3), thisLineNumber - 2)
 
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain oneElementOf Seq(1, 2, 3)) (equality)
+        (left3 should contain oneElementOf Seq(1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e3, left3, Seq(1, 2, 3), thisLineNumber - 2)
 
@@ -276,14 +276,14 @@ class OneElementOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain oneElementOf Seq(1 -> "one", 2 -> "two", 3 -> "three")) (mapEquality)
+        (left4 should contain oneElementOf Seq(1 -> "one", 2 -> "two", 3 -> "three")) (using mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, Seq(1 -> "one", 2 -> "two", 3 -> "three"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain oneElementOf Seq(1, 2, 3)) (equality)
+        (left5 should contain oneElementOf Seq(1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e5, left5, Seq(1, 2, 3), thisLineNumber - 2)
 
@@ -291,7 +291,7 @@ class OneElementOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain oneElementOf Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (javaMapEquality)
+        (left6 should contain oneElementOf Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, Seq(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -302,19 +302,19 @@ class OneElementOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left1 = List("1", " 2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain oneElementOf (Seq("2 ", "6", "8"))) (equality)
+        (left1 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using equality)
       }
       checkShouldNotContainStackDepth(e1, left1, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
       val left2 = Set("1", " 2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain oneElementOf (Seq("2 ", "6", "8"))) (equality)
+        (left2 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using equality)
       }
       checkShouldNotContainStackDepth(e2, left2, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
       val left3 = Array("1", " 2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain oneElementOf (Seq("2 ", "6", "8"))) (equality)
+        (left3 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using equality)
       }
       checkShouldNotContainStackDepth(e3, left3, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
@@ -322,14 +322,14 @@ class OneElementOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left4 = Map(1 -> "one", 2 -> " two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain oneElementOf (Seq(2 -> "two ", 6 -> "six", 8 -> "eight"))) (mapEquality)
+        (left4 should not contain oneElementOf (Seq(2 -> "two ", 6 -> "six", 8 -> "eight"))) (using mapEquality)
       }
       checkShouldNotContainStackDepth(e4, left4, Seq(2 -> "two ", 6 -> "six", 8 -> "eight"), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", " 2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain oneElementOf (Seq("2 ", "6", "8"))) (equality)
+        (left5 should not contain oneElementOf (Seq("2 ", "6", "8"))) (using equality)
       }
       checkShouldNotContainStackDepth(e5, left5, Seq("2 ", "6", "8"), thisLineNumber - 2)
 
@@ -337,7 +337,7 @@ class OneElementOfContainMatcherEqualitySpec extends funspec.AnyFunSpec with Exp
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain oneElementOf (Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight")))) (javaMapEquality)
+        (left6 should not contain oneElementOf (Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight")))) (using javaMapEquality)
       }
       checkShouldNotContainStackDepth(e6, left6, Seq(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight")), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OneOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OneOfContainMatcherDeciderSpec.scala
@@ -265,29 +265,29 @@ class OneOfContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
     
     it("should take specified normalization when 'should contain' is used") {
       
-      (List("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (after being trimmed)
-      (Set("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (after being trimmed)
-      (Array("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (after being trimmed)
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneOf (2 -> "two", 6 -> "six", 8 -> "eight")) (after being mapTrimmed)
+      (List("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using after being trimmed)
+      (Set("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using after being trimmed)
+      (Array("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using after being trimmed)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneOf (2 -> "two", 6 -> "six", 8 -> "eight")) (using after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (after being trimmed)
-      (javaSet("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (after being trimmed)
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneOf (Entry(2, "two"), Entry(6, "six"), Entry(8, "eight"))) (after being javaMapTrimmed)
+      (javaList("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using after being trimmed)
+      (javaSet("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using after being trimmed)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneOf (Entry(2, "two"), Entry(6, "six"), Entry(8, "eight"))) (using after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified normalization when 'should not contain' is used") {
       
-      (List("1", "2", "3") should not contain oneOf ("1", "6", "8")) (after being appended)
-      (Set("1", "2", "3") should not contain oneOf ("1", "6", "8")) (after being appended)
-      (Array("1", "2", "3") should not contain oneOf ("1", "6", "8")) (after being appended)
-      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneOf (1 -> "one", 2 -> "two", 3 -> "three")) (after being mapAppended)
+      (List("1", "2", "3") should not contain oneOf ("1", "6", "8")) (using after being appended)
+      (Set("1", "2", "3") should not contain oneOf ("1", "6", "8")) (using after being appended)
+      (Array("1", "2", "3") should not contain oneOf ("1", "6", "8")) (using after being appended)
+      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneOf (1 -> "one", 2 -> "two", 3 -> "three")) (using after being mapAppended)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", "2", "3") should not contain oneOf ("1", "6", "8")) (after being appended)
-      (javaSet("1", "2", "3") should not contain oneOf ("1", "6", "8")) (after being appended)
-      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (after being javaMapAppended)
+      (javaList("1", "2", "3") should not contain oneOf ("1", "6", "8")) (using after being appended)
+      (javaSet("1", "2", "3") should not contain oneOf ("1", "6", "8")) (using after being appended)
+      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using after being javaMapAppended)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -295,38 +295,38 @@ class OneOfContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("1", "2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain oneOf ("1", "6", "8")) (after being appended)
+        (left1 should contain oneOf ("1", "6", "8")) (using after being appended)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array("1", "6", "8")), thisLineNumber - 2)
         
       val left2 = Set("1", "2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain oneOf ("1", "6", "8")) (after being appended)
+        (left2 should contain oneOf ("1", "6", "8")) (using after being appended)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array("1", "6", "8")), thisLineNumber - 2)
         
       val left3 = Array("1", "2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain oneOf ("1", "6", "8")) (after being appended)
+        (left3 should contain oneOf ("1", "6", "8")) (using after being appended)
       }
         checkShouldContainStackDepth(e3, left3, deep(Array("1", "6", "8")), thisLineNumber - 2)
         
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain oneOf (1 -> "one", 6 -> "six", 8 -> "eight")) (after being mapAppended)
+        (left4 should contain oneOf (1 -> "one", 6 -> "six", 8 -> "eight")) (using after being mapAppended)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> "one", 6 -> "six", 8 -> "eight")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", "2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain oneOf ("1", "6", "8")) (after being appended)
+        (left5 should contain oneOf ("1", "6", "8")) (using after being appended)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array("1", "6", "8")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain oneOf (Entry(1, "one"), Entry(6, "six"), Entry(8, "eight"))) (after being javaMapAppended)
+        (left6 should contain oneOf (Entry(1, "one"), Entry(6, "six"), Entry(8, "eight"))) (using after being javaMapAppended)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(6, "six"), Entry(8, "eight"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -336,38 +336,38 @@ class OneOfContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("1", " 2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain oneOf ("2 ", "6", "8")) (after being trimmed)
+        (left1 should not contain oneOf ("2 ", "6", "8")) (using after being trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
         
       val left2 = Set("1", " 2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain oneOf ("2 ", "6", "8")) (after being trimmed)
+        (left2 should not contain oneOf ("2 ", "6", "8")) (using after being trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
         
       val left3 = Array("1", " 2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain oneOf ("2 ", "6", "8")) (after being trimmed)
+        (left3 should not contain oneOf ("2 ", "6", "8")) (using after being trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
       
       val left4 = Map(1 -> "one", 2 -> " two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (after being mapTrimmed)
+        (left4 should not contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (using after being mapTrimmed)
       }
       checkShouldNotContainStackDepth(e4, left4, deep(Array(2 -> "two ", 6 -> "six", 8 -> "eight")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", " 2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain oneOf ("2 ", "6", "8")) (after being trimmed)
+        (left5 should not contain oneOf ("2 ", "6", "8")) (using after being trimmed)
       }
       checkShouldNotContainStackDepth(e5, left5, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (after being javaMapTrimmed)
+        (left6 should not contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (using after being javaMapTrimmed)
       }
       checkShouldNotContainStackDepth(e6, left6, deep(Array(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -375,27 +375,27 @@ class OneOfContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
     
     it("should take specified equality and normalization equality when 'should contain' is used") {
       
-      (List("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Set("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Array("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> "ONE", 2 -> " TWO", 3 -> "THREE") should contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Set("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Array("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> "ONE", 2 -> " TWO", 3 -> "THREE") should contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "ONE"), Entry(2, " TWO"), Entry(3, "THREE")) should contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "ONE"), Entry(2, " TWO"), Entry(3, "THREE")) should contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified equality and normalization when 'should not contain' is used") {
       
-      (List("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
-      (Set("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
-      (Array("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
-      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain oneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (decided by mapReverseEquality afterBeing mapTrimmed)
+      (List("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (Set("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (Array("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain oneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain oneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+      (javaList("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain oneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -403,38 +403,38 @@ class OneOfContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
         
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain oneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left1 should contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left2 = Set("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain oneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left2 should contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left3 = Array("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain oneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left3 should contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain oneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should contain oneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> " one", 2 -> "two ", 3 -> " three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("one ", " two", "three ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain oneOf (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left5 should contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain oneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should contain oneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -444,38 +444,38 @@ class OneOfContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("ONE ", " TWO", "THREE ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain oneOf ("two ", " six", "eight ")) (decided by lowerCaseEquality afterBeing trimmed)
+        (left1 should not contain oneOf ("two ", " six", "eight ")) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array("two ", " six", "eight ")), thisLineNumber - 2)
         
       val left2 = Set("ONE ", " TWO", "THREE ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain oneOf ("two ", " six", "eight ")) (decided by lowerCaseEquality afterBeing trimmed)
+        (left2 should not contain oneOf ("two ", " six", "eight ")) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array("two ", " six", "eight ")), thisLineNumber - 2)
         
       val left3 = Array("ONE ", " TWO", "THREE ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain oneOf ("two ", " six", "eight ")) (decided by lowerCaseEquality afterBeing trimmed)
+        (left3 should not contain oneOf ("two ", " six", "eight ")) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array("two ", " six", "eight ")), thisLineNumber - 2)
       
       val left4 = Map(1 -> "ONE ", 2 -> " TWO", 3 -> "THREE ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain oneOf (2 -> "two ", 6 -> " six", 8 -> "eight ")) (decided by mapLowerCaseEquality afterBeing mapTrimmed)
+        (left4 should not contain oneOf (2 -> "two ", 6 -> " six", 8 -> "eight ")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
       }
       checkShouldNotContainStackDepth(e4, left4, deep(Array(2 -> "two ", 6 -> " six", 8 -> "eight ")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("ONE ", " TWO", "THREE ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain oneOf ("two ", " six", "eight ")) (decided by lowerCaseEquality afterBeing trimmed)
+        (left5 should not contain oneOf ("two ", " six", "eight ")) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e5, left5, deep(Array("two ", " six", "eight ")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "ONE "), Entry(2, " TWO"), Entry(3, "THREE "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain oneOf (Entry(2, "two "), Entry(6, " six"), Entry(8, "eight "))) (decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+        (left6 should not contain oneOf (Entry(2, "two "), Entry(6, " six"), Entry(8, "eight "))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       }
       checkShouldNotContainStackDepth(e6, left6, deep(Array(Entry(2, "two "), Entry(6, " six"), Entry(8, "eight "))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OneOfContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OneOfContainMatcherDeciderSpec.scala
@@ -265,29 +265,29 @@ class OneOfContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
     
     it("should take specified normalization when 'should contain' is used") {
       
-      (List("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using after being trimmed)
-      (Set("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using after being trimmed)
-      (Array("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using after being trimmed)
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneOf (2 -> "two", 6 -> "six", 8 -> "eight")) (using after being mapTrimmed)
+      (List("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Set("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Array("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneOf (2 -> "two", 6 -> "six", 8 -> "eight")) (/* DOTTY-ONLY using */ after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using after being trimmed)
-      (javaSet("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using after being trimmed)
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneOf (Entry(2, "two"), Entry(6, "six"), Entry(8, "eight"))) (using after being javaMapTrimmed)
+      (javaList("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaSet("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneOf (Entry(2, "two"), Entry(6, "six"), Entry(8, "eight"))) (/* DOTTY-ONLY using */ after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified normalization when 'should not contain' is used") {
       
-      (List("1", "2", "3") should not contain oneOf ("1", "6", "8")) (using after being appended)
-      (Set("1", "2", "3") should not contain oneOf ("1", "6", "8")) (using after being appended)
-      (Array("1", "2", "3") should not contain oneOf ("1", "6", "8")) (using after being appended)
-      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneOf (1 -> "one", 2 -> "two", 3 -> "three")) (using after being mapAppended)
+      (List("1", "2", "3") should not contain oneOf ("1", "6", "8")) (/* DOTTY-ONLY using */ after being appended)
+      (Set("1", "2", "3") should not contain oneOf ("1", "6", "8")) (/* DOTTY-ONLY using */ after being appended)
+      (Array("1", "2", "3") should not contain oneOf ("1", "6", "8")) (/* DOTTY-ONLY using */ after being appended)
+      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneOf (1 -> "one", 2 -> "two", 3 -> "three")) (/* DOTTY-ONLY using */ after being mapAppended)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", "2", "3") should not contain oneOf ("1", "6", "8")) (using after being appended)
-      (javaSet("1", "2", "3") should not contain oneOf ("1", "6", "8")) (using after being appended)
-      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using after being javaMapAppended)
+      (javaList("1", "2", "3") should not contain oneOf ("1", "6", "8")) (/* DOTTY-ONLY using */ after being appended)
+      (javaSet("1", "2", "3") should not contain oneOf ("1", "6", "8")) (/* DOTTY-ONLY using */ after being appended)
+      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ after being javaMapAppended)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -295,38 +295,38 @@ class OneOfContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("1", "2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain oneOf ("1", "6", "8")) (using after being appended)
+        (left1 should contain oneOf ("1", "6", "8")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array("1", "6", "8")), thisLineNumber - 2)
         
       val left2 = Set("1", "2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain oneOf ("1", "6", "8")) (using after being appended)
+        (left2 should contain oneOf ("1", "6", "8")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array("1", "6", "8")), thisLineNumber - 2)
         
       val left3 = Array("1", "2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain oneOf ("1", "6", "8")) (using after being appended)
+        (left3 should contain oneOf ("1", "6", "8")) (/* DOTTY-ONLY using */ after being appended)
       }
         checkShouldContainStackDepth(e3, left3, deep(Array("1", "6", "8")), thisLineNumber - 2)
         
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain oneOf (1 -> "one", 6 -> "six", 8 -> "eight")) (using after being mapAppended)
+        (left4 should contain oneOf (1 -> "one", 6 -> "six", 8 -> "eight")) (/* DOTTY-ONLY using */ after being mapAppended)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> "one", 6 -> "six", 8 -> "eight")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", "2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain oneOf ("1", "6", "8")) (using after being appended)
+        (left5 should contain oneOf ("1", "6", "8")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array("1", "6", "8")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain oneOf (Entry(1, "one"), Entry(6, "six"), Entry(8, "eight"))) (using after being javaMapAppended)
+        (left6 should contain oneOf (Entry(1, "one"), Entry(6, "six"), Entry(8, "eight"))) (/* DOTTY-ONLY using */ after being javaMapAppended)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(6, "six"), Entry(8, "eight"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -336,38 +336,38 @@ class OneOfContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("1", " 2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain oneOf ("2 ", "6", "8")) (using after being trimmed)
+        (left1 should not contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
         
       val left2 = Set("1", " 2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain oneOf ("2 ", "6", "8")) (using after being trimmed)
+        (left2 should not contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
         
       val left3 = Array("1", " 2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain oneOf ("2 ", "6", "8")) (using after being trimmed)
+        (left3 should not contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
       
       val left4 = Map(1 -> "one", 2 -> " two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (using after being mapTrimmed)
+        (left4 should not contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (/* DOTTY-ONLY using */ after being mapTrimmed)
       }
       checkShouldNotContainStackDepth(e4, left4, deep(Array(2 -> "two ", 6 -> "six", 8 -> "eight")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", " 2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain oneOf ("2 ", "6", "8")) (using after being trimmed)
+        (left5 should not contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldNotContainStackDepth(e5, left5, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (using after being javaMapTrimmed)
+        (left6 should not contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (/* DOTTY-ONLY using */ after being javaMapTrimmed)
       }
       checkShouldNotContainStackDepth(e6, left6, deep(Array(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -375,27 +375,27 @@ class OneOfContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
     
     it("should take specified equality and normalization equality when 'should contain' is used") {
       
-      (List("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Set("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Array("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> "ONE", 2 -> " TWO", 3 -> "THREE") should contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Set("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Array("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> "ONE", 2 -> " TWO", 3 -> "THREE") should contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (/* DOTTY-ONLY using */ decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "ONE"), Entry(2, " TWO"), Entry(3, "THREE")) should contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList("ONE", " TWO", "THREE") should contain oneOf ("two ", "six", "eight")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "ONE"), Entry(2, " TWO"), Entry(3, "THREE")) should contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (/* DOTTY-ONLY using */ decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified equality and normalization when 'should not contain' is used") {
       
-      (List("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
-      (Set("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
-      (Array("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
-      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain oneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
+      (List("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Set("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Array("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should not contain oneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (/* DOTTY-ONLY using */ decided by mapReverseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain oneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+      (javaList("one ", " two", "three ") should not contain oneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should not contain oneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (/* DOTTY-ONLY using */ decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -403,38 +403,38 @@ class OneOfContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
         
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left1 should contain oneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left2 = Set("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left2 should contain oneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left3 = Array("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left3 should contain oneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain oneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should contain oneOf (1 -> " one", 2 -> "two ", 3 -> " three")) (/* DOTTY-ONLY using */ decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> " one", 2 -> "two ", 3 -> " three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("one ", " two", "three ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain oneOf (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left5 should contain oneOf (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain oneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should contain oneOf (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (/* DOTTY-ONLY using */ decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -444,38 +444,38 @@ class OneOfContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("ONE ", " TWO", "THREE ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain oneOf ("two ", " six", "eight ")) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left1 should not contain oneOf ("two ", " six", "eight ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array("two ", " six", "eight ")), thisLineNumber - 2)
         
       val left2 = Set("ONE ", " TWO", "THREE ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain oneOf ("two ", " six", "eight ")) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left2 should not contain oneOf ("two ", " six", "eight ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array("two ", " six", "eight ")), thisLineNumber - 2)
         
       val left3 = Array("ONE ", " TWO", "THREE ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain oneOf ("two ", " six", "eight ")) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left3 should not contain oneOf ("two ", " six", "eight ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array("two ", " six", "eight ")), thisLineNumber - 2)
       
       val left4 = Map(1 -> "ONE ", 2 -> " TWO", 3 -> "THREE ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain oneOf (2 -> "two ", 6 -> " six", 8 -> "eight ")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
+        (left4 should not contain oneOf (2 -> "two ", 6 -> " six", 8 -> "eight ")) (/* DOTTY-ONLY using */ decided by mapLowerCaseEquality afterBeing mapTrimmed)
       }
       checkShouldNotContainStackDepth(e4, left4, deep(Array(2 -> "two ", 6 -> " six", 8 -> "eight ")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("ONE ", " TWO", "THREE ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain oneOf ("two ", " six", "eight ")) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left5 should not contain oneOf ("two ", " six", "eight ")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e5, left5, deep(Array("two ", " six", "eight ")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "ONE "), Entry(2, " TWO"), Entry(3, "THREE "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain oneOf (Entry(2, "two "), Entry(6, " six"), Entry(8, "eight "))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+        (left6 should not contain oneOf (Entry(2, "two "), Entry(6, " six"), Entry(8, "eight "))) (/* DOTTY-ONLY using */ decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       }
       checkShouldNotContainStackDepth(e6, left6, deep(Array(Entry(2, "two "), Entry(6, " six"), Entry(8, "eight "))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OneOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OneOfContainMatcherEqualitySpec.scala
@@ -223,35 +223,35 @@ class OneOfContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
     
     it("should take passed in custom explicit equality when 'should contain' is used") {
       implicit val equality = new TrimEquality
-      (List("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (equality)
-      (Set("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (equality)
-      (Array("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (equality)
+      (List("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using equality)
+      (Set("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using equality)
+      (Array("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using equality)
        
       implicit val mapEquality = new MapTrimEquality
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (mapEquality)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (using mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (equality)
+      (javaList("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using equality)
 
       implicit val javaMapEquality = new JavaMapTrimEquality
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (using javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take passed in custom explicit equality when 'should not contain' is used") {
       implicit val equality = new FalseEquality
-      (List(1, 2, 3) should not contain oneOf (1, 2, 3)) (equality)
-      (Set(1, 2, 3) should not contain oneOf (1, 2, 3)) (equality)
-      (Array(1, 2, 3) should not contain oneOf (1, 2, 3)) (equality)
+      (List(1, 2, 3) should not contain oneOf (1, 2, 3)) (using equality)
+      (Set(1, 2, 3) should not contain oneOf (1, 2, 3)) (using equality)
+      (Array(1, 2, 3) should not contain oneOf (1, 2, 3)) (using equality)
         
       implicit val mapEquality = new MapFalseEquality
-      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneOf (1 -> "one", 2 -> "two", 3 -> "three")) (mapEquality)
+      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneOf (1 -> "one", 2 -> "two", 3 -> "three")) (using mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should not contain oneOf (1, 2, 3)) (equality)
+      (javaList(1, 2, 3) should not contain oneOf (1, 2, 3)) (using equality)
 
       implicit val javaMapEquality = new JavaMapFalseEquality
-      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -260,19 +260,19 @@ class OneOfContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
         
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain oneOf (1, 2, 3)) (equality)
+        (left1 should contain oneOf (1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain oneOf (1, 2, 3)) (equality)
+        (left2 should contain oneOf (1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain oneOf (1, 2, 3)) (equality)
+        (left3 should contain oneOf (1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
@@ -280,14 +280,14 @@ class OneOfContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
         
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain oneOf (1 -> "one", 2 -> "two", 3 -> "three")) (mapEquality)
+        (left4 should contain oneOf (1 -> "one", 2 -> "two", 3 -> "three")) (using mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> "one", 2 -> "two", 3 -> "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain oneOf (1, 2, 3)) (equality)
+        (left5 should contain oneOf (1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(1, 2, 3)), thisLineNumber - 2)
 
@@ -295,7 +295,7 @@ class OneOfContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
       
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain oneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (javaMapEquality)
+        (left6 should contain oneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -306,19 +306,19 @@ class OneOfContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
         
       val left1 = List("1", " 2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain oneOf ("2 ", "6", "8")) (equality)
+        (left1 should not contain oneOf ("2 ", "6", "8")) (using equality)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
         
       val left2 = Set("1", " 2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain oneOf ("2 ", "6", "8")) (equality)
+        (left2 should not contain oneOf ("2 ", "6", "8")) (using equality)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
         
       val left3 = Array("1", " 2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain oneOf ("2 ", "6", "8")) (equality)
+        (left3 should not contain oneOf ("2 ", "6", "8")) (using equality)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
         
@@ -326,14 +326,14 @@ class OneOfContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
        
       val left4 = Map(1 -> "one", 2 -> " two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (mapEquality)
+        (left4 should not contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (using mapEquality)
       }
       checkShouldNotContainStackDepth(e4, left4, deep(Array(2 -> "two ", 6 -> "six", 8 -> "eight")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", " 2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain oneOf ("2 ", "6", "8")) (equality)
+        (left5 should not contain oneOf ("2 ", "6", "8")) (using equality)
       }
       checkShouldNotContainStackDepth(e5, left5, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
 
@@ -341,7 +341,7 @@ class OneOfContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
         
       val left6 = javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (javaMapEquality)
+        (left6 should not contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (using javaMapEquality)
       }
       checkShouldNotContainStackDepth(e6, left6, deep(Array(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OneOfContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OneOfContainMatcherEqualitySpec.scala
@@ -223,35 +223,35 @@ class OneOfContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
     
     it("should take passed in custom explicit equality when 'should contain' is used") {
       implicit val equality = new TrimEquality
-      (List("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using equality)
-      (Set("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using equality)
-      (Array("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using equality)
+      (List("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ equality)
+      (Set("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ equality)
+      (Array("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ equality)
        
       implicit val mapEquality = new MapTrimEquality
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (using mapEquality)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (/* DOTTY-ONLY using */ mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (using equality)
+      (javaList("1", " 2", "3") should contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ equality)
 
       implicit val javaMapEquality = new JavaMapTrimEquality
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (using javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (/* DOTTY-ONLY using */ javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take passed in custom explicit equality when 'should not contain' is used") {
       implicit val equality = new FalseEquality
-      (List(1, 2, 3) should not contain oneOf (1, 2, 3)) (using equality)
-      (Set(1, 2, 3) should not contain oneOf (1, 2, 3)) (using equality)
-      (Array(1, 2, 3) should not contain oneOf (1, 2, 3)) (using equality)
+      (List(1, 2, 3) should not contain oneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
+      (Set(1, 2, 3) should not contain oneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
+      (Array(1, 2, 3) should not contain oneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
         
       implicit val mapEquality = new MapFalseEquality
-      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneOf (1 -> "one", 2 -> "two", 3 -> "three")) (using mapEquality)
+      (Map(1 -> "one", 2 -> "two", 3 -> "three") should not contain oneOf (1 -> "one", 2 -> "two", 3 -> "three")) (/* DOTTY-ONLY using */ mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should not contain oneOf (1, 2, 3)) (using equality)
+      (javaList(1, 2, 3) should not contain oneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
 
       implicit val javaMapEquality = new JavaMapFalseEquality
-      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using javaMapEquality)
+      (javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three")) should not contain oneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -260,19 +260,19 @@ class OneOfContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
         
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain oneOf (1, 2, 3)) (using equality)
+        (left1 should contain oneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain oneOf (1, 2, 3)) (using equality)
+        (left2 should contain oneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain oneOf (1, 2, 3)) (using equality)
+        (left3 should contain oneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
@@ -280,14 +280,14 @@ class OneOfContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
         
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain oneOf (1 -> "one", 2 -> "two", 3 -> "three")) (using mapEquality)
+        (left4 should contain oneOf (1 -> "one", 2 -> "two", 3 -> "three")) (/* DOTTY-ONLY using */ mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> "one", 2 -> "two", 3 -> "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain oneOf (1, 2, 3)) (using equality)
+        (left5 should contain oneOf (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(1, 2, 3)), thisLineNumber - 2)
 
@@ -295,7 +295,7 @@ class OneOfContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
       
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain oneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using javaMapEquality)
+        (left6 should contain oneOf (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -306,19 +306,19 @@ class OneOfContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
         
       val left1 = List("1", " 2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain oneOf ("2 ", "6", "8")) (using equality)
+        (left1 should not contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e1, left1, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
         
       val left2 = Set("1", " 2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain oneOf ("2 ", "6", "8")) (using equality)
+        (left2 should not contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e2, left2, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
         
       val left3 = Array("1", " 2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain oneOf ("2 ", "6", "8")) (using equality)
+        (left3 should not contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e3, left3, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
         
@@ -326,14 +326,14 @@ class OneOfContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
        
       val left4 = Map(1 -> "one", 2 -> " two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should not contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (using mapEquality)
+        (left4 should not contain oneOf (2 -> "two ", 6 -> "six", 8 -> "eight")) (/* DOTTY-ONLY using */ mapEquality)
       }
       checkShouldNotContainStackDepth(e4, left4, deep(Array(2 -> "two ", 6 -> "six", 8 -> "eight")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", " 2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should not contain oneOf ("2 ", "6", "8")) (using equality)
+        (left5 should not contain oneOf ("2 ", "6", "8")) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e5, left5, deep(Array("2 ", "6", "8")), thisLineNumber - 2)
 
@@ -341,7 +341,7 @@ class OneOfContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
         
       val left6 = javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should not contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (using javaMapEquality)
+        (left6 should not contain oneOf (Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))) (/* DOTTY-ONLY using */ javaMapEquality)
       }
       checkShouldNotContainStackDepth(e6, left6, deep(Array(Entry(2, "two "), Entry(6, "six"), Entry(8, "eight"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OnlyContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OnlyContainMatcherDeciderSpec.scala
@@ -264,15 +264,15 @@ class OnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
     
     it("should take specified normalization when 'should contain' is used") {
       
-      (List("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (using after being trimmed)
-      (Set("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (using after being trimmed)
-      (Array("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (using after being trimmed)
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (using after being mapTrimmed)
+      (List("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Set("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Array("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (/* DOTTY-ONLY using */ after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (using after being trimmed)
-      (javaSet("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (using after being trimmed)
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using after being javaMapTrimmed)
+      (javaList("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaSet("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (/* DOTTY-ONLY using */ after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -294,38 +294,38 @@ class OnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("1", "2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain only ("1", "2", "3")) (using after being appended)
+        (left1 should contain only ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array("1", "2", "3")), thisLineNumber - 2)
         
       val left2 = Set("1", "2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain only ("1", "2", "3")) (using after being appended)
+        (left2 should contain only ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array("1", "2", "3")), thisLineNumber - 2)
         
       val left3 = Array("1", "2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain only ("1", "2", "3")) (using after being appended)
+        (left3 should contain only ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
         checkShouldContainStackDepth(e3, left3, deep(Array("1", "2", "3")), thisLineNumber - 2)
        
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain only (1 -> "one", 2 -> "two", 3 -> "three")) (using after being mapAppended)
+        (left4 should contain only (1 -> "one", 2 -> "two", 3 -> "three")) (/* DOTTY-ONLY using */ after being mapAppended)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> "one", 2 -> "two", 3 -> "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", "2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain only ("1", "2", "3")) (using after being appended)
+        (left5 should contain only ("1", "2", "3")) (/* DOTTY-ONLY using */ after being appended)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array("1", "2", "3")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain only (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using after being javaMapAppended)
+        (left6 should contain only (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ after being javaMapAppended)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -374,14 +374,14 @@ class OnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
     
     it("should take specified equality and normalization when 'should contain' is used") {
       
-      (List("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Set("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Array("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> "ONE ", 2 -> " TWO", 3 -> "THREE ") should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Set("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Array("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> "ONE ", 2 -> " TWO", 3 -> "THREE ") should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (/* DOTTY-ONLY using */ decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "ONE "), Entry(2, " TWO"), Entry(3, "THREE ")) should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "ONE "), Entry(2, " TWO"), Entry(3, "THREE ")) should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (/* DOTTY-ONLY using */ decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -402,38 +402,38 @@ class OnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain only (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left1 should contain only (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left2 = Set("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain only (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left2 should contain only (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left3 = Array("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain only (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left3 should contain only (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (/* DOTTY-ONLY using */ decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> " one", 2 -> "two ", 3 -> " three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("one ", " two", "three ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain only (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
+        (left5 should contain only (" one", "two ", " three")) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (/* DOTTY-ONLY using */ decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OnlyContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OnlyContainMatcherDeciderSpec.scala
@@ -264,15 +264,15 @@ class OnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
     
     it("should take specified normalization when 'should contain' is used") {
       
-      (List("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (after being trimmed)
-      (Set("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (after being trimmed)
-      (Array("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (after being trimmed)
-      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (after being mapTrimmed)
+      (List("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (using after being trimmed)
+      (Set("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (using after being trimmed)
+      (Array("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (using after being trimmed)
+      (Map(1 -> "one", 2 -> " two", 3 -> "three") should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (using after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (after being trimmed)
-      (javaSet("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (after being trimmed)
-      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (after being javaMapTrimmed)
+      (javaList("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (using after being trimmed)
+      (javaSet("1", " 2", "3") should contain only (" 1", "2 ", " 3")) (using after being trimmed)
+      (javaMap(Entry(1, "one"), Entry(2, " two"), Entry(3, "three")) should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -294,38 +294,38 @@ class OnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("1", "2", "3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain only ("1", "2", "3")) (after being appended)
+        (left1 should contain only ("1", "2", "3")) (using after being appended)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array("1", "2", "3")), thisLineNumber - 2)
         
       val left2 = Set("1", "2", "3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain only ("1", "2", "3")) (after being appended)
+        (left2 should contain only ("1", "2", "3")) (using after being appended)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array("1", "2", "3")), thisLineNumber - 2)
         
       val left3 = Array("1", "2", "3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain only ("1", "2", "3")) (after being appended)
+        (left3 should contain only ("1", "2", "3")) (using after being appended)
       }
         checkShouldContainStackDepth(e3, left3, deep(Array("1", "2", "3")), thisLineNumber - 2)
        
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain only (1 -> "one", 2 -> "two", 3 -> "three")) (after being mapAppended)
+        (left4 should contain only (1 -> "one", 2 -> "two", 3 -> "three")) (using after being mapAppended)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> "one", 2 -> "two", 3 -> "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("1", "2", "3")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain only ("1", "2", "3")) (after being appended)
+        (left5 should contain only ("1", "2", "3")) (using after being appended)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array("1", "2", "3")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain only (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (after being javaMapAppended)
+        (left6 should contain only (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using after being javaMapAppended)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -374,14 +374,14 @@ class OnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
     
     it("should take specified equality and normalization when 'should contain' is used") {
       
-      (List("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Set("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Array("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> "ONE ", 2 -> " TWO", 3 -> "THREE ") should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Set("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Array("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> "ONE ", 2 -> " TWO", 3 -> "THREE ") should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "ONE "), Entry(2, " TWO"), Entry(3, "THREE ")) should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList("ONE ", " TWO", "THREE ") should contain only (" one", "two ", " three")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "ONE "), Entry(2, " TWO"), Entry(3, "THREE ")) should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -402,38 +402,38 @@ class OnlyContainMatcherDeciderSpec extends AnyFunSpec with Explicitly {
       
       val left1 = List("one ", " two", "three ")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain only (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left1 should contain only (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left2 = Set("one ", " two", "three ")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain only (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left2 should contain only (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left3 = Array("one ", " two", "three ")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain only (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left3 should contain only (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
         
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (using decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> " one", 2 -> "two ", 3 -> " three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList("one ", " two", "three ")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain only (" one", "two ", " three")) (decided by reverseEquality afterBeing trimmed)
+        (left5 should contain only (" one", "two ", " three")) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(" one", "two ", " three")), thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OnlyContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OnlyContainMatcherEqualitySpec.scala
@@ -225,18 +225,18 @@ class OnlyContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
     
     it("should take passed in custom explicit equality when 'should contain' is used") {
       implicit val equality = new TrimEquality
-      (List("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (using equality)
-      (Set("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (using equality)
-      (Array("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (using equality)
+      (List("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ equality)
+      (Set("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ equality)
+      (Array("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ equality)
 
       implicit val mapEquality = new MapTrimEquality
-      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (using mapEquality)
+      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (/* DOTTY-ONLY using */ mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (using equality)
+      (javaList("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ equality)
 
       implicit val javaMapEquality = new JavaMapTrimEquality
-      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using javaMapEquality)
+      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (/* DOTTY-ONLY using */ javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -262,19 +262,19 @@ class OnlyContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
         
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain only (1, 2, 3)) (using equality)
+        (left1 should contain only (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain only (1, 2, 3)) (using equality)
+        (left2 should contain only (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain only (1, 2, 3)) (using equality)
+        (left3 should contain only (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
@@ -282,14 +282,14 @@ class OnlyContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
         
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain only (1 -> "one", 2 -> "two", 3 -> "three")) (using mapEquality)
+        (left4 should contain only (1 -> "one", 2 -> "two", 3 -> "three")) (/* DOTTY-ONLY using */ mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> "one", 2 -> "two", 3 -> "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain only (1, 2, 3)) (using equality)
+        (left5 should contain only (1, 2, 3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(1, 2, 3)), thisLineNumber - 2)
 
@@ -297,7 +297,7 @@ class OnlyContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
       
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain only (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using javaMapEquality)
+        (left6 should contain only (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OnlyContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OnlyContainMatcherEqualitySpec.scala
@@ -225,18 +225,18 @@ class OnlyContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
     
     it("should take passed in custom explicit equality when 'should contain' is used") {
       implicit val equality = new TrimEquality
-      (List("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (equality)
-      (Set("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (equality)
-      (Array("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (equality)
+      (List("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (using equality)
+      (Set("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (using equality)
+      (Array("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (using equality)
 
       implicit val mapEquality = new MapTrimEquality
-      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (mapEquality)
+      (Map(1 -> "one ", 2 -> " two", 3 -> "three ") should contain only (1 -> " one", 2 -> "two ", 3 -> " three")) (using mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (equality)
+      (javaList("1 ", " 2", "3 ") should contain only (" 1", "2 ", " 3")) (using equality)
 
       implicit val javaMapEquality = new JavaMapTrimEquality
-      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (javaMapEquality)
+      (javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three ")) should contain only (Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))) (using javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -262,19 +262,19 @@ class OnlyContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
         
       val left1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain only (1, 2, 3)) (equality)
+        (left1 should contain only (1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e1, left1, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain only (1, 2, 3)) (equality)
+        (left2 should contain only (1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e2, left2, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain only (1, 2, 3)) (equality)
+        (left3 should contain only (1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e3, left3, deep(Array(1, 2, 3)), thisLineNumber - 2)
         
@@ -282,14 +282,14 @@ class OnlyContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
         
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain only (1 -> "one", 2 -> "two", 3 -> "three")) (mapEquality)
+        (left4 should contain only (1 -> "one", 2 -> "two", 3 -> "three")) (using mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, deep(Array(1 -> "one", 2 -> "two", 3 -> "three")), thisLineNumber - 2)
 
       // SKIP-SCALATESTJS,NATIVE-START
       val left5 = javaList(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain only (1, 2, 3)) (equality)
+        (left5 should contain only (1, 2, 3)) (using equality)
       }
       checkShouldContainStackDepth(e5, left5, deep(Array(1, 2, 3)), thisLineNumber - 2)
 
@@ -297,7 +297,7 @@ class OnlyContainMatcherEqualitySpec extends AnyFunSpec with Explicitly {
       
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain only (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (javaMapEquality)
+        (left6 should contain only (Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))) (using javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, deep(Array(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))), thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfLogicalAndSpec.scala
@@ -76,15 +76,15 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, FailureMessages.containedOneElementOf(prettifier, fumSome, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedOneElementOf(prettifier, fumSome, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
       }
@@ -125,15 +125,15 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumSome, fumSome) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (be (fumSome) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumSome should (be (fumSome) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (fumSome should (be (toSome) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumSome should (be (toSome) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumSome, toSome), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (fumSome should (be (fumSome) and contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumSome should (be (fumSome) and contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumSome, fumSome) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
@@ -168,21 +168,21 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, FailureMessages.didNotContainOneElementOf(prettifier, toSome, Seq("happy", "birthday", "to", "you")) + ", but " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainOneElementOf(prettifier, toSome, Seq("happy", "birthday", "to", "you")) + ", but " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), fileName, thisLineNumber - 2)
 
         toSome should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
 
         val e3 = intercept[TestFailedException] {
-          (toSome should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) and not contain oneElementOf (Seq("to", "you")))) (after being lowerCased and trimmed, decided by invertedStringEquality)
+          (toSome should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) and not contain oneElementOf (Seq("to", "you")))) (using after being lowerCased and trimmed, decided by invertedStringEquality)
         }
         checkMessageStackDepth(e3, FailureMessages.containedOneElementOf(prettifier, toSome, Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")), fileName, thisLineNumber - 2)
       }
@@ -218,14 +218,14 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, toSome, fumSome) + ", but " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not be (fumSome) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseStringEquality)
+        (toSome should (not be (fumSome) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not be (toSome) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseStringEquality)
+          (toSome should (not be (toSome) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, toSome, toSome), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (toSome should (not be (fumSome) and not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toSome should (not be (fumSome) and not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, toSome, fumSome) + ", but " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), fileName, thisLineNumber - 2)
       }
@@ -298,13 +298,13 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneElementOf Seq("hi", "he") and contain oneElementOf Seq("ho", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiSomes) should (contain oneElementOf Seq("hi", "he") and contain oneElementOf Seq("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiSomes(0), Seq("hi", "he")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, hiSomes(0), Seq("HI", "HE")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, hiSomes(0), Seq("hi", "he")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -363,13 +363,13 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (be (Some("hi")) and contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("hi")) and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (be (Some("ho")) and contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiSomes) should (be (Some("ho")) and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"hi\") was not equal to Some(\"ho\")", thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (hiSomes) should (be (Some("hi")) and contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiSomes) should (be (Some("hi")) and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"hi\") was equal to Some(\"hi\"), but " + FailureMessages.didNotContainOneElementOf(prettifier, hiSomes(0), Seq("hi", "he")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -404,13 +404,13 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, toSomes(0), Seq("happy", "birthday", "to", "you")) + ", but " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("NICE", "TO", "MEET", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) and not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) and not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, toSomes(0), Seq("happy", "birthday", "to", "you")) + ", but " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("NICE", "TO", "MEET", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
@@ -446,13 +446,13 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"to\") was not equal to Some(\"hi\"), but " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not be (Some("hi")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("hi")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not be (Some("to")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseStringEquality)
+          (all (toSomes) should (not be (Some("to")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\")", thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (toSomes) should (not be (Some("he")) and not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (all (toSomes) should (not be (Some("he")) and not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"to\") was not equal to Some(\"he\"), but " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfLogicalAndSpec.scala
@@ -76,15 +76,15 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, FailureMessages.containedOneElementOf(prettifier, fumSome, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum") and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") and contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.containedOneElementOf(prettifier, fumSome, Seq("FEE", "FIE", "FOE", "FUM")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "foe", "fum")), fileName, thisLineNumber - 2)
       }
@@ -125,15 +125,15 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumSome, fumSome) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (be (fumSome) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumSome should (be (fumSome) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (fumSome should (be (toSome) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumSome should (be (toSome) and contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumSome, toSome), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (fumSome should (be (fumSome) and contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumSome should (be (fumSome) and contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasEqualTo(prettifier, fumSome, fumSome) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
@@ -168,21 +168,21 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, FailureMessages.didNotContainOneElementOf(prettifier, toSome, Seq("happy", "birthday", "to", "you")) + ", but " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.didNotContainOneElementOf(prettifier, toSome, Seq("happy", "birthday", "to", "you")) + ", but " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), fileName, thisLineNumber - 2)
 
         toSome should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
 
         val e3 = intercept[TestFailedException] {
-          (toSome should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) and not contain oneElementOf (Seq("to", "you")))) (using after being lowerCased and trimmed, decided by invertedStringEquality)
+          (toSome should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) and not contain oneElementOf (Seq("to", "you")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, decided by invertedStringEquality)
         }
         checkMessageStackDepth(e3, FailureMessages.containedOneElementOf(prettifier, toSome, Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")), fileName, thisLineNumber - 2)
       }
@@ -218,14 +218,14 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, toSome, fumSome) + ", but " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not be (fumSome) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
+        (toSome should (not be (fumSome) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not be (toSome) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
+          (toSome should (not be (toSome) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, toSome, toSome), fileName, thisLineNumber - 2)
 
         val e2 = intercept[TestFailedException] {
-          (toSome should (not be (fumSome) and not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toSome should (not be (fumSome) and not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, FailureMessages.wasNotEqualTo(prettifier, toSome, fumSome) + ", but " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), fileName, thisLineNumber - 2)
       }
@@ -298,13 +298,13 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneElementOf Seq("hi", "he") and contain oneElementOf Seq("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiSomes) should (contain oneElementOf Seq("hi", "he") and contain oneElementOf Seq("ho", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiSomes(0), Seq("hi", "he")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") and contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, hiSomes(0), Seq("HI", "HE")) + ", but " + FailureMessages.didNotContainOneElementOf(prettifier, hiSomes(0), Seq("hi", "he")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -363,13 +363,13 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (be (Some("hi")) and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("hi")) and contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (be (Some("ho")) and contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiSomes) should (be (Some("ho")) and contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"hi\") was not equal to Some(\"ho\")", thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (hiSomes) should (be (Some("hi")) and contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiSomes) should (be (Some("hi")) and contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"hi\") was equal to Some(\"hi\"), but " + FailureMessages.didNotContainOneElementOf(prettifier, hiSomes(0), Seq("hi", "he")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -404,13 +404,13 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, toSomes(0), Seq("happy", "birthday", "to", "you")) + ", but " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("NICE", "TO", "MEET", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) and not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) and not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) and not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, toSomes(0), Seq("happy", "birthday", "to", "you")) + ", but " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("NICE", "TO", "MEET", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
@@ -446,13 +446,13 @@ class OptionShouldContainOneElementOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"to\") was not equal to Some(\"hi\"), but " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not be (Some("hi")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("hi")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not be (Some("to")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
+          (all (toSomes) should (not be (Some("to")) and not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\")", thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (toSomes) should (not be (Some("he")) and not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (all (toSomes) should (not be (Some("he")) and not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"to\") was not equal to Some(\"he\"), but " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfLogicalOrSpec.scala
@@ -69,12 +69,12 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "foe", "fum")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum") or contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum") or contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "foe", "fum")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
@@ -109,12 +109,12 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumSome, toSome) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (be (fumSome) or contain oneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumSome should (be (toSome) or contain oneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumSome should (be (fumSome) or contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumSome should (be (fumSome) or contain oneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumSome should (be (toSome) or contain oneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumSome should (be (fumSome) or contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (fumSome should (be (toSome) or contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumSome should (be (toSome) or contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumSome, toSome) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
@@ -145,11 +145,11 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) + ", and " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("NICE", "TO", "MEET", "YOU")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) + ", and " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("NICE", "TO", "MEET", "YOU")), fileName, thisLineNumber - 2)
       }
@@ -181,11 +181,11 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, toSome, toSome) + ", and " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not be (fumSome) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
-        (toSome should (not be (toSome) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
-        (toSome should (not be (fumSome) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+        (toSome should (not be (fumSome) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (toSome should (not be (toSome) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (toSome should (not be (fumSome) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not be (toSome) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (toSome should (not be (toSome) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, toSome, toSome) + ", and " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), fileName, thisLineNumber - 2)
       }
@@ -247,11 +247,11 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiSomes) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiSomes) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiSomes(0), Seq("hi", "he")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, hiSomes(0), Seq("hi", "he")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -299,11 +299,11 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (be (Some("hi")) or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiSomes) should (be (Some("he")) or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiSomes) should (be (Some("hi")) or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("hi")) or contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("he")) or contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("hi")) or contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (be (Some("he")) or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiSomes) should (be (Some("he")) or contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"hi\") was not equal to Some(\"he\"), and " + FailureMessages.didNotContainOneElementOf(prettifier, hiSomes(0), Seq("hi", "he")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -334,11 +334,11 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) + ", and " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("NICE", "TO", "MEET", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) + ", and " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("NICE", "TO", "MEET", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
@@ -370,11 +370,11 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\"), and " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not be (Some("hi")) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
-        (all (toSomes) should (not be (Some("to")) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
-        (all (toSomes) should (not be (Some("hi")) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("hi")) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("to")) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("hi")) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not be (Some("to")) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
+          (all (toSomes) should (not be (Some("to")) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\"), and " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfLogicalOrSpec.scala
@@ -69,12 +69,12 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "foe", "fum")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM") or contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum") or contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum") or contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum") or contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "foe", "fum")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
@@ -109,12 +109,12 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumSome, toSome) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (be (fumSome) or contain oneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumSome should (be (toSome) or contain oneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumSome should (be (fumSome) or contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumSome should (be (fumSome) or contain oneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumSome should (be (toSome) or contain oneElementOf Seq("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumSome should (be (fumSome) or contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality)
 
         val e1 = intercept[TestFailedException] {
-          (fumSome should (be (toSome) or contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumSome should (be (toSome) or contain oneElementOf Seq("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasNotEqualTo(prettifier, fumSome, toSome) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, fumSome, Seq("fee", "fie", "fum", "foe")), fileName, thisLineNumber - 2)
       }
@@ -145,11 +145,11 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) + ", and " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("NICE", "TO", "MEET", "YOU")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) + ", and " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("NICE", "TO", "MEET", "YOU")), fileName, thisLineNumber - 2)
       }
@@ -181,11 +181,11 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, toSome, toSome) + ", and " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not be (fumSome) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseStringEquality)
-        (toSome should (not be (toSome) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseStringEquality)
-        (toSome should (not be (fumSome) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+        (toSome should (not be (fumSome) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
+        (toSome should (not be (toSome) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
+        (toSome should (not be (fumSome) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not be (toSome) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (toSome should (not be (toSome) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, FailureMessages.wasEqualTo(prettifier, toSome, toSome) + ", and " + FailureMessages.containedOneElementOf(prettifier, toSome, Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), fileName, thisLineNumber - 2)
       }
@@ -247,11 +247,11 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiSomes) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE") or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiSomes) should (contain oneElementOf Seq("hi", "he") or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneElementOf(prettifier, hiSomes(0), Seq("hi", "he")) + ", and " + FailureMessages.didNotContainOneElementOf(prettifier, hiSomes(0), Seq("hi", "he")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -299,11 +299,11 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (be (Some("hi")) or contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiSomes) should (be (Some("he")) or contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiSomes) should (be (Some("hi")) or contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("hi")) or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("he")) or contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("hi")) or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (be (Some("he")) or contain oneElementOf Seq("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiSomes) should (be (Some("he")) or contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"hi\") was not equal to Some(\"he\"), and " + FailureMessages.didNotContainOneElementOf(prettifier, hiSomes(0), Seq("hi", "he")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -334,11 +334,11 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) + ", and " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("NICE", "TO", "MEET", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("nice", "to", "meet", "you")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) or not contain oneElementOf (Seq("NICE", "TO", "MEET", "YOU")))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("HAPPY", "BIRTHDAY", "TO", "YOU")) + ", and " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("NICE", "TO", "MEET", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
@@ -370,11 +370,11 @@ class OptionShouldContainOneElementOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\"), and " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not be (Some("hi")) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseStringEquality)
-        (all (toSomes) should (not be (Some("to")) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseStringEquality)
-        (all (toSomes) should (not be (Some("hi")) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("hi")) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("to")) or not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("hi")) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not be (Some("to")) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseStringEquality)
+          (all (toSomes) should (not be (Some("to")) or not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\"), and " + FailureMessages.containedOneElementOf(prettifier, toSomes(0), Seq("HAPPY", "BIRTHDAY", "TO", "YOU")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfSpec.scala
@@ -62,14 +62,14 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
+        (fumSome should contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumSome should contain oneElementOf Seq("fee", "fie", "foe", "fum")) (using decided by upperCaseEquality)
+          (fumSome should contain oneElementOf Seq("fee", "fie", "foe", "fum")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumSome should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumSome should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumSome should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumSome should contain oneElementOf Seq("fee", "fie", "foe", "fie", "fum")
@@ -96,14 +96,14 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseEquality)
+        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseEquality)
+          (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumSome should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumSome should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumSome should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fie", "fum"))
@@ -137,13 +137,13 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toSome should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (toSome should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toSome should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (toSome should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toSome should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toSome should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toSome should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -179,13 +179,13 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
+        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
+          (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toSome should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toSome should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (toSome should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -256,14 +256,14 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should contain oneElementOf Seq("HI", "HE")) (using decided by upperCaseEquality)
+        (all (hiSomes) should contain oneElementOf Seq("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiSomes) should contain oneElementOf Seq("hi", "he")) (using decided by upperCaseEquality)
+          (all (hiSomes) should contain oneElementOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiSomes) should contain oneElementOf Seq("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiSomes) should contain oneElementOf Seq("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiSomes) should contain oneElementOf Seq("HI", "HE")) (using decided by defaultEquality[String])
+          (all (hiSomes) should contain oneElementOf Seq("HI", "HE")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -324,14 +324,14 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseEquality)
+        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseEquality)
+          (all (hiSomes) should (contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiSomes) should (contain oneElementOf Seq("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiSomes) should (contain oneElementOf Seq("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneElementOf Seq("HI", "HE"))) (using decided by defaultEquality[String])
+          (all (hiSomes) should (contain oneElementOf Seq("HI", "HE"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -375,13 +375,13 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (all (toSomes) should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toSomes) should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (all (toSomes) should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toSomes) should not contain oneElementOf (Seq(" happy ", " birthday ", " to ", " you "))
         intercept[TestFailedException] {
-          (all (toSomes) should not contain oneElementOf (Seq(" happy ", " birthday ", " to ", " you "))) (using after being lowerCased and trimmed)
+          (all (toSomes) should not contain oneElementOf (Seq(" happy ", " birthday ", " to ", " you "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -427,13 +427,13 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
+        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
+          (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toSomes) should (not contain oneElementOf (Seq(" happy ", " birthday ", " to ", " you ")))
         intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
+          (all (toSomes) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneElementOfSpec.scala
@@ -62,14 +62,14 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseEquality)
+        (fumSome should contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumSome should contain oneElementOf Seq("fee", "fie", "foe", "fum")) (decided by upperCaseEquality)
+          (fumSome should contain oneElementOf Seq("fee", "fie", "foe", "fum")) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumSome should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumSome should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumSome should contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumSome should contain oneElementOf Seq("fee", "fie", "foe", "fie", "fum")
@@ -96,14 +96,14 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseEquality)
+        (fumSome should (contain oneElementOf Seq("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (decided by upperCaseEquality)
+          (fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fum"))) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumSome should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumSome should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumSome should (contain oneElementOf Seq(" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should allow RHS to contain duplicated value") {
         fumSome should (contain oneElementOf Seq("fee", "fie", "foe", "fie", "fum"))
@@ -137,13 +137,13 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toSome should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (toSome should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toSome should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (toSome should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         toSome should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toSome should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toSome should not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -179,13 +179,13 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseEquality)
+        (toSome should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseEquality)
+          (toSome should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
         }
         toSome should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))
         intercept[TestFailedException] {
-          (toSome should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (toSome should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -256,14 +256,14 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should contain oneElementOf Seq("HI", "HE")) (decided by upperCaseEquality)
+        (all (hiSomes) should contain oneElementOf Seq("HI", "HE")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiSomes) should contain oneElementOf Seq("hi", "he")) (decided by upperCaseEquality)
+          (all (hiSomes) should contain oneElementOf Seq("hi", "he")) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiSomes) should contain oneElementOf Seq("hi", "he")) (decided by defaultEquality[String])
+        (all (hiSomes) should contain oneElementOf Seq("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiSomes) should contain oneElementOf Seq("HI", "HE")) (decided by defaultEquality[String])
+          (all (hiSomes) should contain oneElementOf Seq("HI", "HE")) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -324,14 +324,14 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE"))) (decided by upperCaseEquality)
+        (all (hiSomes) should (contain oneElementOf Seq("HI", "HE"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneElementOf Seq("hi", "he"))) (decided by upperCaseEquality)
+          (all (hiSomes) should (contain oneElementOf Seq("hi", "he"))) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiSomes) should (contain oneElementOf Seq("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiSomes) should (contain oneElementOf Seq("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneElementOf Seq("HI", "HE"))) (decided by defaultEquality[String])
+          (all (hiSomes) should (contain oneElementOf Seq("HI", "HE"))) (using decided by defaultEquality[String])
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -375,13 +375,13 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (all (toSomes) should not contain oneElementOf (Seq("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toSomes) should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (all (toSomes) should not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         all (toSomes) should not contain oneElementOf (Seq(" happy ", " birthday ", " to ", " you "))
         intercept[TestFailedException] {
-          (all (toSomes) should not contain oneElementOf (Seq(" happy ", " birthday ", " to ", " you "))) (after being lowerCased and trimmed)
+          (all (toSomes) should not contain oneElementOf (Seq(" happy ", " birthday ", " to ", " you "))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {
@@ -427,13 +427,13 @@ class OptionShouldContainOneElementOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (decided by upperCaseEquality)
+        (all (toSomes) should (not contain oneElementOf (Seq("happy", "birthday", "to", "you")))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (decided by upperCaseEquality)
+          (all (toSomes) should (not contain oneElementOf (Seq("HAPPY", "BIRTHDAY", "TO", "YOU")))) (using decided by upperCaseEquality)
         }
         all (toSomes) should (not contain oneElementOf (Seq(" happy ", " birthday ", " to ", " you ")))
         intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (after being lowerCased and trimmed)
+          (all (toSomes) should (not contain oneElementOf (Seq(" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")))) (using after being lowerCased and trimmed)
         }
       }
       it("should allow RHS to contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalAndSpec.scala
@@ -76,15 +76,15 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumSome), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (fumSome should (contain oneOf ("fee", "fie", "foe", "fum") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumSome should (contain oneOf ("fee", "fie", "foe", "fum") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumSome), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
@@ -136,15 +136,15 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumSome), decorateToStringValue(prettifier, fumSome)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (be (fumSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+        (fumSome should (be (fumSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (fumSome should (be (toSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
+          (fumSome should (be (toSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumSome), decorateToStringValue(prettifier, toSome)), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (fumSome should (be (fumSome) and contain oneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumSome should (be (fumSome) and contain oneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumSome), decorateToStringValue(prettifier, fumSome)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
@@ -184,21 +184,21 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, toSome), "\"happy\", \"birthday\", \"to\", \"you\"") + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") and not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") and not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (toSome should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (toSome should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, toSome), "\"happy\", \"birthday\", \"to\", \"you\"") + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
         
         toSome should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         
         val e3 = intercept[TestFailedException] {
-          (toSome should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ") and not contain oneOf ("to", "you"))) (using after being lowerCased and trimmed, decided by invertedStringEquality)
+          (toSome should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ") and not contain oneOf ("to", "you"))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed, decided by invertedStringEquality)
         }
         checkMessageStackDepth(e3, Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\" HAPPY \", \" BIRTHDAY \", \" TO \", \" YOU \""), fileName, thisLineNumber - 2)
       }
@@ -245,14 +245,14 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, toSome), decorateToStringValue(prettifier, fumSome)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not be (fumSome) and not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+        (toSome should (not be (fumSome) and not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not be (toSome) and not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+          (toSome should (not be (toSome) and not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, toSome), decorateToStringValue(prettifier, toSome)), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (toSome should (not be (fumSome) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toSome should (not be (fumSome) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, toSome), decorateToStringValue(prettifier, fumSome)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
@@ -330,13 +330,13 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (contain oneOf ("HI", "HE") and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneOf ("HI", "HE") and contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneOf ("hi", "he") and contain oneOf ("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiSomes) should (contain oneOf ("hi", "he") and contain oneOf ("ho", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiSomes(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneOf ("HI", "HE") and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiSomes) should (contain oneOf ("HI", "HE") and contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiSomes(0), UnquotedString("\"HI\", \"HE\"")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, hiSomes(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -406,13 +406,13 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (be (Some("hi")) and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("hi")) and contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (be (Some("ho")) and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+          (all (hiSomes) should (be (Some("ho")) and contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"hi\") was not equal to Some(\"ho\")", thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (hiSomes) should (be (Some("hi")) and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiSomes) should (be (Some("hi")) and contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"hi\") was equal to Some(\"hi\"), but " + FailureMessages.didNotContainOneOfElements(prettifier, hiSomes(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -452,13 +452,13 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, toSomes(0), UnquotedString("\"happy\", \"birthday\", \"to\", \"you\"")) + ", but " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"NICE\", \"TO\", \"MEET\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("nice", "to", "meet", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("nice", "to", "meet", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") and not contain oneOf ("nice", "to", "meet", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") and not contain oneOf ("nice", "to", "meet", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, toSomes(0), UnquotedString("\"happy\", \"birthday\", \"to\", \"you\"")) + ", but " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"NICE\", \"TO\", \"MEET\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
@@ -505,13 +505,13 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"to\") was not equal to Some(\"hi\"), but " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not be (Some("hi")) and not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("hi")) and not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not be (Some("to")) and not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+          (all (toSomes) should (not be (Some("to")) and not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\")", thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (toSomes) should (not be (Some("he")) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toSomes) should (not be (Some("he")) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"to\") was not equal to Some(\"he\"), but " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalAndSpec.scala
@@ -76,15 +76,15 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumSome), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (fumSome should (contain oneOf ("fee", "fie", "foe", "fum") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumSome should (contain oneOf ("fee", "fie", "foe", "fum") and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") and contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.containedOneOfElements(decorateToStringValue(prettifier, fumSome), "\"FEE\", \"FIE\", \"FOE\", \"FUM\"") + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"foe\", \"fum\""), fileName, thisLineNumber - 2)
       }
@@ -136,15 +136,15 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumSome), decorateToStringValue(prettifier, fumSome)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (be (fumSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+        (fumSome should (be (fumSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (fumSome should (be (toSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality)
+          (fumSome should (be (toSome) and contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumSome), decorateToStringValue(prettifier, toSome)), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (fumSome should (be (fumSome) and contain oneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumSome should (be (fumSome) and contain oneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasEqualTo(decorateToStringValue(prettifier, fumSome), decorateToStringValue(prettifier, fumSome)) + ", but " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
@@ -184,21 +184,21 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, toSome), "\"happy\", \"birthday\", \"to\", \"you\"") + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") and not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") and not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (toSome should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (toSome should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, toSome), "\"happy\", \"birthday\", \"to\", \"you\"") + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
         
         toSome should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         
         val e3 = intercept[TestFailedException] {
-          (toSome should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ") and not contain oneOf ("to", "you"))) (after being lowerCased and trimmed, decided by invertedStringEquality)
+          (toSome should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ") and not contain oneOf ("to", "you"))) (using after being lowerCased and trimmed, decided by invertedStringEquality)
         }
         checkMessageStackDepth(e3, Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\" HAPPY \", \" BIRTHDAY \", \" TO \", \" YOU \""), fileName, thisLineNumber - 2)
       }
@@ -245,14 +245,14 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, toSome), decorateToStringValue(prettifier, fumSome)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not be (fumSome) and not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+        (toSome should (not be (fumSome) and not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not be (toSome) and not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (toSome should (not be (toSome) and not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, toSome), decorateToStringValue(prettifier, toSome)), fileName, thisLineNumber - 2)
         
         val e2 = intercept[TestFailedException] {
-          (toSome should (not be (fumSome) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toSome should (not be (fumSome) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, Resources.wasNotEqualTo(decorateToStringValue(prettifier, toSome), decorateToStringValue(prettifier, fumSome)) + ", but " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
@@ -330,13 +330,13 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (contain oneOf ("HI", "HE") and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneOf ("HI", "HE") and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneOf ("hi", "he") and contain oneOf ("ho", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiSomes) should (contain oneOf ("hi", "he") and contain oneOf ("ho", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiSomes(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneOf ("HI", "HE") and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiSomes) should (contain oneOf ("HI", "HE") and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, hiSomes(0), UnquotedString("\"HI\", \"HE\"")) + ", but " + FailureMessages.didNotContainOneOfElements(prettifier, hiSomes(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -406,13 +406,13 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (be (Some("hi")) and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("hi")) and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (be (Some("ho")) and contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
+          (all (hiSomes) should (be (Some("ho")) and contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"hi\") was not equal to Some(\"ho\")", thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (hiSomes) should (be (Some("hi")) and contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiSomes) should (be (Some("hi")) and contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"hi\") was equal to Some(\"hi\"), but " + FailureMessages.didNotContainOneOfElements(prettifier, hiSomes(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -452,13 +452,13 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, toSomes(0), UnquotedString("\"happy\", \"birthday\", \"to\", \"you\"")) + ", but " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"NICE\", \"TO\", \"MEET\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("nice", "to", "meet", "you"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("nice", "to", "meet", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") and not contain oneOf ("nice", "to", "meet", "you"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") and not contain oneOf ("nice", "to", "meet", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") and not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, toSomes(0), UnquotedString("\"happy\", \"birthday\", \"to\", \"you\"")) + ", but " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"NICE\", \"TO\", \"MEET\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
@@ -505,13 +505,13 @@ class OptionShouldContainOneOfLogicalAndSpec extends AnyFunSpec {
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"to\") was not equal to Some(\"hi\"), but " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not be (Some("hi")) and not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("hi")) and not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not be (Some("to")) and not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
+          (all (toSomes) should (not be (Some("to")) and not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\")", thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
         val e2 = intercept[TestFailedException] {
-          (all (toSomes) should (not be (Some("he")) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toSomes) should (not be (Some("he")) and not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e2, allErrMsg(0, "Some(\"to\") was not equal to Some(\"he\"), but " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalOrSpec.scala
@@ -69,12 +69,12 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumSome should (contain oneOf ("fee", "fie", "foe", "fum") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneOf ("fee", "fie", "foe", "fum") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (fumSome should (contain oneOf ("fee", "fie", "foe", "fum") or contain oneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumSome should (contain oneOf ("fee", "fie", "foe", "fum") or contain oneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
@@ -120,12 +120,12 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumSome), decorateToStringValue(prettifier, toSome)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (be (fumSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumSome should (be (toSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
-        (fumSome should (be (fumSome) or contain oneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality)
+        (fumSome should (be (fumSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumSome should (be (toSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (fumSome should (be (fumSome) or contain oneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (fumSome should (be (toSome) or contain oneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality)
+          (fumSome should (be (toSome) or contain oneOf ("fee", "fie", "fum", "foe"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumSome), decorateToStringValue(prettifier, toSome)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
@@ -161,11 +161,11 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"") + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"NICE\", \"TO\", \"MEET\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("nice", "to", "meet", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("nice", "to", "meet", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (toSome should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("nice", "to", "meet", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("nice", "to", "meet", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"") + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"NICE\", \"TO\", \"MEET\", \"YOU\""), fileName, thisLineNumber - 2)
       }
@@ -208,11 +208,11 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, toSome), decorateToStringValue(prettifier, toSome)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not be (fumSome) or not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
-        (toSome should (not be (toSome) or not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
-        (toSome should (not be (fumSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+        (toSome should (not be (fumSome) or not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (toSome should (not be (toSome) or not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (toSome should (not be (fumSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not be (toSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (toSome should (not be (toSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, toSome), decorateToStringValue(prettifier, toSome)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
@@ -279,11 +279,11 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (contain oneOf ("HI", "HE") or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiSomes) should (contain oneOf ("hi", "he") or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiSomes) should (contain oneOf ("HI", "HE") or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneOf ("HI", "HE") or contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneOf ("hi", "he") or contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneOf ("HI", "HE") or contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneOf ("hi", "he") or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiSomes) should (contain oneOf ("hi", "he") or contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiSomes(0), UnquotedString("\"hi\", \"he\"")) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, hiSomes(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -342,11 +342,11 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (be (Some("hi")) or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiSomes) should (be (Some("he")) or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
-        (all (hiSomes) should (be (Some("hi")) or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("hi")) or contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("he")) or contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("hi")) or contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (be (Some("he")) or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
+          (all (hiSomes) should (be (Some("he")) or contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"hi\") was not equal to Some(\"he\"), and " + FailureMessages.didNotContainOneOfElements(prettifier, hiSomes(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -382,11 +382,11 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")) + ", and " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"NICE\", \"TO\", \"MEET\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("nice", "to", "meet", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("nice", "to", "meet", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("nice", "to", "meet", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("nice", "to", "meet", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")) + ", and " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"NICE\", \"TO\", \"MEET\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
@@ -429,11 +429,11 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\"), and " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not be (Some("hi")) or not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
-        (all (toSomes) should (not be (Some("to")) or not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
-        (all (toSomes) should (not be (Some("hi")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("hi")) or not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("to")) or not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("hi")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not be (Some("to")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
+          (all (toSomes) should (not be (Some("to")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\"), and " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfLogicalOrSpec.scala
@@ -69,12 +69,12 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (fumSome should (contain oneOf ("fee", "fie", "foe", "fum") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM") or contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (fumSome should (contain oneOf ("fee", "fie", "foe", "fum") or contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (fumSome should (contain oneOf ("fee", "fie", "foe", "fum") or contain oneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (fumSome should (contain oneOf ("fee", "fie", "foe", "fum") or contain oneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"foe\", \"fum\"") + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
@@ -120,12 +120,12 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumSome), decorateToStringValue(prettifier, toSome)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (be (fumSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumSome should (be (toSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))) (decided by upperCaseStringEquality)
-        (fumSome should (be (fumSome) or contain oneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality)
+        (fumSome should (be (fumSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumSome should (be (toSome) or contain oneOf ("FEE", "FIE", "FUM", "FOE"))) (using decided by upperCaseStringEquality)
+        (fumSome should (be (fumSome) or contain oneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality)
         
         val e1 = intercept[TestFailedException] {
-          (fumSome should (be (toSome) or contain oneOf ("fee", "fie", "fum", "foe"))) (decided by upperCaseStringEquality)
+          (fumSome should (be (toSome) or contain oneOf ("fee", "fie", "fum", "foe"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasNotEqualTo(decorateToStringValue(prettifier, fumSome), decorateToStringValue(prettifier, toSome)) + ", and " + Resources.didNotContainOneOfElements(decorateToStringValue(prettifier, fumSome), "\"fee\", \"fie\", \"fum\", \"foe\""), fileName, thisLineNumber - 2)
       }
@@ -161,11 +161,11 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"") + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"NICE\", \"TO\", \"MEET\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("nice", "to", "meet", "you"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("nice", "to", "meet", "you"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (toSome should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("nice", "to", "meet", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("nice", "to", "meet", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (toSome should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"") + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"NICE\", \"TO\", \"MEET\", \"YOU\""), fileName, thisLineNumber - 2)
       }
@@ -208,11 +208,11 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, toSome), decorateToStringValue(prettifier, toSome)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not be (fumSome) or not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
-        (toSome should (not be (toSome) or not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
-        (toSome should (not be (fumSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+        (toSome should (not be (fumSome) or not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+        (toSome should (not be (toSome) or not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+        (toSome should (not be (fumSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (toSome should (not be (toSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (toSome should (not be (toSome) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, Resources.wasEqualTo(decorateToStringValue(prettifier, toSome), decorateToStringValue(prettifier, toSome)) + ", and " + Resources.containedOneOfElements(decorateToStringValue(prettifier, toSome), "\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\""), fileName, thisLineNumber - 2)
       }
@@ -279,11 +279,11 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (contain oneOf ("HI", "HE") or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiSomes) should (contain oneOf ("hi", "he") or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (hiSomes) should (contain oneOf ("HI", "HE") or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneOf ("HI", "HE") or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneOf ("hi", "he") or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (hiSomes) should (contain oneOf ("HI", "HE") or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneOf ("hi", "he") or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (hiSomes) should (contain oneOf ("hi", "he") or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.didNotContainOneOfElements(prettifier, hiSomes(0), UnquotedString("\"hi\", \"he\"")) + ", and " + FailureMessages.didNotContainOneOfElements(prettifier, hiSomes(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -342,11 +342,11 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (be (Some("hi")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiSomes) should (be (Some("he")) or contain oneOf ("HI", "HE"))) (decided by upperCaseStringEquality)
-        (all (hiSomes) should (be (Some("hi")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("hi")) or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("he")) or contain oneOf ("HI", "HE"))) (using decided by upperCaseStringEquality)
+        (all (hiSomes) should (be (Some("hi")) or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (hiSomes) should (be (Some("he")) or contain oneOf ("hi", "he"))) (decided by upperCaseStringEquality)
+          (all (hiSomes) should (be (Some("he")) or contain oneOf ("hi", "he"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"hi\") was not equal to Some(\"he\"), and " + FailureMessages.didNotContainOneOfElements(prettifier, hiSomes(0), UnquotedString("\"hi\", \"he\"")), thisLineNumber - 2, hiSomes), fileName, thisLineNumber - 2)
       }
@@ -382,11 +382,11 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")) + ", and " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"NICE\", \"TO\", \"MEET\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("nice", "to", "meet", "you"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("nice", "to", "meet", "you"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
-        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("nice", "to", "meet", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("nice", "to", "meet", "you"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (decided by upperCaseStringEquality, decided by upperCaseStringEquality)
+          (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU") or not contain oneOf ("NICE", "TO", "MEET", "YOU"))) (using decided by upperCaseStringEquality, decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")) + ", and " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"NICE\", \"TO\", \"MEET\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
@@ -429,11 +429,11 @@ class OptionShouldContainOneOfLogicalOrSpec extends AnyFunSpec {
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\"), and " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not be (Some("hi")) or not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
-        (all (toSomes) should (not be (Some("to")) or not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseStringEquality)
-        (all (toSomes) should (not be (Some("hi")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("hi")) or not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("to")) or not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseStringEquality)
+        (all (toSomes) should (not be (Some("hi")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         val e1 = intercept[TestFailedException] {
-          (all (toSomes) should (not be (Some("to")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseStringEquality)
+          (all (toSomes) should (not be (Some("to")) or not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseStringEquality)
         }
         checkMessageStackDepth(e1, allErrMsg(0, "Some(\"to\") was equal to Some(\"to\"), and " + FailureMessages.containedOneOfElements(prettifier, toSomes(0), UnquotedString("\"HAPPY\", \"BIRTHDAY\", \"TO\", \"YOU\"")), thisLineNumber - 2, toSomes), fileName, thisLineNumber - 2)
       }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfSpec.scala
@@ -62,14 +62,14 @@ class OptionShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should contain oneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
+        (fumSome should contain oneOf ("FEE", "FIE", "FOE", "FUM")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumSome should contain oneOf ("fee", "fie", "foe", "fum")) (using decided by upperCaseEquality)
+          (fumSome should contain oneOf ("fee", "fie", "foe", "fum")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumSome should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumSome should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
+        (fumSome should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -101,14 +101,14 @@ class OptionShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseEquality)
+        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumSome should (contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseEquality)
+          (fumSome should (contain oneOf ("fee", "fie", "foe", "fum"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumSome should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumSome should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
+        (fumSome should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -147,13 +147,13 @@ class OptionShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toSome should not contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+        (toSome should not contain oneOf ("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toSome should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (toSome should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toSome should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toSome should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
+          (toSome should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -194,13 +194,13 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (toSome should (not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         toSome should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toSome should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (toSome should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -276,14 +276,14 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should contain oneOf ("HI", "HE")) (using decided by upperCaseEquality)
+        (all (hiSomes) should contain oneOf ("HI", "HE")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiSomes) should contain oneOf ("hi", "he")) (using decided by upperCaseEquality)
+          (all (hiSomes) should contain oneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiSomes) should contain oneOf ("hi", "he")) (using decided by defaultEquality[String])
+        (all (hiSomes) should contain oneOf ("hi", "he")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiSomes) should contain oneOf ("HI", "HE")) (using decided by defaultEquality[String])
+          (all (hiSomes) should contain oneOf ("HI", "HE")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -349,14 +349,14 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (contain oneOf ("HI", "HE"))) (using decided by upperCaseEquality)
+        (all (hiSomes) should (contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneOf ("hi", "he"))) (using decided by upperCaseEquality)
+          (all (hiSomes) should (contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiSomes) should (contain oneOf ("hi", "he"))) (using decided by defaultEquality[String])
+        (all (hiSomes) should (contain oneOf ("hi", "he"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneOf ("HI", "HE"))) (using decided by defaultEquality[String])
+          (all (hiSomes) should (contain oneOf ("HI", "HE"))) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -405,13 +405,13 @@ scala> all (some1s) should (contain (oneOf (1, 3, 4)))
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should not contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
+        (all (toSomes) should not contain oneOf ("happy", "birthday", "to", "you")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toSomes) should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
+          (all (toSomes) should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toSomes) should not contain oneOf (" happy ", " birthday ", " to ", " you ")
         intercept[TestFailedException] {
-          (all (toSomes) should not contain oneOf (" happy ", " birthday ", " to ", " you ")) (using after being lowerCased and trimmed)
+          (all (toSomes) should not contain oneOf (" happy ", " birthday ", " to ", " you ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -462,13 +462,13 @@ The top two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
+        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
+          (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (/* DOTTY-ONLY using */ decided by upperCaseEquality)
         }
         all (toSomes) should (not contain oneOf (" happy ", " birthday ", " to ", " you "))
         intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
+          (all (toSomes) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainOneOfSpec.scala
@@ -62,14 +62,14 @@ class OptionShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should contain oneOf ("FEE", "FIE", "FOE", "FUM")) (decided by upperCaseEquality)
+        (fumSome should contain oneOf ("FEE", "FIE", "FOE", "FUM")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumSome should contain oneOf ("fee", "fie", "foe", "fum")) (decided by upperCaseEquality)
+          (fumSome should contain oneOf ("fee", "fie", "foe", "fum")) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumSome should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")
         }
-        (fumSome should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (after being lowerCased and trimmed)
+        (fumSome should contain oneOf (" FEE ", " FIE ", " FOE ", " FUM ")) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -101,14 +101,14 @@ class OptionShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (decided by upperCaseEquality)
+        (fumSome should (contain oneOf ("FEE", "FIE", "FOE", "FUM"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (fumSome should (contain oneOf ("fee", "fie", "foe", "fum"))) (decided by upperCaseEquality)
+          (fumSome should (contain oneOf ("fee", "fie", "foe", "fum"))) (using decided by upperCaseEquality)
         }
         intercept[TestFailedException] {
           fumSome should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))
         }
-        (fumSome should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (after being lowerCased and trimmed)
+        (fumSome should (contain oneOf (" FEE ", " FIE ", " FOE ", " FUM "))) (using after being lowerCased and trimmed)
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
         val e1 = intercept[exceptions.NotAllowedException] {
@@ -147,13 +147,13 @@ class OptionShouldContainOneOfSpec extends AnyFunSpec {
         }
       }
       it("should use an explicitly provided Equality") {
-        (toSome should not contain oneOf ("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+        (toSome should not contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toSome should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (toSome should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
         toSome should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")
         intercept[TestFailedException] {
-          (toSome should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (after being lowerCased and trimmed)
+          (toSome should not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -194,13 +194,13 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (toSome should (not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (toSome should (not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (toSome should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         toSome should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))
         intercept[TestFailedException] {
-          (toSome should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (toSome should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -276,14 +276,14 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should contain oneOf ("HI", "HE")) (decided by upperCaseEquality)
+        (all (hiSomes) should contain oneOf ("HI", "HE")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiSomes) should contain oneOf ("hi", "he")) (decided by upperCaseEquality)
+          (all (hiSomes) should contain oneOf ("hi", "he")) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiSomes) should contain oneOf ("hi", "he")) (decided by defaultEquality[String])
+        (all (hiSomes) should contain oneOf ("hi", "he")) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiSomes) should contain oneOf ("HI", "HE")) (decided by defaultEquality[String])
+          (all (hiSomes) should contain oneOf ("HI", "HE")) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -349,14 +349,14 @@ The bottom two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (hiSomes) should (contain oneOf ("HI", "HE"))) (decided by upperCaseEquality)
+        (all (hiSomes) should (contain oneOf ("HI", "HE"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneOf ("hi", "he"))) (decided by upperCaseEquality)
+          (all (hiSomes) should (contain oneOf ("hi", "he"))) (using decided by upperCaseEquality)
         }
         implicit val ise = upperCaseEquality
-        (all (hiSomes) should (contain oneOf ("hi", "he"))) (decided by defaultEquality[String])
+        (all (hiSomes) should (contain oneOf ("hi", "he"))) (using decided by defaultEquality[String])
         intercept[TestFailedException] {
-          (all (hiSomes) should (contain oneOf ("HI", "HE"))) (decided by defaultEquality[String])
+          (all (hiSomes) should (contain oneOf ("HI", "HE"))) (using decided by defaultEquality[String])
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -405,13 +405,13 @@ scala> all (some1s) should (contain (oneOf (1, 3, 4)))
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should not contain oneOf ("happy", "birthday", "to", "you")) (decided by upperCaseEquality)
+        (all (toSomes) should not contain oneOf ("happy", "birthday", "to", "you")) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toSomes) should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (decided by upperCaseEquality)
+          (all (toSomes) should not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU")) (using decided by upperCaseEquality)
         }
         all (toSomes) should not contain oneOf (" happy ", " birthday ", " to ", " you ")
         intercept[TestFailedException] {
-          (all (toSomes) should not contain oneOf (" happy ", " birthday ", " to ", " you ")) (after being lowerCased and trimmed)
+          (all (toSomes) should not contain oneOf (" happy ", " birthday ", " to ", " you ")) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {
@@ -462,13 +462,13 @@ The top two don't, but still I don't want to support that in general.
         }
       }
       it("should use an explicitly provided Equality") {
-        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you"))) (decided by upperCaseEquality)
+        (all (toSomes) should (not contain oneOf ("happy", "birthday", "to", "you"))) (using decided by upperCaseEquality)
         intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (decided by upperCaseEquality)
+          (all (toSomes) should (not contain oneOf ("HAPPY", "BIRTHDAY", "TO", "YOU"))) (using decided by upperCaseEquality)
         }
         all (toSomes) should (not contain oneOf (" happy ", " birthday ", " to ", " you "))
         intercept[TestFailedException] {
-          (all (toSomes) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (after being lowerCased and trimmed)
+          (all (toSomes) should (not contain oneOf (" HAPPY ", " BIRTHDAY ", " TO ", " YOU "))) (using after being lowerCased and trimmed)
         }
       }
       it("should throw NotAllowedException with correct stack depth and message when RHS contain duplicated value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainSpec.scala
@@ -81,12 +81,12 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
         intercept[TestFailedException] {
           some should contain ("HI")
         }
-        (some should contain ("HI")) (decided by defaultEquality afterBeing lowerCased)
-        (some should contain ("HI")) (after being lowerCased)
+        (some should contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
+        (some should contain ("HI")) (using after being lowerCased)
         intercept[TestFailedException] {
-          (some should contain ("HI ")) (after being lowerCased)
+          (some should contain ("HI ")) (using after being lowerCased)
         }
-        (some should contain ("HI ")) (after being lowerCased and trimmed)
+        (some should contain ("HI ")) (using after being lowerCased and trimmed)
         
         {
           implicit val e = new Equality[String] {
@@ -95,7 +95,7 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
           intercept[TestFailedException] {
             some should contain ("hi")
           }
-          (some should contain ("hi")) (decided by defaultEquality[String])
+          (some should contain ("hi")) (using decided by defaultEquality[String])
         }
       }
       it("should do nothing when used with null and LHS contains null value") {
@@ -150,13 +150,13 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
       it("should use an explicitly provided Equality") {
         some should not contain "HI"
         some should not contain "HI "
-        (some should not contain "HI ") (decided by defaultEquality afterBeing lowerCased)
-        (some should not contain "HI ") (after being lowerCased)
+        (some should not contain "HI ") (using decided by defaultEquality afterBeing lowerCased)
+        (some should not contain "HI ") (using after being lowerCased)
         intercept[TestFailedException] {
-          (some should not contain "HI") (decided by defaultEquality afterBeing lowerCased)
+          (some should not contain "HI") (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (some should not contain "HI ") (after being lowerCased and trimmed)
+          (some should not contain "HI ") (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -214,13 +214,13 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
       it("should use an explicitly provided Equality") {
         some should not (contain ("HI"))
         some should not (contain ("HI "))
-        (some should not (contain ("HI "))) (decided by defaultEquality afterBeing lowerCased)
-        (some should not (contain ("HI "))) (after being lowerCased)
+        (some should not (contain ("HI "))) (using decided by defaultEquality afterBeing lowerCased)
+        (some should not (contain ("HI "))) (using after being lowerCased)
         intercept[TestFailedException] {
-          (some should not (contain ("HI"))) (decided by defaultEquality afterBeing lowerCased)
+          (some should not (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (some should not (contain ("HI "))) (after being lowerCased and trimmed)
+          (some should not (contain ("HI "))) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -277,13 +277,13 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
       it("should use an explicitly provided Equality") {
         some should (not contain "HI")
         some should (not contain "HI ")
-        (some should (not contain "HI ")) (decided by defaultEquality afterBeing lowerCased)
-        (some should (not contain "HI ")) (after being lowerCased)
+        (some should (not contain "HI ")) (using decided by defaultEquality afterBeing lowerCased)
+        (some should (not contain "HI ")) (using after being lowerCased)
         intercept[TestFailedException] {
-          (some should (not contain "HI")) (decided by defaultEquality afterBeing lowerCased)
+          (some should (not contain "HI")) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (some should (not contain "HI ")) (after being lowerCased and trimmed)
+          (some should (not contain "HI ")) (using after being lowerCased and trimmed)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -332,13 +332,13 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
       it("should use an explicitly provided Equality") {
         some shouldNot contain ("HI")
         some shouldNot contain ("HI ")
-        (some shouldNot contain ("HI ")) (decided by defaultEquality afterBeing lowerCased)
-        (some shouldNot contain ("HI ")) (after being lowerCased)
+        (some shouldNot contain ("HI ")) (using decided by defaultEquality afterBeing lowerCased)
+        (some shouldNot contain ("HI ")) (using after being lowerCased)
         intercept[TestFailedException] {
-          (some shouldNot contain ("HI")) (decided by defaultEquality afterBeing lowerCased)
+          (some shouldNot contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (some shouldNot contain ("HI ")) (after being lowerCased and trimmed)
+          (some shouldNot contain ("HI ")) (using after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -411,16 +411,16 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
       it("should use an explicitly provided Equality") {
         some shouldNot (contain ("HI"))
         some shouldNot (contain ("HI "))
-        (some shouldNot (contain ("HI "))) (decided by defaultEquality afterBeing lowerCased)
-        (some shouldNot (contain ("HI "))) (after being lowerCased)
+        (some shouldNot (contain ("HI "))) (using decided by defaultEquality afterBeing lowerCased)
+        (some shouldNot (contain ("HI "))) (using after being lowerCased)
         intercept[TestFailedException] {
-          (some shouldNot (contain ("HI"))) (decided by defaultEquality afterBeing lowerCased)
+          (some shouldNot (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (some shouldNot (contain ("HI"))) (after being lowerCased)
+          (some shouldNot (contain ("HI"))) (using after being lowerCased)
         }
         intercept[TestFailedException] {
-          (some shouldNot (contain ("HI "))) (after being lowerCased and trimmed)
+          (some shouldNot (contain ("HI "))) (using after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -529,8 +529,8 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
         intercept[TestFailedException] {
           all (hiSomes) should contain ("HI ")
         }
-        (all (hiSomes) should contain ("HI")) (decided by defaultEquality afterBeing lowerCased)
-        (all (hiSomes) should contain ("HI ")) (after being trimmed and lowerCased)
+        (all (hiSomes) should contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
+        (all (hiSomes) should contain ("HI ")) (using after being trimmed and lowerCased)
       }
       it("should do nothing when used with null and LHS contains null value") {
         all (hiNullSomes) should contain (null)
@@ -593,10 +593,10 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
         all (hiSomes) should not contain "HI"
         all (hiSomes) should not contain "HI "
         intercept[TestFailedException] {
-          (all (hiSomes) should not contain "HI") (decided by defaultEquality afterBeing lowerCased)
+          (all (hiSomes) should not contain "HI") (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiSomes) should not contain "HI ") (after being trimmed and lowerCased)
+          (all (hiSomes) should not contain "HI ") (using after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -660,10 +660,10 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
         all (hiSomes) should not (contain ("HI"))
         all (hiSomes) should not (contain ("HI "))
         intercept[TestFailedException] {
-          (all (hiSomes) should not (contain ("HI"))) (decided by defaultEquality afterBeing lowerCased)
+          (all (hiSomes) should not (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiSomes) should not (contain ("HI "))) (after being trimmed and lowerCased)
+          (all (hiSomes) should not (contain ("HI "))) (using after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -727,10 +727,10 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
         all (hiSomes) should (not contain "HI")
         all (hiSomes) should (not contain "HI ")
         intercept[TestFailedException] {
-          (all (hiSomes) should (not contain "HI")) (decided by defaultEquality afterBeing lowerCased)
+          (all (hiSomes) should (not contain "HI")) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiSomes) should (not contain "HI ")) (after being trimmed and lowerCased)
+          (all (hiSomes) should (not contain "HI ")) (using after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -795,10 +795,10 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
         all (hiSomes) shouldNot contain ("HI")
         all (hiSomes) shouldNot contain ("HI ")
         intercept[TestFailedException] {
-          (all (hiSomes) shouldNot contain ("HI")) (decided by defaultEquality afterBeing lowerCased)
+          (all (hiSomes) shouldNot contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiSomes) shouldNot contain ("HI ")) (after being trimmed and lowerCased)
+          (all (hiSomes) shouldNot contain ("HI ")) (using after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -863,10 +863,10 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
         all (hiSomes) shouldNot (contain ("HI"))
         all (hiSomes) shouldNot (contain ("HI "))
         intercept[TestFailedException] {
-          (all (hiSomes) shouldNot (contain ("HI"))) (decided by defaultEquality afterBeing lowerCased)
+          (all (hiSomes) shouldNot (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiSomes) shouldNot (contain ("HI "))) (after being trimmed and lowerCased)
+          (all (hiSomes) shouldNot (contain ("HI "))) (using after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/OptionShouldContainSpec.scala
@@ -81,12 +81,12 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
         intercept[TestFailedException] {
           some should contain ("HI")
         }
-        (some should contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
-        (some should contain ("HI")) (using after being lowerCased)
+        (some should contain ("HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (some should contain ("HI")) (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (some should contain ("HI ")) (using after being lowerCased)
+          (some should contain ("HI ")) (/* DOTTY-ONLY using */ after being lowerCased)
         }
-        (some should contain ("HI ")) (using after being lowerCased and trimmed)
+        (some should contain ("HI ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         
         {
           implicit val e = new Equality[String] {
@@ -95,7 +95,7 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
           intercept[TestFailedException] {
             some should contain ("hi")
           }
-          (some should contain ("hi")) (using decided by defaultEquality[String])
+          (some should contain ("hi")) (/* DOTTY-ONLY using */ decided by defaultEquality[String])
         }
       }
       it("should do nothing when used with null and LHS contains null value") {
@@ -150,13 +150,13 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
       it("should use an explicitly provided Equality") {
         some should not contain "HI"
         some should not contain "HI "
-        (some should not contain "HI ") (using decided by defaultEquality afterBeing lowerCased)
-        (some should not contain "HI ") (using after being lowerCased)
+        (some should not contain "HI ") (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (some should not contain "HI ") (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (some should not contain "HI") (using decided by defaultEquality afterBeing lowerCased)
+          (some should not contain "HI") (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (some should not contain "HI ") (using after being lowerCased and trimmed)
+          (some should not contain "HI ") (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -214,13 +214,13 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
       it("should use an explicitly provided Equality") {
         some should not (contain ("HI"))
         some should not (contain ("HI "))
-        (some should not (contain ("HI "))) (using decided by defaultEquality afterBeing lowerCased)
-        (some should not (contain ("HI "))) (using after being lowerCased)
+        (some should not (contain ("HI "))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (some should not (contain ("HI "))) (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (some should not (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
+          (some should not (contain ("HI"))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (some should not (contain ("HI "))) (using after being lowerCased and trimmed)
+          (some should not (contain ("HI "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -277,13 +277,13 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
       it("should use an explicitly provided Equality") {
         some should (not contain "HI")
         some should (not contain "HI ")
-        (some should (not contain "HI ")) (using decided by defaultEquality afterBeing lowerCased)
-        (some should (not contain "HI ")) (using after being lowerCased)
+        (some should (not contain "HI ")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (some should (not contain "HI ")) (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (some should (not contain "HI")) (using decided by defaultEquality afterBeing lowerCased)
+          (some should (not contain "HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (some should (not contain "HI ")) (using after being lowerCased and trimmed)
+          (some should (not contain "HI ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -332,13 +332,13 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
       it("should use an explicitly provided Equality") {
         some shouldNot contain ("HI")
         some shouldNot contain ("HI ")
-        (some shouldNot contain ("HI ")) (using decided by defaultEquality afterBeing lowerCased)
-        (some shouldNot contain ("HI ")) (using after being lowerCased)
+        (some shouldNot contain ("HI ")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (some shouldNot contain ("HI ")) (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (some shouldNot contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
+          (some shouldNot contain ("HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (some shouldNot contain ("HI ")) (using after being lowerCased and trimmed)
+          (some shouldNot contain ("HI ")) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -411,16 +411,16 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
       it("should use an explicitly provided Equality") {
         some shouldNot (contain ("HI"))
         some shouldNot (contain ("HI "))
-        (some shouldNot (contain ("HI "))) (using decided by defaultEquality afterBeing lowerCased)
-        (some shouldNot (contain ("HI "))) (using after being lowerCased)
+        (some shouldNot (contain ("HI "))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (some shouldNot (contain ("HI "))) (/* DOTTY-ONLY using */ after being lowerCased)
         intercept[TestFailedException] {
-          (some shouldNot (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
+          (some shouldNot (contain ("HI"))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (some shouldNot (contain ("HI"))) (using after being lowerCased)
+          (some shouldNot (contain ("HI"))) (/* DOTTY-ONLY using */ after being lowerCased)
         }
         intercept[TestFailedException] {
-          (some shouldNot (contain ("HI "))) (using after being lowerCased and trimmed)
+          (some shouldNot (contain ("HI "))) (/* DOTTY-ONLY using */ after being lowerCased and trimmed)
         }
       }
       it("should minimize normalization if an implicit NormalizingEquality is in scope") {
@@ -529,8 +529,8 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
         intercept[TestFailedException] {
           all (hiSomes) should contain ("HI ")
         }
-        (all (hiSomes) should contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
-        (all (hiSomes) should contain ("HI ")) (using after being trimmed and lowerCased)
+        (all (hiSomes) should contain ("HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
+        (all (hiSomes) should contain ("HI ")) (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
       }
       it("should do nothing when used with null and LHS contains null value") {
         all (hiNullSomes) should contain (null)
@@ -593,10 +593,10 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
         all (hiSomes) should not contain "HI"
         all (hiSomes) should not contain "HI "
         intercept[TestFailedException] {
-          (all (hiSomes) should not contain "HI") (using decided by defaultEquality afterBeing lowerCased)
+          (all (hiSomes) should not contain "HI") (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiSomes) should not contain "HI ") (using after being trimmed and lowerCased)
+          (all (hiSomes) should not contain "HI ") (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -660,10 +660,10 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
         all (hiSomes) should not (contain ("HI"))
         all (hiSomes) should not (contain ("HI "))
         intercept[TestFailedException] {
-          (all (hiSomes) should not (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
+          (all (hiSomes) should not (contain ("HI"))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiSomes) should not (contain ("HI "))) (using after being trimmed and lowerCased)
+          (all (hiSomes) should not (contain ("HI "))) (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -727,10 +727,10 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
         all (hiSomes) should (not contain "HI")
         all (hiSomes) should (not contain "HI ")
         intercept[TestFailedException] {
-          (all (hiSomes) should (not contain "HI")) (using decided by defaultEquality afterBeing lowerCased)
+          (all (hiSomes) should (not contain "HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiSomes) should (not contain "HI ")) (using after being trimmed and lowerCased)
+          (all (hiSomes) should (not contain "HI ")) (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -795,10 +795,10 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
         all (hiSomes) shouldNot contain ("HI")
         all (hiSomes) shouldNot contain ("HI ")
         intercept[TestFailedException] {
-          (all (hiSomes) shouldNot contain ("HI")) (using decided by defaultEquality afterBeing lowerCased)
+          (all (hiSomes) shouldNot contain ("HI")) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiSomes) shouldNot contain ("HI ")) (using after being trimmed and lowerCased)
+          (all (hiSomes) shouldNot contain ("HI ")) (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {
@@ -863,10 +863,10 @@ class OptionShouldContainSpec extends AnyFunSpec with Matchers {
         all (hiSomes) shouldNot (contain ("HI"))
         all (hiSomes) shouldNot (contain ("HI "))
         intercept[TestFailedException] {
-          (all (hiSomes) shouldNot (contain ("HI"))) (using decided by defaultEquality afterBeing lowerCased)
+          (all (hiSomes) shouldNot (contain ("HI"))) (/* DOTTY-ONLY using */ decided by defaultEquality afterBeing lowerCased)
         }
         intercept[TestFailedException] {
-          (all (hiSomes) shouldNot (contain ("HI "))) (using after being trimmed and lowerCased)
+          (all (hiSomes) shouldNot (contain ("HI "))) (/* DOTTY-ONLY using */ after being trimmed and lowerCased)
         }
       }
       it("should do nothing when used with null and LHS did not contain null value") {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedExplicitSpec.scala
@@ -61,12 +61,12 @@ class ShouldBeDefinedExplicitSpec extends AnyFunSpec {
     describe("when work with 'thing should be (defined)'") {
       
       it("should do nothing when thing is defined") {
-        (something should be (defined)) (definition)
+        (something should be (defined)) (/* DOTTY-ONLY using */ definition)
       }
       
       it("should throw TestFailedException with correct stack depth when thing is not defined") {
         val caught1 = intercept[TestFailedException] {
-          (nothing should be (defined)) (definition)
+          (nothing should be (defined)) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught1.message === Some(wasNotDefined(nothing)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -78,12 +78,12 @@ class ShouldBeDefinedExplicitSpec extends AnyFunSpec {
     describe("when work with 'thing should not be defined'") {
       
       it("should do nothing when thing is not defined") {
-        (nothing should not be defined) (definition)
+        (nothing should not be defined) (/* DOTTY-ONLY using */ definition)
       }
       
       it("should throw TestFailedException with correct stack depth when thing is defined") {
         val caught1 = intercept[TestFailedException] {
-          (something should not be defined) (definition)
+          (something should not be defined) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught1.message === Some(wasDefined(something)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -94,12 +94,12 @@ class ShouldBeDefinedExplicitSpec extends AnyFunSpec {
     describe("when work with 'thing shouldBe defined'") {
       
       it("should do nothing when thing is defined") {
-        (something shouldBe defined) (definition)
+        (something shouldBe defined) (/* DOTTY-ONLY using */ definition)
       }
       
       it("should throw TestFailedException with correct stack depth when thing is not defined") {
         val caught1 = intercept[TestFailedException] {
-          (nothing shouldBe defined) (definition)
+          (nothing shouldBe defined) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught1.message === Some(wasNotDefined(nothing)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -111,12 +111,12 @@ class ShouldBeDefinedExplicitSpec extends AnyFunSpec {
     describe("when work with 'thing shouldNot be (defined)'") {
       
       it("should do nothing when thing is not defined") {
-        (nothing shouldNot be (defined)) (definition)
+        (nothing shouldNot be (defined)) (/* DOTTY-ONLY using */ definition)
       }
       
       it("should throw TestFailedException with correct stack depth when thing is defined") {
         val caught1 = intercept[TestFailedException] {
-          (something shouldNot be (defined)) (definition)
+          (something shouldNot be (defined)) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught1.message === Some(wasDefined(something)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -128,13 +128,13 @@ class ShouldBeDefinedExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) should be (defined)'") {
       
       it("should do nothing when all(xs) is defined") {
-        (all(List(something)) should be (defined)) (definition)
+        (all(List(something)) should be (defined)) (/* DOTTY-ONLY using */ definition)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is not defined") {
         val left1 = List(nothing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should be (defined)) (definition)
+          (all(left1) should be (defined)) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught1.message === Some(allError(left1, wasNotDefined(nothing), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -146,13 +146,13 @@ class ShouldBeDefinedExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) should not be defined'") {
       
       it("should do nothing when all(xs) is not defined") {
-        (all(List(nothing)) should not be defined) (definition)
+        (all(List(nothing)) should not be defined) (/* DOTTY-ONLY using */ definition)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is defined") {
         val left1 = List(something)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should not be defined) (definition)
+          (all(left1) should not be defined) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught1.message === Some(allError(left1, wasDefined(something), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -164,13 +164,13 @@ class ShouldBeDefinedExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) shouldBe defined'") {
       
       it("should do nothing when all(xs) is defined") {
-        (all(List(something)) shouldBe defined) (definition)
+        (all(List(something)) shouldBe defined) (/* DOTTY-ONLY using */ definition)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is not defined") {
         val left1 = List(nothing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) shouldBe defined) (definition)
+          (all(left1) shouldBe defined) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught1.message === Some(allError(left1, wasNotDefined(nothing), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -181,13 +181,13 @@ class ShouldBeDefinedExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) shouldNot be (defined)'") {
       
       it("should do nothing when all(xs) is not defined") {
-        (all(List(nothing)) shouldNot be (defined)) (definition)
+        (all(List(nothing)) shouldNot be (defined)) (/* DOTTY-ONLY using */ definition)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is defined") {
         val left1 = List(something)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) shouldNot be (defined)) (definition)
+          (all(left1) shouldNot be (defined)) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught1.message === Some(allError(left1, wasDefined(something), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalAndExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalAndExplicitSpec.scala
@@ -73,37 +73,37 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends AnyFunSpec {
     describe("when work with 'thing should be (defined)'") {
       
       it("should do nothing when thing is defined") {
-        (something should (equal (something) and be (defined))) (defaultEquality, definition)
-        (something should (be (defined) and equal (something))) (definition, defaultEquality)
+        (something should (equal (something) and be (defined))) (/* DOTTY-ONLY using */ defaultEquality, definition)
+        (something should (be (defined) and equal (something))) (/* DOTTY-ONLY using */ definition, defaultEquality)
         
-        (something should (be (something) and be (defined))) (definition)
-        (something should (be (defined) and be (something))) (definition)
+        (something should (be (something) and be (defined))) (/* DOTTY-ONLY using */ definition)
+        (something should (be (defined) and be (something))) (/* DOTTY-ONLY using */ definition)
       }
       
       it("should throw TestFailedException with correct stack depth when thing is not defined") {
         val caught1 = intercept[TestFailedException] {
-          (nothing should (equal (nothing) and be (defined))) (defaultEquality, definition)
+          (nothing should (equal (nothing) and be (defined))) (/* DOTTY-ONLY using */ defaultEquality, definition)
         }
         assert(caught1.message === Some(equaled(nothing, nothing) + ", but " + wasNotDefined(nothing)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (nothing should (be (defined) and equal (nothing))) (definition, defaultEquality)
+          (nothing should (be (defined) and equal (nothing))) (/* DOTTY-ONLY using */ definition, defaultEquality)
         }
         assert(caught2.message === Some(wasNotDefined(nothing)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (nothing should (be (nothing) and be (defined))) (definition)
+          (nothing should (be (nothing) and be (defined))) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught3.message === Some(wasEqualTo(nothing, nothing) + ", but " + wasNotDefined(nothing)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (nothing should (be (defined) and be (nothing))) (definition)
+          (nothing should (be (defined) and be (nothing))) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught4.message === Some(wasNotDefined(nothing)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -114,37 +114,37 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends AnyFunSpec {
     describe("when work with 'thing should not be defined'") {
       
       it("should do nothing when thing is not defined") {
-        (nothing should (not equal something and not be defined)) (defaultEquality, definition)
-        (nothing should (not be defined and not equal something)) (definition, defaultEquality)
+        (nothing should (not equal something and not be defined)) (/* DOTTY-ONLY using */ defaultEquality, definition)
+        (nothing should (not be defined and not equal something)) (/* DOTTY-ONLY using */ definition, defaultEquality)
         
-        (nothing should (not be something and not be defined)) (definition)
-        (nothing should (not be defined and not be something)) (definition)
+        (nothing should (not be something and not be defined)) (/* DOTTY-ONLY using */ definition)
+        (nothing should (not be defined and not be something)) (/* DOTTY-ONLY using */ definition)
       }
       
       it("should throw TestFailedException with correct stack depth when xs is not defined") {
         val caught1 = intercept[TestFailedException] {
-          (something should (not equal nothing and not be defined)) (defaultEquality, definition)
+          (something should (not equal nothing and not be defined)) (/* DOTTY-ONLY using */ defaultEquality, definition)
         }
         assert(caught1.message === Some(didNotEqual(something, nothing) + ", but " + wasDefined(something)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (something should (not be defined and not equal nothing)) (definition, defaultEquality)
+          (something should (not be defined and not equal nothing)) (/* DOTTY-ONLY using */ definition, defaultEquality)
         }
         assert(caught2.message === Some(wasDefined(something)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (something should (not be nothing and not be defined)) (definition)
+          (something should (not be nothing and not be defined)) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught3.message === Some(wasNotEqualTo(something, nothing) + ", but " + wasDefined(something)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (something should (not be defined and not be nothing)) (definition)
+          (something should (not be defined and not be nothing)) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught4.message === Some(wasDefined(something)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -155,17 +155,17 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) should be (defined)'") {
       
       it("should do nothing when all(xs) is defined") {
-        (all(List(something)) should (be (something) and be (defined))) (definition)
-        (all(List(something)) should (be (defined) and be (something))) (definition)
+        (all(List(something)) should (be (something) and be (defined))) (/* DOTTY-ONLY using */ definition)
+        (all(List(something)) should (be (defined) and be (something))) (/* DOTTY-ONLY using */ definition)
         
-        (all(List(something)) should (equal (something) and be (defined))) (defaultEquality, definition)
-        (all(List(something)) should (be (defined) and equal (something))) (definition, defaultEquality)
+        (all(List(something)) should (equal (something) and be (defined))) (/* DOTTY-ONLY using */ defaultEquality, definition)
+        (all(List(something)) should (be (defined) and equal (something))) (/* DOTTY-ONLY using */ definition, defaultEquality)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is not defined") {
         val left1 = List(nothing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (nothing) and be (defined))) (definition)
+          (all(left1) should (be (nothing) and be (defined))) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught1.message === Some(allError(wasEqualTo(nothing, nothing) + ", but " + wasNotDefined(nothing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -173,7 +173,7 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left2 = List(nothing)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (defined) and be (nothing))) (definition)
+          (all(left2) should (be (defined) and be (nothing))) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught2.message === Some(allError(wasNotDefined(nothing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -181,7 +181,7 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left3 = List(nothing)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (equal (nothing) and be (defined))) (defaultEquality, definition)
+          (all(left3) should (equal (nothing) and be (defined))) (/* DOTTY-ONLY using */ defaultEquality, definition)
         }
         assert(caught3.message === Some(allError(equaled(nothing, nothing) + ", but " + wasNotDefined(nothing), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -189,7 +189,7 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left4 = List(nothing)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (be (defined) and equal (nothing))) (definition, defaultEquality)
+          (all(left4) should (be (defined) and equal (nothing))) (/* DOTTY-ONLY using */ definition, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasNotDefined(nothing), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -199,17 +199,17 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends AnyFunSpec {
     
     describe("when work with 'all(xs) should not be defined'") {
       it("should do nothing when all(xs) is not defined") {
-        (all(List(nothing)) should (not be defined and not be something)) (definition)
-        (all(List(nothing)) should (not be something and not be defined)) (definition)
+        (all(List(nothing)) should (not be defined and not be something)) (/* DOTTY-ONLY using */ definition)
+        (all(List(nothing)) should (not be something and not be defined)) (/* DOTTY-ONLY using */ definition)
         
-        (all(List(nothing)) should (not be defined and not equal something)) (definition, defaultEquality)
-        (all(List(nothing)) should (not equal something and not be defined)) (defaultEquality, definition)
+        (all(List(nothing)) should (not be defined and not equal something)) (/* DOTTY-ONLY using */ definition, defaultEquality)
+        (all(List(nothing)) should (not equal something and not be defined)) (/* DOTTY-ONLY using */ defaultEquality, definition)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is defined") {
         val left1 = List(something)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be nothing and not be defined)) (definition)
+          (all(left1) should (not be nothing and not be defined)) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(something, nothing) + ", but " + wasDefined(something), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -217,7 +217,7 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left2 = List(something)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be defined and not be nothing)) (definition)
+          (all(left2) should (not be defined and not be nothing)) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught2.message === Some(allError(wasDefined(something), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -225,7 +225,7 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left3 = List(something)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (not equal nothing and not be defined)) (defaultEquality, definition)
+          (all(left3) should (not equal nothing and not be defined)) (/* DOTTY-ONLY using */ defaultEquality, definition)
         }
         assert(caught3.message === Some(allError(didNotEqual(something, nothing) + ", but " + wasDefined(something), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -233,7 +233,7 @@ class ShouldBeDefinedLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left4 = List(something)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (not be defined and not equal nothing)) (definition, defaultEquality)
+          (all(left4) should (not be defined and not equal nothing)) (/* DOTTY-ONLY using */ definition, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasDefined(something), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalOrExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeDefinedLogicalOrExplicitSpec.scala
@@ -74,47 +74,47 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends AnyFunSpec {
       
       it("should do nothing when thing is defined ") {
         
-        (something should (be (defined ) or be (something))) (definition)
-        (nothing should (be (defined ) or be (nothing))) (definition)
-        (something should (be (defined ) or be (nothing))) (definition)
+        (something should (be (defined ) or be (something))) (/* DOTTY-ONLY using */ definition)
+        (nothing should (be (defined ) or be (nothing))) (/* DOTTY-ONLY using */ definition)
+        (something should (be (defined ) or be (nothing))) (/* DOTTY-ONLY using */ definition)
         
-        (something should (be (something) or be (defined ))) (definition)
-        (something should (be (nothing) or be (defined ))) (definition)
-        (nothing should (be (nothing) or be (defined ))) (definition)
+        (something should (be (something) or be (defined ))) (/* DOTTY-ONLY using */ definition)
+        (something should (be (nothing) or be (defined ))) (/* DOTTY-ONLY using */ definition)
+        (nothing should (be (nothing) or be (defined ))) (/* DOTTY-ONLY using */ definition)
         
-        (something should (be (defined ) or equal (something))) (definition, defaultEquality)
-        (nothing should (be (defined ) or equal (nothing))) (definition, defaultEquality)
-        (something should (be (defined ) or equal (nothing))) (definition, defaultEquality)
+        (something should (be (defined ) or equal (something))) (/* DOTTY-ONLY using */ definition, defaultEquality)
+        (nothing should (be (defined ) or equal (nothing))) (/* DOTTY-ONLY using */ definition, defaultEquality)
+        (something should (be (defined ) or equal (nothing))) (/* DOTTY-ONLY using */ definition, defaultEquality)
         
-        (something should (equal (something) or be (defined ))) (defaultEquality, definition)
-        (something should (equal (nothing) or be (defined ))) (defaultEquality, definition)
-        (nothing should (equal (nothing) or be (defined ))) (defaultEquality, definition)
+        (something should (equal (something) or be (defined ))) (/* DOTTY-ONLY using */ defaultEquality, definition)
+        (something should (equal (nothing) or be (defined ))) (/* DOTTY-ONLY using */ defaultEquality, definition)
+        (nothing should (equal (nothing) or be (defined ))) (/* DOTTY-ONLY using */ defaultEquality, definition)
       }
       
       it("should throw TestFailedException with correct stack depth when thing is not defined ") {
         val caught1 = intercept[TestFailedException] {
-          (nothing should (be (defined ) or be (something))) (definition)
+          (nothing should (be (defined ) or be (something))) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught1.message === Some(wasNotDefined(nothing) + ", and " + wasNotEqualTo(nothing, something)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (nothing should (be (something) or be (defined ))) (definition)
+          (nothing should (be (something) or be (defined ))) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught2.message === Some(wasNotEqualTo(nothing, something) + ", and " + wasNotDefined(nothing)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (nothing should (be (defined ) or equal (something))) (definition, defaultEquality)
+          (nothing should (be (defined ) or equal (something))) (/* DOTTY-ONLY using */ definition, defaultEquality)
         }
         assert(caught3.message === Some(wasNotDefined(nothing) + ", and " + didNotEqual(nothing, something)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (nothing should (equal (something) or be (defined ))) (defaultEquality, definition)
+          (nothing should (equal (something) or be (defined ))) (/* DOTTY-ONLY using */ defaultEquality, definition)
         }
         assert(caught4.message === Some(didNotEqual(nothing, something) + ", and " + wasNotDefined(nothing)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -125,47 +125,47 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends AnyFunSpec {
     describe("when work with 'thing should not be defined '") {
       
       it("should do nothing when thing is not defined ") {
-        (nothing should (not be defined  or not be something)) (definition)
-        (something should (not be defined  or not be nothing)) (definition)
-        (nothing should (not be defined  or not be nothing)) (definition)
+        (nothing should (not be defined  or not be something)) (/* DOTTY-ONLY using */ definition)
+        (something should (not be defined  or not be nothing)) (/* DOTTY-ONLY using */ definition)
+        (nothing should (not be defined  or not be nothing)) (/* DOTTY-ONLY using */ definition)
         
-        (nothing should (not be something or not be defined )) (definition)
-        (nothing should (not be nothing or not be defined )) (definition)
-        (something should (not be nothing or not be defined )) (definition)
+        (nothing should (not be something or not be defined )) (/* DOTTY-ONLY using */ definition)
+        (nothing should (not be nothing or not be defined )) (/* DOTTY-ONLY using */ definition)
+        (something should (not be nothing or not be defined )) (/* DOTTY-ONLY using */ definition)
         
-        (nothing should (not be defined  or not equal something)) (definition, defaultEquality)
-        (something should (not be defined  or not equal nothing)) (definition, defaultEquality)
-        (nothing should (not be defined  or not equal nothing)) (definition, defaultEquality)
+        (nothing should (not be defined  or not equal something)) (/* DOTTY-ONLY using */ definition, defaultEquality)
+        (something should (not be defined  or not equal nothing)) (/* DOTTY-ONLY using */ definition, defaultEquality)
+        (nothing should (not be defined  or not equal nothing)) (/* DOTTY-ONLY using */ definition, defaultEquality)
         
-        (nothing should (not equal something or not be defined )) (defaultEquality, definition)
-        (nothing should (not equal nothing or not be defined )) (defaultEquality, definition)
-        (something should (not equal nothing or not be defined )) (defaultEquality, definition)
+        (nothing should (not equal something or not be defined )) (/* DOTTY-ONLY using */ defaultEquality, definition)
+        (nothing should (not equal nothing or not be defined )) (/* DOTTY-ONLY using */ defaultEquality, definition)
+        (something should (not equal nothing or not be defined )) (/* DOTTY-ONLY using */ defaultEquality, definition)
       }
       
       it("should throw TestFailedException with correct stack depth when thing is defined ") {
         val caught1 = intercept[TestFailedException] {
-          (something should (not be defined  or not be something)) (definition)
+          (something should (not be defined  or not be something)) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught1.message === Some(wasDefined(something) + ", and " + wasEqualTo(something, something)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (something should (not be something or not be defined )) (definition)
+          (something should (not be something or not be defined )) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught2.message === Some(wasEqualTo(something, something) + ", and " + wasDefined(something)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (something should (not be defined  or not equal something)) (definition, defaultEquality)
+          (something should (not be defined  or not equal something)) (/* DOTTY-ONLY using */ definition, defaultEquality)
         }
         assert(caught3.message === Some(wasDefined(something) + ", and " + equaled(something, something)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (something should (not equal something or not be defined )) (defaultEquality, definition)
+          (something should (not equal something or not be defined )) (/* DOTTY-ONLY using */ defaultEquality, definition)
         }
         assert(caught4.message === Some(equaled(something, something) + ", and " + wasDefined(something)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -176,27 +176,27 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) should be (defined )'") {
       
       it("should do nothing when all(xs) is defined ") {
-        (all(List(something)) should (be (defined ) or be (something))) (definition)
-        (all(List(nothing)) should (be (defined ) or be (nothing))) (definition)
-        (all(List(something)) should (be (defined ) or be (nothing))) (definition)
+        (all(List(something)) should (be (defined ) or be (something))) (/* DOTTY-ONLY using */ definition)
+        (all(List(nothing)) should (be (defined ) or be (nothing))) (/* DOTTY-ONLY using */ definition)
+        (all(List(something)) should (be (defined ) or be (nothing))) (/* DOTTY-ONLY using */ definition)
         
-        (all(List(something)) should (be (something) or be (defined ))) (definition)
-        (all(List(something)) should (be (nothing) or be (defined ))) (definition)
-        (all(List(nothing)) should (be (nothing) or be (defined ))) (definition)
+        (all(List(something)) should (be (something) or be (defined ))) (/* DOTTY-ONLY using */ definition)
+        (all(List(something)) should (be (nothing) or be (defined ))) (/* DOTTY-ONLY using */ definition)
+        (all(List(nothing)) should (be (nothing) or be (defined ))) (/* DOTTY-ONLY using */ definition)
         
-        (all(List(something)) should (be (defined ) or equal (something))) (definition, defaultEquality)
-        (all(List(nothing)) should (be (defined ) or equal (nothing))) (definition, defaultEquality)
-        (all(List(something)) should (be (defined ) or equal (nothing))) (definition, defaultEquality)
+        (all(List(something)) should (be (defined ) or equal (something))) (/* DOTTY-ONLY using */ definition, defaultEquality)
+        (all(List(nothing)) should (be (defined ) or equal (nothing))) (/* DOTTY-ONLY using */ definition, defaultEquality)
+        (all(List(something)) should (be (defined ) or equal (nothing))) (/* DOTTY-ONLY using */ definition, defaultEquality)
         
-        (all(List(something)) should (equal (something) or be (defined ))) (defaultEquality, definition)
-        (all(List(something)) should (equal (nothing) or be (defined ))) (defaultEquality, definition)
-        (all(List(nothing)) should (equal (nothing) or be (defined ))) (defaultEquality, definition)
+        (all(List(something)) should (equal (something) or be (defined ))) (/* DOTTY-ONLY using */ defaultEquality, definition)
+        (all(List(something)) should (equal (nothing) or be (defined ))) (/* DOTTY-ONLY using */ defaultEquality, definition)
+        (all(List(nothing)) should (equal (nothing) or be (defined ))) (/* DOTTY-ONLY using */ defaultEquality, definition)
       }
       
       it("should throw TestFailedException with correct stack depth when xs is not defined ") {
         val left1 = List(nothing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (something) or be (defined ))) (definition)
+          (all(left1) should (be (something) or be (defined ))) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(nothing, something) + ", and " + wasNotDefined(nothing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -204,7 +204,7 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left2 = List(nothing)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (defined ) or be (something))) (definition)
+          (all(left2) should (be (defined ) or be (something))) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught2.message === Some(allError(wasNotDefined(nothing) + ", and " + wasNotEqualTo(nothing, something), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -212,7 +212,7 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left3 = List(nothing)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (equal (something) or be (defined ))) (defaultEquality, definition)
+          (all(left3) should (equal (something) or be (defined ))) (/* DOTTY-ONLY using */ defaultEquality, definition)
         }
         assert(caught3.message === Some(allError(didNotEqual(nothing, something) + ", and " + wasNotDefined(nothing), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -220,7 +220,7 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left4 = List(nothing)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (be (defined ) or equal (something))) (definition, defaultEquality)
+          (all(left4) should (be (defined ) or equal (something))) (/* DOTTY-ONLY using */ definition, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasNotDefined(nothing) + ", and " + didNotEqual(nothing, something), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -230,27 +230,27 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends AnyFunSpec {
     
     describe("when work with 'all(xs) should not be defined '") {
       it("should do nothing when xs is not defined ") {
-        (all(List(nothing)) should (not be defined  or not be something)) (definition)
-        (all(List(something)) should (not be defined  or not be nothing)) (definition)
-        (all(List(nothing)) should (not be defined  or not be nothing)) (definition)
+        (all(List(nothing)) should (not be defined  or not be something)) (/* DOTTY-ONLY using */ definition)
+        (all(List(something)) should (not be defined  or not be nothing)) (/* DOTTY-ONLY using */ definition)
+        (all(List(nothing)) should (not be defined  or not be nothing)) (/* DOTTY-ONLY using */ definition)
         
-        (all(List(nothing)) should (not be something or not be defined )) (definition)
-        (all(List(nothing)) should (not be nothing or not be defined )) (definition)
-        (all(List(something)) should (not be nothing or not be defined )) (definition)
+        (all(List(nothing)) should (not be something or not be defined )) (/* DOTTY-ONLY using */ definition)
+        (all(List(nothing)) should (not be nothing or not be defined )) (/* DOTTY-ONLY using */ definition)
+        (all(List(something)) should (not be nothing or not be defined )) (/* DOTTY-ONLY using */ definition)
         
-        (all(List(nothing)) should (not be defined  or not equal something)) (definition, defaultEquality)
-        (all(List(something)) should (not be defined  or not equal nothing)) (definition, defaultEquality)
-        (all(List(nothing)) should (not be defined  or not equal nothing)) (definition, defaultEquality)
+        (all(List(nothing)) should (not be defined  or not equal something)) (/* DOTTY-ONLY using */ definition, defaultEquality)
+        (all(List(something)) should (not be defined  or not equal nothing)) (/* DOTTY-ONLY using */ definition, defaultEquality)
+        (all(List(nothing)) should (not be defined  or not equal nothing)) (/* DOTTY-ONLY using */ definition, defaultEquality)
         
-        (all(List(nothing)) should (not equal something or not be defined )) (defaultEquality, definition)
-        (all(List(nothing)) should (not equal nothing or not be defined )) (defaultEquality, definition)
-        (all(List(something)) should (not equal nothing or not be defined )) (defaultEquality, definition)
+        (all(List(nothing)) should (not equal something or not be defined )) (/* DOTTY-ONLY using */ defaultEquality, definition)
+        (all(List(nothing)) should (not equal nothing or not be defined )) (/* DOTTY-ONLY using */ defaultEquality, definition)
+        (all(List(something)) should (not equal nothing or not be defined )) (/* DOTTY-ONLY using */ defaultEquality, definition)
       }
       
       it("should throw TestFailedException with correct stack depth when xs is not defined ") {
         val left1 = List(something)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be something or not be defined )) (definition)
+          (all(left1) should (not be something or not be defined )) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught1.message === Some(allError(wasEqualTo(something, something) + ", and " + wasDefined(something), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -258,7 +258,7 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left2 = List(something)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be defined  or not be something)) (definition)
+          (all(left2) should (not be defined  or not be something)) (/* DOTTY-ONLY using */ definition)
         }
         assert(caught2.message === Some(allError(wasDefined(something) + ", and " + wasEqualTo(something, something), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -266,7 +266,7 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left3 = List(something)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (not equal something or not be defined )) (defaultEquality, definition)
+          (all(left3) should (not equal something or not be defined )) (/* DOTTY-ONLY using */ defaultEquality, definition)
         }
         assert(caught3.message === Some(allError(equaled(something, something) + ", and " + wasDefined(something), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -274,7 +274,7 @@ class ShouldBeDefinedLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left4 = List(something)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (not be defined  or not equal something)) (definition, defaultEquality)
+          (all(left4) should (not be defined  or not equal something)) (/* DOTTY-ONLY using */ definition, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasDefined(something) + ", and " + equaled(something, something), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyExplicitSpec.scala
@@ -60,12 +60,12 @@ class ShouldBeEmptyExplicitSpec extends AnyFunSpec {
     describe("when work with 'list should be (empty)'") {
       
       it("should do nothing when list is empty") {
-        (emptyThing should be (empty)) (emptiness)
+        (emptyThing should be (empty)) (/* DOTTY-ONLY using */ emptiness)
       }
       
       it("should throw TestFailedException with correct stack depth when list is not empty") {
         val caught1 = intercept[TestFailedException] {
-          (nonEmptyThing should be (empty)) (emptiness)
+          (nonEmptyThing should be (empty)) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught1.message === Some(wasNotEmpty(nonEmptyThing)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -77,12 +77,12 @@ class ShouldBeEmptyExplicitSpec extends AnyFunSpec {
     describe("when work with 'list should not be empty'") {
       
       it("should do nothing when list is not empty") {
-        (nonEmptyThing should not be empty) (emptiness)
+        (nonEmptyThing should not be empty) (/* DOTTY-ONLY using */ emptiness)
       }
       
       it("should throw TestFailedException with correct stack depth when list is empty") {
         val caught1 = intercept[TestFailedException] {
-          (emptyThing should not be empty) (emptiness)
+          (emptyThing should not be empty) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught1.message === Some(wasEmpty(emptyThing)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -93,12 +93,12 @@ class ShouldBeEmptyExplicitSpec extends AnyFunSpec {
     describe("when work with 'list shouldBe empty'") {
       
       it("should do nothing when list is empty") {
-        (emptyThing shouldBe empty) (emptiness)
+        (emptyThing shouldBe empty) (/* DOTTY-ONLY using */ emptiness)
       }
       
       it("should throw TestFailedException with correct stack depth when list is not empty") {
         val caught1 = intercept[TestFailedException] {
-          (nonEmptyThing shouldBe empty) (emptiness)
+          (nonEmptyThing shouldBe empty) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught1.message === Some(wasNotEmpty(nonEmptyThing)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -110,12 +110,12 @@ class ShouldBeEmptyExplicitSpec extends AnyFunSpec {
     describe("when work with 'list shouldNot be (empty)'") {
       
       it("should do nothing when list is not empty") {
-        (nonEmptyThing shouldNot be (empty)) (emptiness)
+        (nonEmptyThing shouldNot be (empty)) (/* DOTTY-ONLY using */ emptiness)
       }
       
       it("should throw TestFailedException with correct stack depth when list is empty") {
         val caught1 = intercept[TestFailedException] {
-          (emptyThing shouldNot be (empty)) (emptiness)
+          (emptyThing shouldNot be (empty)) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught1.message === Some(wasEmpty(emptyThing)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -127,13 +127,13 @@ class ShouldBeEmptyExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) should be (empty)'") {
       
       it("should do nothing when all(xs) is empty") {
-        (all(List(emptyThing)) should be (empty)) (emptiness)
+        (all(List(emptyThing)) should be (empty)) (/* DOTTY-ONLY using */ emptiness)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is not empty") {
         val left1 = List(nonEmptyThing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should be (empty)) (emptiness)
+          (all(left1) should be (empty)) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught1.message === Some(allError(left1, wasNotEmpty(nonEmptyThing), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -145,13 +145,13 @@ class ShouldBeEmptyExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) should not be empty'") {
       
       it("should do nothing when all(xs) is not empty") {
-        (all(List(nonEmptyThing)) should not be empty) (emptiness)
+        (all(List(nonEmptyThing)) should not be empty) (/* DOTTY-ONLY using */ emptiness)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is empty") {
         val left1 = List(emptyThing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should not be empty) (emptiness)
+          (all(left1) should not be empty) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught1.message === Some(allError(left1, wasEmpty(emptyThing), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -163,13 +163,13 @@ class ShouldBeEmptyExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) shouldBe empty'") {
       
       it("should do nothing when all(xs) is empty") {
-        (all(List(emptyThing)) shouldBe empty) (emptiness)
+        (all(List(emptyThing)) shouldBe empty) (/* DOTTY-ONLY using */ emptiness)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is not empty") {
         val left1 = List(nonEmptyThing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) shouldBe empty) (emptiness)
+          (all(left1) shouldBe empty) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught1.message === Some(allError(left1, wasNotEmpty(nonEmptyThing), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -180,13 +180,13 @@ class ShouldBeEmptyExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) shouldNot be (empty)'") {
       
       it("should do nothing when all(xs) is not empty") {
-        (all(List(nonEmptyThing)) shouldNot be (empty)) (emptiness)
+        (all(List(nonEmptyThing)) shouldNot be (empty)) (/* DOTTY-ONLY using */ emptiness)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is empty") {
         val left1 = List(emptyThing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) shouldNot be (empty)) (emptiness)
+          (all(left1) shouldNot be (empty)) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught1.message === Some(allError(left1, wasEmpty(emptyThing), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyLogicalAndExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyLogicalAndExplicitSpec.scala
@@ -72,37 +72,37 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends AnyFunSpec {
     describe("when work with 'list should be (empty)'") {
       
       it("should do nothing when list is empty") {
-        (emptyThing should (equal (emptyThing) and be (empty))) (defaultEquality, emptiness)
-        (emptyThing should (be (empty) and equal (emptyThing))) (emptiness, defaultEquality)
+        (emptyThing should (equal (emptyThing) and be (empty))) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
+        (emptyThing should (be (empty) and equal (emptyThing))) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
         
-        (emptyThing should (be (emptyThing) and be (empty))) (emptiness)
-        (emptyThing should (be (empty) and be (emptyThing))) (emptiness)
+        (emptyThing should (be (emptyThing) and be (empty))) (/* DOTTY-ONLY using */ emptiness)
+        (emptyThing should (be (empty) and be (emptyThing))) (/* DOTTY-ONLY using */ emptiness)
       }
       
       it("should throw TestFailedException with correct stack depth when list is not empty") {
         val caught1 = intercept[TestFailedException] {
-          (nonEmptyThing should (equal (nonEmptyThing) and be (empty))) (defaultEquality, emptiness)
+          (nonEmptyThing should (equal (nonEmptyThing) and be (empty))) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
         }
         assert(caught1.message === Some(equaled(nonEmptyThing, nonEmptyThing) + ", but " + wasNotEmpty(nonEmptyThing)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (nonEmptyThing should (be (empty) and equal (nonEmptyThing))) (emptiness, defaultEquality)
+          (nonEmptyThing should (be (empty) and equal (nonEmptyThing))) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
         }
         assert(caught2.message === Some(wasNotEmpty(nonEmptyThing)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (nonEmptyThing should (be (nonEmptyThing) and be (empty))) (emptiness)
+          (nonEmptyThing should (be (nonEmptyThing) and be (empty))) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught3.message === Some(wasEqualTo(nonEmptyThing, nonEmptyThing) + ", but " + wasNotEmpty(nonEmptyThing)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (nonEmptyThing should (be (empty) and be (nonEmptyThing))) (emptiness)
+          (nonEmptyThing should (be (empty) and be (nonEmptyThing))) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught4.message === Some(wasNotEmpty(nonEmptyThing)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -113,37 +113,37 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends AnyFunSpec {
     describe("when work with 'list should not be empty'") {
       
       it("should do nothing when file is not empty") {
-        (nonEmptyThing should (not equal emptyThing and not be empty)) (defaultEquality, emptiness)
-        (nonEmptyThing should (not be empty and not equal emptyThing)) (emptiness, defaultEquality)
+        (nonEmptyThing should (not equal emptyThing and not be empty)) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
+        (nonEmptyThing should (not be empty and not equal emptyThing)) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
         
-        (nonEmptyThing should (not be emptyThing and not be empty)) (emptiness)
-        (nonEmptyThing should (not be empty and not be emptyThing)) (emptiness)
+        (nonEmptyThing should (not be emptyThing and not be empty)) (/* DOTTY-ONLY using */ emptiness)
+        (nonEmptyThing should (not be empty and not be emptyThing)) (/* DOTTY-ONLY using */ emptiness)
       }
       
       it("should throw TestFailedException with correct stack depth when list is not empty") {
         val caught1 = intercept[TestFailedException] {
-          (emptyThing should (not equal nonEmptyThing and not be empty)) (defaultEquality, emptiness)
+          (emptyThing should (not equal nonEmptyThing and not be empty)) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
         }
         assert(caught1.message === Some(didNotEqual(emptyThing, nonEmptyThing) + ", but " + wasEmpty(emptyThing)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (emptyThing should (not be empty and not equal nonEmptyThing)) (emptiness, defaultEquality)
+          (emptyThing should (not be empty and not equal nonEmptyThing)) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
         }
         assert(caught2.message === Some(wasEmpty(emptyThing)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (emptyThing should (not be nonEmptyThing and not be empty)) (emptiness)
+          (emptyThing should (not be nonEmptyThing and not be empty)) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught3.message === Some(wasNotEqualTo(emptyThing, nonEmptyThing) + ", but " + wasEmpty(emptyThing)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (emptyThing should (not be empty and not be nonEmptyThing)) (emptiness)
+          (emptyThing should (not be empty and not be nonEmptyThing)) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught4.message === Some(wasEmpty(emptyThing)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -154,17 +154,17 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) should be (empty)'") {
       
       it("should do nothing when all(xs) is empty") {
-        (all(List(emptyThing)) should (be (emptyThing) and be (empty))) (emptiness)
-        (all(List(emptyThing)) should (be (empty) and be (emptyThing))) (emptiness)
+        (all(List(emptyThing)) should (be (emptyThing) and be (empty))) (/* DOTTY-ONLY using */ emptiness)
+        (all(List(emptyThing)) should (be (empty) and be (emptyThing))) (/* DOTTY-ONLY using */ emptiness)
         
-        (all(List(emptyThing)) should (equal (emptyThing) and be (empty))) (defaultEquality, emptiness)
-        (all(List(emptyThing)) should (be (empty) and equal (emptyThing))) (emptiness, defaultEquality)
+        (all(List(emptyThing)) should (equal (emptyThing) and be (empty))) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
+        (all(List(emptyThing)) should (be (empty) and equal (emptyThing))) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is not empty") {
         val left1 = List(nonEmptyThing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (nonEmptyThing) and be (empty))) (emptiness)
+          (all(left1) should (be (nonEmptyThing) and be (empty))) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught1.message === Some(allError(wasEqualTo(nonEmptyThing, nonEmptyThing) + ", but " + wasNotEmpty(nonEmptyThing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -172,7 +172,7 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left2 = List(nonEmptyThing)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (empty) and be (nonEmptyThing))) (emptiness)
+          (all(left2) should (be (empty) and be (nonEmptyThing))) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught2.message === Some(allError(wasNotEmpty(nonEmptyThing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -180,7 +180,7 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left3 = List(nonEmptyThing)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (equal (nonEmptyThing) and be (empty))) (defaultEquality, emptiness)
+          (all(left3) should (equal (nonEmptyThing) and be (empty))) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
         }
         assert(caught3.message === Some(allError(equaled(nonEmptyThing, nonEmptyThing) + ", but " + wasNotEmpty(nonEmptyThing), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -188,7 +188,7 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left4 = List(nonEmptyThing)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (be (empty) and equal (nonEmptyThing))) (emptiness, defaultEquality)
+          (all(left4) should (be (empty) and equal (nonEmptyThing))) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasNotEmpty(nonEmptyThing), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -198,17 +198,17 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends AnyFunSpec {
     
     describe("when work with 'all(xs) should not be empty'") {
       it("should do nothing when all(xs) is not empty") {
-        (all(List(nonEmptyThing)) should (not be empty and not be emptyThing)) (emptiness)
-        (all(List(nonEmptyThing)) should (not be emptyThing and not be empty)) (emptiness)
+        (all(List(nonEmptyThing)) should (not be empty and not be emptyThing)) (/* DOTTY-ONLY using */ emptiness)
+        (all(List(nonEmptyThing)) should (not be emptyThing and not be empty)) (/* DOTTY-ONLY using */ emptiness)
         
-        (all(List(nonEmptyThing)) should (not be empty and not equal emptyThing)) (emptiness, defaultEquality)
-        (all(List(nonEmptyThing)) should (not equal emptyThing and not be empty)) (defaultEquality, emptiness)
+        (all(List(nonEmptyThing)) should (not be empty and not equal emptyThing)) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
+        (all(List(nonEmptyThing)) should (not equal emptyThing and not be empty)) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is empty") {
         val left1 = List(emptyThing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be nonEmptyThing and not be empty)) (emptiness)
+          (all(left1) should (not be nonEmptyThing and not be empty)) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(emptyThing, nonEmptyThing) + ", but " + wasEmpty(emptyThing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -216,7 +216,7 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left2 = List(emptyThing)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be empty and not be nonEmptyThing)) (emptiness)
+          (all(left2) should (not be empty and not be nonEmptyThing)) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught2.message === Some(allError(wasEmpty(emptyThing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -224,7 +224,7 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left3 = List(emptyThing)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (not equal nonEmptyThing and not be empty)) (defaultEquality, emptiness)
+          (all(left3) should (not equal nonEmptyThing and not be empty)) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
         }
         assert(caught3.message === Some(allError(didNotEqual(emptyThing, nonEmptyThing) + ", but " + wasEmpty(emptyThing), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -232,7 +232,7 @@ class ShouldBeEmptyLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left4 = List(emptyThing)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (not be empty and not equal nonEmptyThing)) (emptiness, defaultEquality)
+          (all(left4) should (not be empty and not equal nonEmptyThing)) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasEmpty(emptyThing), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyLogicalOrExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeEmptyLogicalOrExplicitSpec.scala
@@ -73,47 +73,47 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends AnyFunSpec {
       
       it("should do nothing when list is empty") {
         
-        (emptyThing should (be (empty) or be (emptyThing))) (emptiness)
-        (nonEmptyThing should (be (empty) or be (nonEmptyThing))) (emptiness)
-        (emptyThing should (be (empty) or be (nonEmptyThing))) (emptiness)
+        (emptyThing should (be (empty) or be (emptyThing))) (/* DOTTY-ONLY using */ emptiness)
+        (nonEmptyThing should (be (empty) or be (nonEmptyThing))) (/* DOTTY-ONLY using */ emptiness)
+        (emptyThing should (be (empty) or be (nonEmptyThing))) (/* DOTTY-ONLY using */ emptiness)
         
-        (emptyThing should (be (emptyThing) or be (empty))) (emptiness)
-        (emptyThing should (be (nonEmptyThing) or be (empty))) (emptiness)
-        (nonEmptyThing should (be (nonEmptyThing) or be (empty))) (emptiness)
+        (emptyThing should (be (emptyThing) or be (empty))) (/* DOTTY-ONLY using */ emptiness)
+        (emptyThing should (be (nonEmptyThing) or be (empty))) (/* DOTTY-ONLY using */ emptiness)
+        (nonEmptyThing should (be (nonEmptyThing) or be (empty))) (/* DOTTY-ONLY using */ emptiness)
         
-        (emptyThing should (be (empty) or equal (emptyThing))) (emptiness, defaultEquality)
-        (nonEmptyThing should (be (empty) or equal (nonEmptyThing))) (emptiness, defaultEquality)
-        (emptyThing should (be (empty) or equal (nonEmptyThing))) (emptiness, defaultEquality)
+        (emptyThing should (be (empty) or equal (emptyThing))) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
+        (nonEmptyThing should (be (empty) or equal (nonEmptyThing))) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
+        (emptyThing should (be (empty) or equal (nonEmptyThing))) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
         
-        (emptyThing should (equal (emptyThing) or be (empty))) (defaultEquality, emptiness)
-        (emptyThing should (equal (nonEmptyThing) or be (empty))) (defaultEquality, emptiness)
-        (nonEmptyThing should (equal (nonEmptyThing) or be (empty))) (defaultEquality, emptiness)
+        (emptyThing should (equal (emptyThing) or be (empty))) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
+        (emptyThing should (equal (nonEmptyThing) or be (empty))) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
+        (nonEmptyThing should (equal (nonEmptyThing) or be (empty))) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
       }
       
       it("should throw TestFailedException with correct stack depth when file is not empty") {
         val caught1 = intercept[TestFailedException] {
-          (nonEmptyThing should (be (empty) or be (emptyThing))) (emptiness)
+          (nonEmptyThing should (be (empty) or be (emptyThing))) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught1.message === Some(wasNotEmpty(nonEmptyThing) + ", and " + wasNotEqualTo(nonEmptyThing, emptyThing)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (nonEmptyThing should (be (emptyThing) or be (empty))) (emptiness)
+          (nonEmptyThing should (be (emptyThing) or be (empty))) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught2.message === Some(wasNotEqualTo(nonEmptyThing, emptyThing) + ", and " + wasNotEmpty(nonEmptyThing)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (nonEmptyThing should (be (empty) or equal (emptyThing))) (emptiness, defaultEquality)
+          (nonEmptyThing should (be (empty) or equal (emptyThing))) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
         }
         assert(caught3.message === Some(wasNotEmpty(nonEmptyThing) + ", and " + didNotEqual(nonEmptyThing, emptyThing)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (nonEmptyThing should (equal (emptyThing) or be (empty))) (defaultEquality, emptiness)
+          (nonEmptyThing should (equal (emptyThing) or be (empty))) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
         }
         assert(caught4.message === Some(didNotEqual(nonEmptyThing, emptyThing) + ", and " + wasNotEmpty(nonEmptyThing)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -124,47 +124,47 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends AnyFunSpec {
     describe("when work with 'file should not be empty'") {
       
       it("should do nothing when file is not empty") {
-        (nonEmptyThing should (not be empty or not be emptyThing)) (emptiness)
-        (emptyThing should (not be empty or not be nonEmptyThing)) (emptiness)
-        (nonEmptyThing should (not be empty or not be nonEmptyThing)) (emptiness)
+        (nonEmptyThing should (not be empty or not be emptyThing)) (/* DOTTY-ONLY using */ emptiness)
+        (emptyThing should (not be empty or not be nonEmptyThing)) (/* DOTTY-ONLY using */ emptiness)
+        (nonEmptyThing should (not be empty or not be nonEmptyThing)) (/* DOTTY-ONLY using */ emptiness)
         
-        (nonEmptyThing should (not be emptyThing or not be empty)) (emptiness)
-        (nonEmptyThing should (not be nonEmptyThing or not be empty)) (emptiness)
-        (emptyThing should (not be nonEmptyThing or not be empty)) (emptiness)
+        (nonEmptyThing should (not be emptyThing or not be empty)) (/* DOTTY-ONLY using */ emptiness)
+        (nonEmptyThing should (not be nonEmptyThing or not be empty)) (/* DOTTY-ONLY using */ emptiness)
+        (emptyThing should (not be nonEmptyThing or not be empty)) (/* DOTTY-ONLY using */ emptiness)
         
-        (nonEmptyThing should (not be empty or not equal emptyThing)) (emptiness, defaultEquality)
-        (emptyThing should (not be empty or not equal nonEmptyThing)) (emptiness, defaultEquality)
-        (nonEmptyThing should (not be empty or not equal nonEmptyThing)) (emptiness, defaultEquality)
+        (nonEmptyThing should (not be empty or not equal emptyThing)) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
+        (emptyThing should (not be empty or not equal nonEmptyThing)) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
+        (nonEmptyThing should (not be empty or not equal nonEmptyThing)) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
         
-        (nonEmptyThing should (not equal emptyThing or not be empty)) (defaultEquality, emptiness)
-        (nonEmptyThing should (not equal nonEmptyThing or not be empty)) (defaultEquality, emptiness)
-        (emptyThing should (not equal nonEmptyThing or not be empty)) (defaultEquality, emptiness)
+        (nonEmptyThing should (not equal emptyThing or not be empty)) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
+        (nonEmptyThing should (not equal nonEmptyThing or not be empty)) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
+        (emptyThing should (not equal nonEmptyThing or not be empty)) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
       }
       
       it("should throw TestFailedException with correct stack depth when file is empty") {
         val caught1 = intercept[TestFailedException] {
-          (emptyThing should (not be empty or not be emptyThing)) (emptiness)
+          (emptyThing should (not be empty or not be emptyThing)) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught1.message === Some(wasEmpty(emptyThing) + ", and " + wasEqualTo(emptyThing, emptyThing)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (emptyThing should (not be emptyThing or not be empty)) (emptiness)
+          (emptyThing should (not be emptyThing or not be empty)) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught2.message === Some(wasEqualTo(emptyThing, emptyThing) + ", and " + wasEmpty(emptyThing)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (emptyThing should (not be empty or not equal emptyThing)) (emptiness, defaultEquality)
+          (emptyThing should (not be empty or not equal emptyThing)) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
         }
         assert(caught3.message === Some(wasEmpty(emptyThing) + ", and " + equaled(emptyThing, emptyThing)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (emptyThing should (not equal emptyThing or not be empty)) (defaultEquality, emptiness)
+          (emptyThing should (not equal emptyThing or not be empty)) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
         }
         assert(caught4.message === Some(equaled(emptyThing, emptyThing) + ", and " + wasEmpty(emptyThing)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -175,27 +175,27 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) should be (empty)'") {
       
       it("should do nothing when all(xs) is empty") {
-        (all(List(emptyThing)) should (be (empty) or be (emptyThing))) (emptiness)
-        (all(List(nonEmptyThing)) should (be (empty) or be (nonEmptyThing))) (emptiness)
-        (all(List(emptyThing)) should (be (empty) or be (nonEmptyThing))) (emptiness)
+        (all(List(emptyThing)) should (be (empty) or be (emptyThing))) (/* DOTTY-ONLY using */ emptiness)
+        (all(List(nonEmptyThing)) should (be (empty) or be (nonEmptyThing))) (/* DOTTY-ONLY using */ emptiness)
+        (all(List(emptyThing)) should (be (empty) or be (nonEmptyThing))) (/* DOTTY-ONLY using */ emptiness)
         
-        (all(List(emptyThing)) should (be (emptyThing) or be (empty))) (emptiness)
-        (all(List(emptyThing)) should (be (nonEmptyThing) or be (empty))) (emptiness)
-        (all(List(nonEmptyThing)) should (be (nonEmptyThing) or be (empty))) (emptiness)
+        (all(List(emptyThing)) should (be (emptyThing) or be (empty))) (/* DOTTY-ONLY using */ emptiness)
+        (all(List(emptyThing)) should (be (nonEmptyThing) or be (empty))) (/* DOTTY-ONLY using */ emptiness)
+        (all(List(nonEmptyThing)) should (be (nonEmptyThing) or be (empty))) (/* DOTTY-ONLY using */ emptiness)
         
-        (all(List(emptyThing)) should (be (empty) or equal (emptyThing))) (emptiness, defaultEquality)
-        (all(List(nonEmptyThing)) should (be (empty) or equal (nonEmptyThing))) (emptiness, defaultEquality)
-        (all(List(emptyThing)) should (be (empty) or equal (nonEmptyThing))) (emptiness, defaultEquality)
+        (all(List(emptyThing)) should (be (empty) or equal (emptyThing))) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
+        (all(List(nonEmptyThing)) should (be (empty) or equal (nonEmptyThing))) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
+        (all(List(emptyThing)) should (be (empty) or equal (nonEmptyThing))) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
         
-        (all(List(emptyThing)) should (equal (emptyThing) or be (empty))) (defaultEquality, emptiness)
-        (all(List(emptyThing)) should (equal (nonEmptyThing) or be (empty))) (defaultEquality, emptiness)
-        (all(List(nonEmptyThing)) should (equal (nonEmptyThing) or be (empty))) (defaultEquality, emptiness)
+        (all(List(emptyThing)) should (equal (emptyThing) or be (empty))) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
+        (all(List(emptyThing)) should (equal (nonEmptyThing) or be (empty))) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
+        (all(List(nonEmptyThing)) should (equal (nonEmptyThing) or be (empty))) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
       }
       
       it("should throw TestFailedException with correct stack depth when xs is not sorted") {
         val left1 = List(nonEmptyThing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (emptyThing) or be (empty))) (emptiness)
+          (all(left1) should (be (emptyThing) or be (empty))) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(nonEmptyThing, emptyThing) + ", and " + wasNotEmpty(nonEmptyThing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -203,7 +203,7 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left2 = List(nonEmptyThing)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (empty) or be (emptyThing))) (emptiness)
+          (all(left2) should (be (empty) or be (emptyThing))) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught2.message === Some(allError(wasNotEmpty(nonEmptyThing) + ", and " + wasNotEqualTo(nonEmptyThing, emptyThing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -211,7 +211,7 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left3 = List(nonEmptyThing)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (equal (emptyThing) or be (empty))) (defaultEquality, emptiness)
+          (all(left3) should (equal (emptyThing) or be (empty))) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
         }
         assert(caught3.message === Some(allError(didNotEqual(nonEmptyThing, emptyThing) + ", and " + wasNotEmpty(nonEmptyThing), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -219,7 +219,7 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left4 = List(nonEmptyThing)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (be (empty) or equal (emptyThing))) (emptiness, defaultEquality)
+          (all(left4) should (be (empty) or equal (emptyThing))) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasNotEmpty(nonEmptyThing) + ", and " + didNotEqual(nonEmptyThing, emptyThing), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -229,27 +229,27 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends AnyFunSpec {
     
     describe("when work with 'all(xs) should not be sorted'") {
       it("should do nothing when xs is not sorted") {
-        (all(List(nonEmptyThing)) should (not be empty or not be emptyThing)) (emptiness)
-        (all(List(emptyThing)) should (not be empty or not be nonEmptyThing)) (emptiness)
-        (all(List(nonEmptyThing)) should (not be empty or not be nonEmptyThing)) (emptiness)
+        (all(List(nonEmptyThing)) should (not be empty or not be emptyThing)) (/* DOTTY-ONLY using */ emptiness)
+        (all(List(emptyThing)) should (not be empty or not be nonEmptyThing)) (/* DOTTY-ONLY using */ emptiness)
+        (all(List(nonEmptyThing)) should (not be empty or not be nonEmptyThing)) (/* DOTTY-ONLY using */ emptiness)
         
-        (all(List(nonEmptyThing)) should (not be emptyThing or not be empty)) (emptiness)
-        (all(List(nonEmptyThing)) should (not be nonEmptyThing or not be empty)) (emptiness)
-        (all(List(emptyThing)) should (not be nonEmptyThing or not be empty)) (emptiness)
+        (all(List(nonEmptyThing)) should (not be emptyThing or not be empty)) (/* DOTTY-ONLY using */ emptiness)
+        (all(List(nonEmptyThing)) should (not be nonEmptyThing or not be empty)) (/* DOTTY-ONLY using */ emptiness)
+        (all(List(emptyThing)) should (not be nonEmptyThing or not be empty)) (/* DOTTY-ONLY using */ emptiness)
         
-        (all(List(nonEmptyThing)) should (not be empty or not equal emptyThing)) (emptiness, defaultEquality)
-        (all(List(emptyThing)) should (not be empty or not equal nonEmptyThing)) (emptiness, defaultEquality)
-        (all(List(nonEmptyThing)) should (not be empty or not equal nonEmptyThing)) (emptiness, defaultEquality)
+        (all(List(nonEmptyThing)) should (not be empty or not equal emptyThing)) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
+        (all(List(emptyThing)) should (not be empty or not equal nonEmptyThing)) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
+        (all(List(nonEmptyThing)) should (not be empty or not equal nonEmptyThing)) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
         
-        (all(List(nonEmptyThing)) should (not equal emptyThing or not be empty)) (defaultEquality, emptiness)
-        (all(List(nonEmptyThing)) should (not equal nonEmptyThing or not be empty)) (defaultEquality, emptiness)
-        (all(List(emptyThing)) should (not equal nonEmptyThing or not be empty)) (defaultEquality, emptiness)
+        (all(List(nonEmptyThing)) should (not equal emptyThing or not be empty)) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
+        (all(List(nonEmptyThing)) should (not equal nonEmptyThing or not be empty)) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
+        (all(List(emptyThing)) should (not equal nonEmptyThing or not be empty)) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
       }
       
       it("should throw TestFailedException with correct stack depth when xs is not sorted") {
         val left1 = List(emptyThing)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be emptyThing or not be empty)) (emptiness)
+          (all(left1) should (not be emptyThing or not be empty)) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught1.message === Some(allError(wasEqualTo(emptyThing, emptyThing) + ", and " + wasEmpty(emptyThing), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -257,7 +257,7 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left2 = List(emptyThing)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be empty or not be emptyThing)) (emptiness)
+          (all(left2) should (not be empty or not be emptyThing)) (/* DOTTY-ONLY using */ emptiness)
         }
         assert(caught2.message === Some(allError(wasEmpty(emptyThing) + ", and " + wasEqualTo(emptyThing, emptyThing), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -265,7 +265,7 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left3 = List(emptyThing)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (not equal emptyThing or not be empty)) (defaultEquality, emptiness)
+          (all(left3) should (not equal emptyThing or not be empty)) (/* DOTTY-ONLY using */ defaultEquality, emptiness)
         }
         assert(caught3.message === Some(allError(equaled(emptyThing, emptyThing) + ", and " + wasEmpty(emptyThing), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -273,7 +273,7 @@ class ShouldBeEmptyLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left4 = List(emptyThing)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (not be empty or not equal emptyThing)) (emptiness, defaultEquality)
+          (all(left4) should (not be empty or not equal emptyThing)) (/* DOTTY-ONLY using */ emptiness, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasEmpty(emptyThing) + ", and " + equaled(emptyThing, emptyThing), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableExplicitSpec.scala
@@ -66,12 +66,12 @@ class ShouldBeReadableExplicitSpec extends AnyFunSpec {
     describe("when work with 'file should be (readable)'") {
       
       it("should do nothing when file is readable") {
-        (book should be (readable)) (readability)
+        (book should be (readable)) (/* DOTTY-ONLY using */ readability)
       }
       
       it("should throw TestFailedException with correct stack depth when file is not readable") {
         val caught1 = intercept[TestFailedException] {
-          (stone should be (readable)) (readability)
+          (stone should be (readable)) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught1.message === Some(wasNotReadable(stone)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -83,12 +83,12 @@ class ShouldBeReadableExplicitSpec extends AnyFunSpec {
     describe("when work with 'file should not be readable'") {
       
       it("should do nothing when file is not readable") {
-        (stone should not be readable) (readability)
+        (stone should not be readable) (/* DOTTY-ONLY using */ readability)
       }
       
       it("should throw TestFailedException with correct stack depth when file is readable") {
         val caught1 = intercept[TestFailedException] {
-          (book should not be readable) (readability)
+          (book should not be readable) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught1.message === Some(wasReadable(book)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -99,12 +99,12 @@ class ShouldBeReadableExplicitSpec extends AnyFunSpec {
     describe("when work with 'file shouldBe readable'") {
       
       it("should do nothing when file is readable") {
-        (book shouldBe readable) (readability)
+        (book shouldBe readable) (/* DOTTY-ONLY using */ readability)
       }
       
       it("should throw TestFailedException with correct stack depth when file is not readable") {
         val caught1 = intercept[TestFailedException] {
-          (stone shouldBe readable) (readability)
+          (stone shouldBe readable) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught1.message === Some(wasNotReadable(stone)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -116,12 +116,12 @@ class ShouldBeReadableExplicitSpec extends AnyFunSpec {
     describe("when work with 'file shouldNot be (readable)'") {
       
       it("should do nothing when file is not readable") {
-        (stone shouldNot be (readable)) (readability)
+        (stone shouldNot be (readable)) (/* DOTTY-ONLY using */ readability)
       }
       
       it("should throw TestFailedException with correct stack depth when file is readable") {
         val caught1 = intercept[TestFailedException] {
-          (book shouldNot be (readable)) (readability)
+          (book shouldNot be (readable)) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught1.message === Some(wasReadable(book)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -133,13 +133,13 @@ class ShouldBeReadableExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) should be (readable)'") {
       
       it("should do nothing when all(xs) is readable") {
-        (all(List(book)) should be (readable)) (readability)
+        (all(List(book)) should be (readable)) (/* DOTTY-ONLY using */ readability)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is not readable") {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should be (readable)) (readability)
+          (all(left1) should be (readable)) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught1.message === Some(allError(left1, wasNotReadable(stone), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -151,13 +151,13 @@ class ShouldBeReadableExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) should not be readable'") {
       
       it("should do nothing when all(xs) is not readable") {
-        (all(List(stone)) should not be readable) (readability)
+        (all(List(stone)) should not be readable) (/* DOTTY-ONLY using */ readability)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is readable") {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should not be readable) (readability)
+          (all(left1) should not be readable) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught1.message === Some(allError(left1, wasReadable(book), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -169,13 +169,13 @@ class ShouldBeReadableExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) shouldBe readable'") {
       
       it("should do nothing when all(xs) is readable") {
-        (all(List(book)) shouldBe readable) (readability)
+        (all(List(book)) shouldBe readable) (/* DOTTY-ONLY using */ readability)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is not readable") {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) shouldBe readable) (readability)
+          (all(left1) shouldBe readable) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught1.message === Some(allError(left1, wasNotReadable(stone), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -186,13 +186,13 @@ class ShouldBeReadableExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) shouldNot be (readable)'") {
       
       it("should do nothing when all(xs) is not readable") {
-        (all(List(stone)) shouldNot be (readable)) (readability)
+        (all(List(stone)) shouldNot be (readable)) (/* DOTTY-ONLY using */ readability)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is readable") {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) shouldNot be (readable)) (readability)
+          (all(left1) shouldNot be (readable)) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught1.message === Some(allError(left1, wasReadable(book), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalAndExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalAndExplicitSpec.scala
@@ -73,37 +73,37 @@ class ShouldBeReadableLogicalAndExplicitSpec extends AnyFunSpec {
     describe("when work with 'file should be (readable)'") {
 
       it("should do nothing when file is readable") {
-        (book should (equal (book) and be (readable))) (defaultEquality, readability)
-        (book should (be (readable) and equal (book))) (readability, defaultEquality)
+        (book should (equal (book) and be (readable))) (/* DOTTY-ONLY using */ defaultEquality, readability)
+        (book should (be (readable) and equal (book))) (/* DOTTY-ONLY using */ readability, defaultEquality)
 
-        (book should (be (book) and be (readable))) (readability)
-        (book should (be (readable) and be (book))) (readability)
+        (book should (be (book) and be (readable))) (/* DOTTY-ONLY using */ readability)
+        (book should (be (readable) and be (book))) (/* DOTTY-ONLY using */ readability)
       }
 
       it("should throw TestFailedException with correct stack depth when file is not readable") {
         val caught1 = intercept[TestFailedException] {
-          (stone should (equal (stone) and be (readable))) (defaultEquality, readability)
+          (stone should (equal (stone) and be (readable))) (/* DOTTY-ONLY using */ defaultEquality, readability)
         }
         assert(caught1.message === Some(equaled(stone, stone) + ", but " + wasNotReadable(stone)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
 
         val caught2 = intercept[TestFailedException] {
-          (stone should (be (readable) and equal (stone))) (readability, defaultEquality)
+          (stone should (be (readable) and equal (stone))) (/* DOTTY-ONLY using */ readability, defaultEquality)
         }
         assert(caught2.message === Some(wasNotReadable(stone)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
 
         val caught3 = intercept[TestFailedException] {
-          (stone should (be (stone) and be (readable))) (readability)
+          (stone should (be (stone) and be (readable))) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught3.message === Some(wasEqualTo(stone, stone) + ", but " + wasNotReadable(stone)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
 
         val caught4 = intercept[TestFailedException] {
-          (stone should (be (readable) and be (stone))) (readability)
+          (stone should (be (readable) and be (stone))) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught4.message === Some(wasNotReadable(stone)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -114,37 +114,37 @@ class ShouldBeReadableLogicalAndExplicitSpec extends AnyFunSpec {
     describe("when work with 'file should not be sorted'") {
 
       it("should do nothing when file is not readable") {
-        (stone should (not equal book and not be readable)) (defaultEquality, readability)
-        (stone should (not be readable and not equal book)) (readability, defaultEquality)
+        (stone should (not equal book and not be readable)) (/* DOTTY-ONLY using */ defaultEquality, readability)
+        (stone should (not be readable and not equal book)) (/* DOTTY-ONLY using */ readability, defaultEquality)
 
-        (stone should (not be book and not be readable)) (readability)
-        (stone should (not be readable and not be book)) (readability)
+        (stone should (not be book and not be readable)) (/* DOTTY-ONLY using */ readability)
+        (stone should (not be readable and not be book)) (/* DOTTY-ONLY using */ readability)
       }
 
       it("should throw TestFailedException with correct stack depth when xs is not sorted") {
         val caught1 = intercept[TestFailedException] {
-          (book should (not equal stone and not be readable)) (defaultEquality, readability)
+          (book should (not equal stone and not be readable)) (/* DOTTY-ONLY using */ defaultEquality, readability)
         }
         assert(caught1.message === Some(didNotEqual(book, stone) + ", but " + wasReadable(book)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
 
         val caught2 = intercept[TestFailedException] {
-          (book should (not be readable and not equal stone)) (readability, defaultEquality)
+          (book should (not be readable and not equal stone)) (/* DOTTY-ONLY using */ readability, defaultEquality)
         }
         assert(caught2.message === Some(wasReadable(book)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
 
         val caught3 = intercept[TestFailedException] {
-          (book should (not be stone and not be readable)) (readability)
+          (book should (not be stone and not be readable)) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught3.message === Some(wasNotEqualTo(book, stone) + ", but " + wasReadable(book)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
 
         val caught4 = intercept[TestFailedException] {
-          (book should (not be readable and not be stone)) (readability)
+          (book should (not be readable and not be stone)) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught4.message === Some(wasReadable(book)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -155,17 +155,17 @@ class ShouldBeReadableLogicalAndExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) should be (readable)'") {
 
       it("should do nothing when all(xs) is readable") {
-        (all(List(book)) should (be (book) and be (readable))) (readability)
-        (all(List(book)) should (be (readable) and be (book))) (readability)
+        (all(List(book)) should (be (book) and be (readable))) (/* DOTTY-ONLY using */ readability)
+        (all(List(book)) should (be (readable) and be (book))) (/* DOTTY-ONLY using */ readability)
 
-        (all(List(book)) should (equal (book) and be (readable))) (defaultEquality, readability)
-        (all(List(book)) should (be (readable) and equal (book))) (readability, defaultEquality)
+        (all(List(book)) should (equal (book) and be (readable))) (/* DOTTY-ONLY using */ defaultEquality, readability)
+        (all(List(book)) should (be (readable) and equal (book))) (/* DOTTY-ONLY using */ readability, defaultEquality)
       }
 
       it("should throw TestFailedException with correct stack depth when all(xs) is not readable") {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (stone) and be (readable))) (readability)
+          (all(left1) should (be (stone) and be (readable))) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught1.message === Some(allError(wasEqualTo(stone, stone) + ", but " + wasNotReadable(stone), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -173,7 +173,7 @@ class ShouldBeReadableLogicalAndExplicitSpec extends AnyFunSpec {
 
         val left2 = List(stone)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (readable) and be (stone))) (readability)
+          (all(left2) should (be (readable) and be (stone))) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught2.message === Some(allError(wasNotReadable(stone), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -181,7 +181,7 @@ class ShouldBeReadableLogicalAndExplicitSpec extends AnyFunSpec {
 
         val left3 = List(stone)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (equal (stone) and be (readable))) (defaultEquality, readability)
+          (all(left3) should (equal (stone) and be (readable))) (/* DOTTY-ONLY using */ defaultEquality, readability)
         }
         assert(caught3.message === Some(allError(equaled(stone, stone) + ", but " + wasNotReadable(stone), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -189,7 +189,7 @@ class ShouldBeReadableLogicalAndExplicitSpec extends AnyFunSpec {
 
         val left4 = List(stone)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (be (readable) and equal (stone))) (readability, defaultEquality)
+          (all(left4) should (be (readable) and equal (stone))) (/* DOTTY-ONLY using */ readability, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasNotReadable(stone), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -199,17 +199,17 @@ class ShouldBeReadableLogicalAndExplicitSpec extends AnyFunSpec {
 
     describe("when work with 'all(xs) should not be readable'") {
       it("should do nothing when all(xs) is not readable") {
-        (all(List(stone)) should (not be readable and not be book)) (readability)
-        (all(List(stone)) should (not be book and not be readable)) (readability)
+        (all(List(stone)) should (not be readable and not be book)) (/* DOTTY-ONLY using */ readability)
+        (all(List(stone)) should (not be book and not be readable)) (/* DOTTY-ONLY using */ readability)
 
-        (all(List(stone)) should (not be readable and not equal book)) (readability, defaultEquality)
-        (all(List(stone)) should (not equal book and not be readable)) (defaultEquality, readability)
+        (all(List(stone)) should (not be readable and not equal book)) (/* DOTTY-ONLY using */ readability, defaultEquality)
+        (all(List(stone)) should (not equal book and not be readable)) (/* DOTTY-ONLY using */ defaultEquality, readability)
       }
 
       it("should throw TestFailedException with correct stack depth when all(xs) is readable") {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be stone and not be readable)) (readability)
+          (all(left1) should (not be stone and not be readable)) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(book, stone) + ", but " + wasReadable(book), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -217,7 +217,7 @@ class ShouldBeReadableLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left2 = List(book)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be readable and not be stone)) (readability)
+          (all(left2) should (not be readable and not be stone)) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught2.message === Some(allError(wasReadable(book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -225,7 +225,7 @@ class ShouldBeReadableLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left3 = List(book)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (not equal stone and not be readable)) (defaultEquality, readability)
+          (all(left3) should (not equal stone and not be readable)) (/* DOTTY-ONLY using */ defaultEquality, readability)
         }
         assert(caught3.message === Some(allError(didNotEqual(book, stone) + ", but " + wasReadable(book), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -233,7 +233,7 @@ class ShouldBeReadableLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left4 = List(book)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (not be readable and not equal stone)) (readability, defaultEquality)
+          (all(left4) should (not be readable and not equal stone)) (/* DOTTY-ONLY using */ readability, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasReadable(book), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalOrExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeReadableLogicalOrExplicitSpec.scala
@@ -74,47 +74,47 @@ class ShouldBeReadableLogicalOrExplicitSpec extends AnyFunSpec {
       
       it("should do nothing when file is readable") {
         
-        (book should (be (readable) or be (book))) (readability)
-        (stone should (be (readable) or be (stone))) (readability)
-        (book should (be (readable) or be (stone))) (readability)
+        (book should (be (readable) or be (book))) (/* DOTTY-ONLY using */ readability)
+        (stone should (be (readable) or be (stone))) (/* DOTTY-ONLY using */ readability)
+        (book should (be (readable) or be (stone))) (/* DOTTY-ONLY using */ readability)
         
-        (book should (be (book) or be (readable))) (readability)
-        (book should (be (stone) or be (readable))) (readability)
-        (stone should (be (stone) or be (readable))) (readability)
+        (book should (be (book) or be (readable))) (/* DOTTY-ONLY using */ readability)
+        (book should (be (stone) or be (readable))) (/* DOTTY-ONLY using */ readability)
+        (stone should (be (stone) or be (readable))) (/* DOTTY-ONLY using */ readability)
         
-        (book should (be (readable) or equal (book))) (readability, defaultEquality)
-        (stone should (be (readable) or equal (stone))) (readability, defaultEquality)
-        (book should (be (readable) or equal (stone))) (readability, defaultEquality)
+        (book should (be (readable) or equal (book))) (/* DOTTY-ONLY using */ readability, defaultEquality)
+        (stone should (be (readable) or equal (stone))) (/* DOTTY-ONLY using */ readability, defaultEquality)
+        (book should (be (readable) or equal (stone))) (/* DOTTY-ONLY using */ readability, defaultEquality)
         
-        (book should (equal (book) or be (readable))) (defaultEquality, readability)
-        (book should (equal (stone) or be (readable))) (defaultEquality, readability)
-        (stone should (equal (stone) or be (readable))) (defaultEquality, readability)
+        (book should (equal (book) or be (readable))) (/* DOTTY-ONLY using */ defaultEquality, readability)
+        (book should (equal (stone) or be (readable))) (/* DOTTY-ONLY using */ defaultEquality, readability)
+        (stone should (equal (stone) or be (readable))) (/* DOTTY-ONLY using */ defaultEquality, readability)
       }
       
       it("should throw TestFailedException with correct stack depth when file is not readable") {
         val caught1 = intercept[TestFailedException] {
-          (stone should (be (readable) or be (book))) (readability)
+          (stone should (be (readable) or be (book))) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught1.message === Some(wasNotReadable(stone) + ", and " + wasNotEqualTo(stone, book)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (stone should (be (book) or be (readable))) (readability)
+          (stone should (be (book) or be (readable))) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught2.message === Some(wasNotEqualTo(stone, book) + ", and " + wasNotReadable(stone)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (stone should (be (readable) or equal (book))) (readability, defaultEquality)
+          (stone should (be (readable) or equal (book))) (/* DOTTY-ONLY using */ readability, defaultEquality)
         }
         assert(caught3.message === Some(wasNotReadable(stone) + ", and " + didNotEqual(stone, book)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (stone should (equal (book) or be (readable))) (defaultEquality, readability)
+          (stone should (equal (book) or be (readable))) (/* DOTTY-ONLY using */ defaultEquality, readability)
         }
         assert(caught4.message === Some(didNotEqual(stone, book) + ", and " + wasNotReadable(stone)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -125,47 +125,47 @@ class ShouldBeReadableLogicalOrExplicitSpec extends AnyFunSpec {
     describe("when work with 'file should not be readable'") {
       
       it("should do nothing when file is not readable") {
-        (stone should (not be readable or not be book)) (readability)
-        (book should (not be readable or not be stone)) (readability)
-        (stone should (not be readable or not be stone)) (readability)
+        (stone should (not be readable or not be book)) (/* DOTTY-ONLY using */ readability)
+        (book should (not be readable or not be stone)) (/* DOTTY-ONLY using */ readability)
+        (stone should (not be readable or not be stone)) (/* DOTTY-ONLY using */ readability)
         
-        (stone should (not be book or not be readable)) (readability)
-        (stone should (not be stone or not be readable)) (readability)
-        (book should (not be stone or not be readable)) (readability)
+        (stone should (not be book or not be readable)) (/* DOTTY-ONLY using */ readability)
+        (stone should (not be stone or not be readable)) (/* DOTTY-ONLY using */ readability)
+        (book should (not be stone or not be readable)) (/* DOTTY-ONLY using */ readability)
         
-        (stone should (not be readable or not equal book)) (readability, defaultEquality)
-        (book should (not be readable or not equal stone)) (readability, defaultEquality)
-        (stone should (not be readable or not equal stone)) (readability, defaultEquality)
+        (stone should (not be readable or not equal book)) (/* DOTTY-ONLY using */ readability, defaultEquality)
+        (book should (not be readable or not equal stone)) (/* DOTTY-ONLY using */ readability, defaultEquality)
+        (stone should (not be readable or not equal stone)) (/* DOTTY-ONLY using */ readability, defaultEquality)
         
-        (stone should (not equal book or not be readable)) (defaultEquality, readability)
-        (stone should (not equal stone or not be readable)) (defaultEquality, readability)
-        (book should (not equal stone or not be readable)) (defaultEquality, readability)
+        (stone should (not equal book or not be readable)) (/* DOTTY-ONLY using */ defaultEquality, readability)
+        (stone should (not equal stone or not be readable)) (/* DOTTY-ONLY using */ defaultEquality, readability)
+        (book should (not equal stone or not be readable)) (/* DOTTY-ONLY using */ defaultEquality, readability)
       }
       
       it("should throw TestFailedException with correct stack depth when file is readable") {
         val caught1 = intercept[TestFailedException] {
-          (book should (not be readable or not be book)) (readability)
+          (book should (not be readable or not be book)) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught1.message === Some(wasReadable(book) + ", and " + wasEqualTo(book, book)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (book should (not be book or not be readable)) (readability)
+          (book should (not be book or not be readable)) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught2.message === Some(wasEqualTo(book, book) + ", and " + wasReadable(book)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (book should (not be readable or not equal book)) (readability, defaultEquality)
+          (book should (not be readable or not equal book)) (/* DOTTY-ONLY using */ readability, defaultEquality)
         }
         assert(caught3.message === Some(wasReadable(book) + ", and " + equaled(book, book)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (book should (not equal book or not be readable)) (defaultEquality, readability)
+          (book should (not equal book or not be readable)) (/* DOTTY-ONLY using */ defaultEquality, readability)
         }
         assert(caught4.message === Some(equaled(book, book) + ", and " + wasReadable(book)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -176,27 +176,27 @@ class ShouldBeReadableLogicalOrExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) should be (readable)'") {
       
       it("should do nothing when all(xs) is readable") {
-        (all(List(book)) should (be (readable) or be (book))) (readability)
-        (all(List(stone)) should (be (readable) or be (stone))) (readability)
-        (all(List(book)) should (be (readable) or be (stone))) (readability)
+        (all(List(book)) should (be (readable) or be (book))) (/* DOTTY-ONLY using */ readability)
+        (all(List(stone)) should (be (readable) or be (stone))) (/* DOTTY-ONLY using */ readability)
+        (all(List(book)) should (be (readable) or be (stone))) (/* DOTTY-ONLY using */ readability)
         
-        (all(List(book)) should (be (book) or be (readable))) (readability)
-        (all(List(book)) should (be (stone) or be (readable))) (readability)
-        (all(List(stone)) should (be (stone) or be (readable))) (readability)
+        (all(List(book)) should (be (book) or be (readable))) (/* DOTTY-ONLY using */ readability)
+        (all(List(book)) should (be (stone) or be (readable))) (/* DOTTY-ONLY using */ readability)
+        (all(List(stone)) should (be (stone) or be (readable))) (/* DOTTY-ONLY using */ readability)
         
-        (all(List(book)) should (be (readable) or equal (book))) (readability, defaultEquality)
-        (all(List(stone)) should (be (readable) or equal (stone))) (readability, defaultEquality)
-        (all(List(book)) should (be (readable) or equal (stone))) (readability, defaultEquality)
+        (all(List(book)) should (be (readable) or equal (book))) (/* DOTTY-ONLY using */ readability, defaultEquality)
+        (all(List(stone)) should (be (readable) or equal (stone))) (/* DOTTY-ONLY using */ readability, defaultEquality)
+        (all(List(book)) should (be (readable) or equal (stone))) (/* DOTTY-ONLY using */ readability, defaultEquality)
         
-        (all(List(book)) should (equal (book) or be (readable))) (defaultEquality, readability)
-        (all(List(book)) should (equal (stone) or be (readable))) (defaultEquality, readability)
-        (all(List(stone)) should (equal (stone) or be (readable))) (defaultEquality, readability)
+        (all(List(book)) should (equal (book) or be (readable))) (/* DOTTY-ONLY using */ defaultEquality, readability)
+        (all(List(book)) should (equal (stone) or be (readable))) (/* DOTTY-ONLY using */ defaultEquality, readability)
+        (all(List(stone)) should (equal (stone) or be (readable))) (/* DOTTY-ONLY using */ defaultEquality, readability)
       }
       
       it("should throw TestFailedException with correct stack depth when xs is not sorted") {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (book) or be (readable))) (readability)
+          (all(left1) should (be (book) or be (readable))) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(stone, book) + ", and " + wasNotReadable(stone), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -204,7 +204,7 @@ class ShouldBeReadableLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left2 = List(stone)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (readable) or be (book))) (readability)
+          (all(left2) should (be (readable) or be (book))) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught2.message === Some(allError(wasNotReadable(stone) + ", and " + wasNotEqualTo(stone, book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -212,7 +212,7 @@ class ShouldBeReadableLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left3 = List(stone)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (equal (book) or be (readable))) (defaultEquality, readability)
+          (all(left3) should (equal (book) or be (readable))) (/* DOTTY-ONLY using */ defaultEquality, readability)
         }
         assert(caught3.message === Some(allError(didNotEqual(stone, book) + ", and " + wasNotReadable(stone), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -220,7 +220,7 @@ class ShouldBeReadableLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left4 = List(stone)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (be (readable) or equal (book))) (readability, defaultEquality)
+          (all(left4) should (be (readable) or equal (book))) (/* DOTTY-ONLY using */ readability, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasNotReadable(stone) + ", and " + didNotEqual(stone, book), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -230,27 +230,27 @@ class ShouldBeReadableLogicalOrExplicitSpec extends AnyFunSpec {
     
     describe("when work with 'all(xs) should not be sorted'") {
       it("should do nothing when xs is not sorted") {
-        (all(List(stone)) should (not be readable or not be book)) (readability)
-        (all(List(book)) should (not be readable or not be stone)) (readability)
-        (all(List(stone)) should (not be readable or not be stone)) (readability)
+        (all(List(stone)) should (not be readable or not be book)) (/* DOTTY-ONLY using */ readability)
+        (all(List(book)) should (not be readable or not be stone)) (/* DOTTY-ONLY using */ readability)
+        (all(List(stone)) should (not be readable or not be stone)) (/* DOTTY-ONLY using */ readability)
         
-        (all(List(stone)) should (not be book or not be readable)) (readability)
-        (all(List(stone)) should (not be stone or not be readable)) (readability)
-        (all(List(book)) should (not be stone or not be readable)) (readability)
+        (all(List(stone)) should (not be book or not be readable)) (/* DOTTY-ONLY using */ readability)
+        (all(List(stone)) should (not be stone or not be readable)) (/* DOTTY-ONLY using */ readability)
+        (all(List(book)) should (not be stone or not be readable)) (/* DOTTY-ONLY using */ readability)
         
-        (all(List(stone)) should (not be readable or not equal book)) (readability, defaultEquality)
-        (all(List(book)) should (not be readable or not equal stone)) (readability, defaultEquality)
-        (all(List(stone)) should (not be readable or not equal stone)) (readability, defaultEquality)
+        (all(List(stone)) should (not be readable or not equal book)) (/* DOTTY-ONLY using */ readability, defaultEquality)
+        (all(List(book)) should (not be readable or not equal stone)) (/* DOTTY-ONLY using */ readability, defaultEquality)
+        (all(List(stone)) should (not be readable or not equal stone)) (/* DOTTY-ONLY using */ readability, defaultEquality)
         
-        (all(List(stone)) should (not equal book or not be readable)) (defaultEquality, readability)
-        (all(List(stone)) should (not equal stone or not be readable)) (defaultEquality, readability)
-        (all(List(book)) should (not equal stone or not be readable)) (defaultEquality, readability)
+        (all(List(stone)) should (not equal book or not be readable)) (/* DOTTY-ONLY using */ defaultEquality, readability)
+        (all(List(stone)) should (not equal stone or not be readable)) (/* DOTTY-ONLY using */ defaultEquality, readability)
+        (all(List(book)) should (not equal stone or not be readable)) (/* DOTTY-ONLY using */ defaultEquality, readability)
       }
       
       it("should throw TestFailedException with correct stack depth when xs is not sorted") {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be book or not be readable)) (readability)
+          (all(left1) should (not be book or not be readable)) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught1.message === Some(allError(wasEqualTo(book, book) + ", and " + wasReadable(book), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -258,7 +258,7 @@ class ShouldBeReadableLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left2 = List(book)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be readable or not be book)) (readability)
+          (all(left2) should (not be readable or not be book)) (/* DOTTY-ONLY using */ readability)
         }
         assert(caught2.message === Some(allError(wasReadable(book) + ", and " + wasEqualTo(book, book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -266,7 +266,7 @@ class ShouldBeReadableLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left3 = List(book)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (not equal book or not be readable)) (defaultEquality, readability)
+          (all(left3) should (not equal book or not be readable)) (/* DOTTY-ONLY using */ defaultEquality, readability)
         }
         assert(caught3.message === Some(allError(equaled(book, book) + ", and " + wasReadable(book), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -274,7 +274,7 @@ class ShouldBeReadableLogicalOrExplicitSpec extends AnyFunSpec {
         
         val left4 = List(book)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (not be readable or not equal book)) (readability, defaultEquality)
+          (all(left4) should (not be readable or not equal book)) (/* DOTTY-ONLY using */ readability, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasReadable(book) + ", and " + equaled(book, book), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeSortedLogicalAndSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeSortedLogicalAndSpec.scala
@@ -153,7 +153,7 @@ class ShouldBeSortedLogicalAndSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           outOfOrderInts should (be (sorted) and equal (outOfOrderInts))
         }
-        (outOfOrderInts should (be (sorted) and equal (outOfOrderInts))) (trueSortable, defaultEquality)
+        (outOfOrderInts should (be (sorted) and equal (outOfOrderInts))) (/* DOTTY-ONLY using */ trueSortable, defaultEquality)
       }
     }
     
@@ -229,7 +229,7 @@ class ShouldBeSortedLogicalAndSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           orderedInts should (not be (sorted) and not equal (outOfOrderInts))
         }
-        (orderedInts should (not be (sorted) and not equal (outOfOrderInts))) (falseSortable, defaultEquality)
+        (orderedInts should (not be (sorted) and not equal (outOfOrderInts))) (/* DOTTY-ONLY using */ falseSortable, defaultEquality)
       }
     }
     
@@ -314,7 +314,7 @@ class ShouldBeSortedLogicalAndSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           all(List(outOfOrderInts)) should (be (sorted) and equal (outOfOrderInts))
         }
-        (all(List(outOfOrderInts)) should (be (sorted) and equal (outOfOrderInts))) (trueSortable, defaultEquality)
+        (all(List(outOfOrderInts)) should (be (sorted) and equal (outOfOrderInts))) (/* DOTTY-ONLY using */ trueSortable, defaultEquality)
       }
     }
     
@@ -395,7 +395,7 @@ class ShouldBeSortedLogicalAndSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           all(List(orderedInts)) should (not be (sorted) and not equal (outOfOrderInts))
         }
-        (all(List(orderedInts)) should (not be (sorted) and not equal (outOfOrderInts))) (falseSortable, defaultEquality)
+        (all(List(orderedInts)) should (not be (sorted) and not equal (outOfOrderInts))) (/* DOTTY-ONLY using */ falseSortable, defaultEquality)
       }
     }
     

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeSortedLogicalOrSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeSortedLogicalOrSpec.scala
@@ -153,7 +153,7 @@ class ShouldBeSortedLogicalOrSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           outOfOrderInts should (be (sorted) or equal (orderedInts))
         }
-        (outOfOrderInts should (be (sorted) or equal (orderedInts))) (trueSortable, defaultEquality)
+        (outOfOrderInts should (be (sorted) or equal (orderedInts))) (/* DOTTY-ONLY using */ trueSortable, defaultEquality)
       }
     }
     
@@ -226,7 +226,7 @@ class ShouldBeSortedLogicalOrSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           orderedInts should (not be (sorted) or not equal (orderedInts))
         }
-        (orderedInts should (not be (sorted) or not equal (orderedInts))) (falseSortable, defaultEquality)
+        (orderedInts should (not be (sorted) or not equal (orderedInts))) (/* DOTTY-ONLY using */ falseSortable, defaultEquality)
       }
     }
     
@@ -311,7 +311,7 @@ class ShouldBeSortedLogicalOrSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           all(List(outOfOrderInts)) should (be (sorted) or equal (orderedInts))
         }
-        (all(List(outOfOrderInts)) should (be (sorted) or equal (orderedInts))) (trueSortable, defaultEquality)
+        (all(List(outOfOrderInts)) should (be (sorted) or equal (orderedInts))) (/* DOTTY-ONLY using */ trueSortable, defaultEquality)
       }
     }
     
@@ -392,7 +392,7 @@ class ShouldBeSortedLogicalOrSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           all(List(orderedInts)) should (not be (sorted) or not equal (orderedInts))
         }
-        (all(List(orderedInts)) should (not be (sorted) or not equal (orderedInts))) (falseSortable, defaultEquality)
+        (all(List(orderedInts)) should (not be (sorted) or not equal (orderedInts))) (/* DOTTY-ONLY using */ falseSortable, defaultEquality)
       }
     }
     

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeSortedSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeSortedSpec.scala
@@ -128,7 +128,7 @@ class ShouldBeSortedSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           outOfOrderInts should be (sorted)
         }
-        outOfOrderInts should be (sorted) (trueSortable)
+        (outOfOrderInts should be (sorted)) (/* DOTTY-ONLY using */ trueSortable)
       }
       
     }
@@ -219,7 +219,7 @@ class ShouldBeSortedSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           orderedInts should not be sorted
         }
-        (orderedInts should not be (sorted)) (falseSortable)
+        (orderedInts should not be (sorted)) (/* DOTTY-ONLY using */ falseSortable)
       }
     }
     
@@ -280,7 +280,7 @@ class ShouldBeSortedSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           outOfOrderInts shouldBe sorted
         }
-        (outOfOrderInts shouldBe (sorted)) (trueSortable)
+        (outOfOrderInts shouldBe (sorted)) (/* DOTTY-ONLY using */ trueSortable)
       }
       
     }
@@ -371,7 +371,7 @@ class ShouldBeSortedSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           orderedInts shouldNot be (sorted)
         }
-        orderedInts shouldNot be (sorted) (falseSortable)
+        (orderedInts shouldNot be (sorted)) (/* DOTTY-ONLY using */ falseSortable)
       }
     }
     
@@ -435,7 +435,7 @@ class ShouldBeSortedSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           all(List(outOfOrderInts)) should be (sorted)
         }
-        all(List(outOfOrderInts)) should be (sorted) (trueSortable)
+        (all(List(outOfOrderInts)) should be (sorted)) (/* DOTTY-ONLY using */ trueSortable)
       }
     }
     
@@ -533,7 +533,7 @@ class ShouldBeSortedSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           all(List(orderedInts)) should not be sorted
         }
-        (all(List(orderedInts)) should not be (sorted)) (falseSortable)
+        (all(List(orderedInts)) should not be (sorted)) (/* DOTTY-ONLY using */ falseSortable)
       }
     }
     
@@ -597,7 +597,7 @@ class ShouldBeSortedSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           all(List(outOfOrderInts)) shouldBe sorted
         }
-        (all(List(outOfOrderInts)) shouldBe (sorted)) (trueSortable)
+        (all(List(outOfOrderInts)) shouldBe (sorted)) (/* DOTTY-ONLY using */ trueSortable)
       }
       
     }
@@ -696,7 +696,7 @@ class ShouldBeSortedSpec extends AnyFunSpec {
         intercept[TestFailedException] {
           all(List(orderedInts)) shouldNot be (sorted)
         }
-        all(List(orderedInts)) shouldNot be (sorted) (falseSortable)
+        (all(List(orderedInts)) shouldNot be (sorted)) (/* DOTTY-ONLY using */ falseSortable)
       }
     }
   }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableExplicitSpec.scala
@@ -66,12 +66,12 @@ class ShouldBeWritableExplicitSpec extends AnyFunSpec {
     describe("when work with 'file should be (writable)'") {
       
       it("should do nothing when file is writable") {
-        (book should be (writable)) (writability)
+        (book should be (writable)) (/* DOTTY-ONLY using */ writability)
       }
       
       it("should throw TestFailedException with correct stack depth when file is not writable") {
         val caught1 = intercept[TestFailedException] {
-          (stone should be (writable)) (writability)
+          (stone should be (writable)) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught1.message === Some(wasNotWritable(stone)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -83,12 +83,12 @@ class ShouldBeWritableExplicitSpec extends AnyFunSpec {
     describe("when work with 'file should not be writable'") {
       
       it("should do nothing when file is not writable") {
-        (stone should not be writable) (writability)
+        (stone should not be writable) (/* DOTTY-ONLY using */ writability)
       }
       
       it("should throw TestFailedException with correct stack depth when file is writable") {
         val caught1 = intercept[TestFailedException] {
-          (book should not be writable) (writability)
+          (book should not be writable) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught1.message === Some(wasWritable(book)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -99,12 +99,12 @@ class ShouldBeWritableExplicitSpec extends AnyFunSpec {
     describe("when work with 'file shouldBe writable'") {
       
       it("should do nothing when file is writable") {
-        (book shouldBe writable) (writability)
+        (book shouldBe writable) (/* DOTTY-ONLY using */ writability)
       }
       
       it("should throw TestFailedException with correct stack depth when file is not writable") {
         val caught1 = intercept[TestFailedException] {
-          (stone shouldBe writable) (writability)
+          (stone shouldBe writable) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught1.message === Some(wasNotWritable(stone)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -116,12 +116,12 @@ class ShouldBeWritableExplicitSpec extends AnyFunSpec {
     describe("when work with 'file shouldNot be (writable)'") {
       
       it("should do nothing when file is not writable") {
-        (stone shouldNot be (writable)) (writability)
+        (stone shouldNot be (writable)) (/* DOTTY-ONLY using */ writability)
       }
       
       it("should throw TestFailedException with correct stack depth when file is writable") {
         val caught1 = intercept[TestFailedException] {
-          (book shouldNot be (writable)) (writability)
+          (book shouldNot be (writable)) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught1.message === Some(wasWritable(book)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -133,13 +133,13 @@ class ShouldBeWritableExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) should be (writable)'") {
       
       it("should do nothing when all(xs) is writable") {
-        (all(List(book)) should be (writable)) (writability)
+        (all(List(book)) should be (writable)) (/* DOTTY-ONLY using */ writability)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is not writable") {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should be (writable)) (writability)
+          (all(left1) should be (writable)) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught1.message === Some(allError(left1, wasNotWritable(stone), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -151,13 +151,13 @@ class ShouldBeWritableExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) should not be writable'") {
       
       it("should do nothing when all(xs) is not writable") {
-        (all(List(stone)) should not be writable) (writability)
+        (all(List(stone)) should not be writable) (/* DOTTY-ONLY using */ writability)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is writable") {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should not be writable) (writability)
+          (all(left1) should not be writable) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught1.message === Some(allError(left1, wasWritable(book), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -169,13 +169,13 @@ class ShouldBeWritableExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) shouldBe writable'") {
       
       it("should do nothing when all(xs) is writable") {
-        (all(List(book)) shouldBe writable) (writability)
+        (all(List(book)) shouldBe writable) (/* DOTTY-ONLY using */ writability)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is not writable") {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) shouldBe writable) (writability)
+          (all(left1) shouldBe writable) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught1.message === Some(allError(left1, wasNotWritable(stone), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -186,13 +186,13 @@ class ShouldBeWritableExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) shouldNot be (writable)'") {
       
       it("should do nothing when all(xs) is not writable") {
-        (all(List(stone)) shouldNot be (writable)) (writability)
+        (all(List(stone)) shouldNot be (writable)) (/* DOTTY-ONLY using */ writability)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is writable") {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) shouldNot be (writable)) (writability)
+          (all(left1) shouldNot be (writable)) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught1.message === Some(allError(left1, wasWritable(book), thisLineNumber - 2)))
         assert(caught1.failedCodeFileName === Some(fileName))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalAndExplicitSpec.scala
@@ -73,37 +73,37 @@ class ShouldBeWritableLogicalAndExplicitSpec extends AnyFunSpec {
     describe("when work with 'file should be (writable)'") {
       
       it("should do nothing when file is writable") {
-        (book should (equal (book) and be (writable))) (defaultEquality, writability)
-        (book should (be (writable) and equal (book))) (writability, defaultEquality)
+        (book should (equal (book) and be (writable))) (/* DOTTY-ONLY using */ defaultEquality, writability)
+        (book should (be (writable) and equal (book))) (/* DOTTY-ONLY using */ writability, defaultEquality)
         
-        (book should (be (book) and be (writable))) (writability)
-        (book should (be (writable) and be (book))) (writability)
+        (book should (be (book) and be (writable))) (/* DOTTY-ONLY using */ writability)
+        (book should (be (writable) and be (book))) (/* DOTTY-ONLY using */ writability)
       }
       
       it("should throw TestFailedException with correct stack depth when file is not writable") {
         val caught1 = intercept[TestFailedException] {
-          (stone should (equal (stone) and be (writable))) (defaultEquality, writability)
+          (stone should (equal (stone) and be (writable))) (/* DOTTY-ONLY using */ defaultEquality, writability)
         }
         assert(caught1.message === Some(equaled(stone, stone) + ", but " + wasNotWritable(stone)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (stone should (be (writable) and equal (stone))) (writability, defaultEquality)
+          (stone should (be (writable) and equal (stone))) (/* DOTTY-ONLY using */ writability, defaultEquality)
         }
         assert(caught2.message === Some(wasNotWritable(stone)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (stone should (be (stone) and be (writable))) (writability)
+          (stone should (be (stone) and be (writable))) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught3.message === Some(wasEqualTo(stone, stone) + ", but " + wasNotWritable(stone)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (stone should (be (writable) and be (stone))) (writability)
+          (stone should (be (writable) and be (stone))) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught4.message === Some(wasNotWritable(stone)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -114,37 +114,37 @@ class ShouldBeWritableLogicalAndExplicitSpec extends AnyFunSpec {
     describe("when work with 'file should not be sorted'") {
       
       it("should do nothing when file is not writable") {
-        (stone should (not equal book and not be writable)) (defaultEquality, writability)
-        (stone should (not be writable and not equal book)) (writability, defaultEquality)
+        (stone should (not equal book and not be writable)) (/* DOTTY-ONLY using */ defaultEquality, writability)
+        (stone should (not be writable and not equal book)) (/* DOTTY-ONLY using */ writability, defaultEquality)
         
-        (stone should (not be book and not be writable)) (writability)
-        (stone should (not be writable and not be book)) (writability)
+        (stone should (not be book and not be writable)) (/* DOTTY-ONLY using */ writability)
+        (stone should (not be writable and not be book)) (/* DOTTY-ONLY using */ writability)
       }
       
       it("should throw TestFailedException with correct stack depth when xs is not sorted") {
         val caught1 = intercept[TestFailedException] {
-          (book should (not equal stone and not be writable)) (defaultEquality, writability)
+          (book should (not equal stone and not be writable)) (/* DOTTY-ONLY using */ defaultEquality, writability)
         }
         assert(caught1.message === Some(didNotEqual(book, stone) + ", but " + wasWritable(book)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (book should (not be writable and not equal stone)) (writability, defaultEquality)
+          (book should (not be writable and not equal stone)) (/* DOTTY-ONLY using */ writability, defaultEquality)
         }
         assert(caught2.message === Some(wasWritable(book)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (book should (not be stone and not be writable)) (writability)
+          (book should (not be stone and not be writable)) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught3.message === Some(wasNotEqualTo(book, stone) + ", but " + wasWritable(book)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (book should (not be writable and not be stone)) (writability)
+          (book should (not be writable and not be stone)) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught4.message === Some(wasWritable(book)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -155,17 +155,17 @@ class ShouldBeWritableLogicalAndExplicitSpec extends AnyFunSpec {
     describe("when work with 'all(xs) should be (writable)'") {
       
       it("should do nothing when all(xs) is writable") {
-        (all(List(book)) should (be (book) and be (writable))) (writability)
-        (all(List(book)) should (be (writable) and be (book))) (writability)
+        (all(List(book)) should (be (book) and be (writable))) (/* DOTTY-ONLY using */ writability)
+        (all(List(book)) should (be (writable) and be (book))) (/* DOTTY-ONLY using */ writability)
         
-        (all(List(book)) should (equal (book) and be (writable))) (defaultEquality, writability)
-        (all(List(book)) should (be (writable) and equal (book))) (writability, defaultEquality)
+        (all(List(book)) should (equal (book) and be (writable))) (/* DOTTY-ONLY using */ defaultEquality, writability)
+        (all(List(book)) should (be (writable) and equal (book))) (/* DOTTY-ONLY using */ writability, defaultEquality)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is not writable") {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (stone) and be (writable))) (writability)
+          (all(left1) should (be (stone) and be (writable))) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught1.message === Some(allError(wasEqualTo(stone, stone) + ", but " + wasNotWritable(stone), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -173,7 +173,7 @@ class ShouldBeWritableLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left2 = List(stone)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (writable) and be (stone))) (writability)
+          (all(left2) should (be (writable) and be (stone))) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught2.message === Some(allError(wasNotWritable(stone), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -181,7 +181,7 @@ class ShouldBeWritableLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left3 = List(stone)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (equal (stone) and be (writable))) (defaultEquality, writability)
+          (all(left3) should (equal (stone) and be (writable))) (/* DOTTY-ONLY using */ defaultEquality, writability)
         }
         assert(caught3.message === Some(allError(equaled(stone, stone) + ", but " + wasNotWritable(stone), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -189,7 +189,7 @@ class ShouldBeWritableLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left4 = List(stone)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (be (writable) and equal (stone))) (writability, defaultEquality)
+          (all(left4) should (be (writable) and equal (stone))) (/* DOTTY-ONLY using */ writability, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasNotWritable(stone), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -199,17 +199,17 @@ class ShouldBeWritableLogicalAndExplicitSpec extends AnyFunSpec {
     
     describe("when work with 'all(xs) should not be writable'") {
       it("should do nothing when all(xs) is not writable") {
-        (all(List(stone)) should (not be writable and not be book)) (writability)
-        (all(List(stone)) should (not be book and not be writable)) (writability)
+        (all(List(stone)) should (not be writable and not be book)) (/* DOTTY-ONLY using */ writability)
+        (all(List(stone)) should (not be book and not be writable)) (/* DOTTY-ONLY using */ writability)
         
-        (all(List(stone)) should (not be writable and not equal book)) (writability, defaultEquality)
-        (all(List(stone)) should (not equal book and not be writable)) (defaultEquality, writability)
+        (all(List(stone)) should (not be writable and not equal book)) (/* DOTTY-ONLY using */ writability, defaultEquality)
+        (all(List(stone)) should (not equal book and not be writable)) (/* DOTTY-ONLY using */ defaultEquality, writability)
       }
       
       it("should throw TestFailedException with correct stack depth when all(xs) is writable") {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be stone and not be writable)) (writability)
+          (all(left1) should (not be stone and not be writable)) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(book, stone) + ", but " + wasWritable(book), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -217,7 +217,7 @@ class ShouldBeWritableLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left2 = List(book)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be writable and not be stone)) (writability)
+          (all(left2) should (not be writable and not be stone)) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught2.message === Some(allError(wasWritable(book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -225,7 +225,7 @@ class ShouldBeWritableLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left3 = List(book)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (not equal stone and not be writable)) (defaultEquality, writability)
+          (all(left3) should (not equal stone and not be writable)) (/* DOTTY-ONLY using */ defaultEquality, writability)
         }
         assert(caught3.message === Some(allError(didNotEqual(book, stone) + ", but " + wasWritable(book), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -233,7 +233,7 @@ class ShouldBeWritableLogicalAndExplicitSpec extends AnyFunSpec {
         
         val left4 = List(book)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (not be writable and not equal stone)) (writability, defaultEquality)
+          (all(left4) should (not be writable and not equal stone)) (/* DOTTY-ONLY using */ writability, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasWritable(book), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldBeWritableLogicalOrExplicitSpec.scala
@@ -74,47 +74,47 @@ class ShouldBeWritableLogicalOrExplicitSpec extends AnyFunSpec with Matchers {
       
       it("should do nothing when file is writable") {
         
-        (book should (be (writable) or be (book))) (writability)
-        (stone should (be (writable) or be (stone))) (writability)
-        (book should (be (writable) or be (stone))) (writability)
+        (book should (be (writable) or be (book))) (/* DOTTY-ONLY using */ writability)
+        (stone should (be (writable) or be (stone))) (/* DOTTY-ONLY using */ writability)
+        (book should (be (writable) or be (stone))) (/* DOTTY-ONLY using */ writability)
         
-        (book should (be (book) or be (writable))) (writability)
-        (book should (be (stone) or be (writable))) (writability)
-        (stone should (be (stone) or be (writable))) (writability)
+        (book should (be (book) or be (writable))) (/* DOTTY-ONLY using */ writability)
+        (book should (be (stone) or be (writable))) (/* DOTTY-ONLY using */ writability)
+        (stone should (be (stone) or be (writable))) (/* DOTTY-ONLY using */ writability)
         
-        (book should (be (writable) or equal (book))) (writability, defaultEquality)
-        (stone should (be (writable) or equal (stone))) (writability, defaultEquality)
-        (book should (be (writable) or equal (stone))) (writability, defaultEquality)
+        (book should (be (writable) or equal (book))) (/* DOTTY-ONLY using */ writability, defaultEquality)
+        (stone should (be (writable) or equal (stone))) (/* DOTTY-ONLY using */ writability, defaultEquality)
+        (book should (be (writable) or equal (stone))) (/* DOTTY-ONLY using */ writability, defaultEquality)
         
-        (book should (equal (book) or be (writable))) (defaultEquality, writability)
-        (book should (equal (stone) or be (writable))) (defaultEquality, writability)
-        (stone should (equal (stone) or be (writable))) (defaultEquality, writability)
+        (book should (equal (book) or be (writable))) (/* DOTTY-ONLY using */ defaultEquality, writability)
+        (book should (equal (stone) or be (writable))) (/* DOTTY-ONLY using */ defaultEquality, writability)
+        (stone should (equal (stone) or be (writable))) (/* DOTTY-ONLY using */ defaultEquality, writability)
       }
       
       it("should throw TestFailedException with correct stack depth when file is not writable") {
         val caught1 = intercept[TestFailedException] {
-          (stone should (be (writable) or be (book))) (writability)
+          (stone should (be (writable) or be (book))) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught1.message === Some(wasNotWritable(stone) + ", and " + wasNotEqualTo(stone, book)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (stone should (be (book) or be (writable))) (writability)
+          (stone should (be (book) or be (writable))) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught2.message === Some(wasNotEqualTo(stone, book) + ", and " + wasNotWritable(stone)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (stone should (be (writable) or equal (book))) (writability, defaultEquality)
+          (stone should (be (writable) or equal (book))) (/* DOTTY-ONLY using */ writability, defaultEquality)
         }
         assert(caught3.message === Some(wasNotWritable(stone) + ", and " + didNotEqual(stone, book)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (stone should (equal (book) or be (writable))) (defaultEquality, writability)
+          (stone should (equal (book) or be (writable))) (/* DOTTY-ONLY using */ defaultEquality, writability)
         }
         assert(caught4.message === Some(didNotEqual(stone, book) + ", and " + wasNotWritable(stone)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -125,47 +125,47 @@ class ShouldBeWritableLogicalOrExplicitSpec extends AnyFunSpec with Matchers {
     describe("when work with 'file should not be writable'") {
       
       it("should do nothing when file is not writable") {
-        (stone should (not be writable or not be book)) (writability)
-        (book should (not be writable or not be stone)) (writability)
-        (stone should (not be writable or not be stone)) (writability)
+        (stone should (not be writable or not be book)) (/* DOTTY-ONLY using */ writability)
+        (book should (not be writable or not be stone)) (/* DOTTY-ONLY using */ writability)
+        (stone should (not be writable or not be stone)) (/* DOTTY-ONLY using */ writability)
         
-        (stone should (not be book or not be writable)) (writability)
-        (stone should (not be stone or not be writable)) (writability)
-        (book should (not be stone or not be writable)) (writability)
+        (stone should (not be book or not be writable)) (/* DOTTY-ONLY using */ writability)
+        (stone should (not be stone or not be writable)) (/* DOTTY-ONLY using */ writability)
+        (book should (not be stone or not be writable)) (/* DOTTY-ONLY using */ writability)
         
-        (stone should (not be writable or not equal book)) (writability, defaultEquality)
-        (book should (not be writable or not equal stone)) (writability, defaultEquality)
-        (stone should (not be writable or not equal stone)) (writability, defaultEquality)
+        (stone should (not be writable or not equal book)) (/* DOTTY-ONLY using */ writability, defaultEquality)
+        (book should (not be writable or not equal stone)) (/* DOTTY-ONLY using */ writability, defaultEquality)
+        (stone should (not be writable or not equal stone)) (/* DOTTY-ONLY using */ writability, defaultEquality)
         
-        (stone should (not equal book or not be writable)) (defaultEquality, writability)
-        (stone should (not equal stone or not be writable)) (defaultEquality, writability)
-        (book should (not equal stone or not be writable)) (defaultEquality, writability)
+        (stone should (not equal book or not be writable)) (/* DOTTY-ONLY using */ defaultEquality, writability)
+        (stone should (not equal stone or not be writable)) (/* DOTTY-ONLY using */ defaultEquality, writability)
+        (book should (not equal stone or not be writable)) (/* DOTTY-ONLY using */ defaultEquality, writability)
       }
       
       it("should throw TestFailedException with correct stack depth when file is writable") {
         val caught1 = intercept[TestFailedException] {
-          (book should (not be writable or not be book)) (writability)
+          (book should (not be writable or not be book)) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught1.message === Some(wasWritable(book) + ", and " + wasEqualTo(book, book)))
         assert(caught1.failedCodeFileName === Some(fileName))
         assert(caught1.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught2 = intercept[TestFailedException] {
-          (book should (not be book or not be writable)) (writability)
+          (book should (not be book or not be writable)) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught2.message === Some(wasEqualTo(book, book) + ", and " + wasWritable(book)))
         assert(caught2.failedCodeFileName === Some(fileName))
         assert(caught2.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught3 = intercept[TestFailedException] {
-          (book should (not be writable or not equal book)) (writability, defaultEquality)
+          (book should (not be writable or not equal book)) (/* DOTTY-ONLY using */ writability, defaultEquality)
         }
         assert(caught3.message === Some(wasWritable(book) + ", and " + equaled(book, book)))
         assert(caught3.failedCodeFileName === Some(fileName))
         assert(caught3.failedCodeLineNumber === Some(thisLineNumber - 4))
         
         val caught4 = intercept[TestFailedException] {
-          (book should (not equal book or not be writable)) (defaultEquality, writability)
+          (book should (not equal book or not be writable)) (/* DOTTY-ONLY using */ defaultEquality, writability)
         }
         assert(caught4.message === Some(equaled(book, book) + ", and " + wasWritable(book)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -176,27 +176,27 @@ class ShouldBeWritableLogicalOrExplicitSpec extends AnyFunSpec with Matchers {
     describe("when work with 'all(xs) should be (writable)'") {
       
       it("should do nothing when all(xs) is writable") {
-        (all(List(book)) should (be (writable) or be (book))) (writability)
-        (all(List(stone)) should (be (writable) or be (stone))) (writability)
-        (all(List(book)) should (be (writable) or be (stone))) (writability)
+        (all(List(book)) should (be (writable) or be (book))) (/* DOTTY-ONLY using */ writability)
+        (all(List(stone)) should (be (writable) or be (stone))) (/* DOTTY-ONLY using */ writability)
+        (all(List(book)) should (be (writable) or be (stone))) (/* DOTTY-ONLY using */ writability)
         
-        (all(List(book)) should (be (book) or be (writable))) (writability)
-        (all(List(book)) should (be (stone) or be (writable))) (writability)
-        (all(List(stone)) should (be (stone) or be (writable))) (writability)
+        (all(List(book)) should (be (book) or be (writable))) (/* DOTTY-ONLY using */ writability)
+        (all(List(book)) should (be (stone) or be (writable))) (/* DOTTY-ONLY using */ writability)
+        (all(List(stone)) should (be (stone) or be (writable))) (/* DOTTY-ONLY using */ writability)
         
-        (all(List(book)) should (be (writable) or equal (book))) (writability, defaultEquality)
-        (all(List(stone)) should (be (writable) or equal (stone))) (writability, defaultEquality)
-        (all(List(book)) should (be (writable) or equal (stone))) (writability, defaultEquality)
+        (all(List(book)) should (be (writable) or equal (book))) (/* DOTTY-ONLY using */ writability, defaultEquality)
+        (all(List(stone)) should (be (writable) or equal (stone))) (/* DOTTY-ONLY using */ writability, defaultEquality)
+        (all(List(book)) should (be (writable) or equal (stone))) (/* DOTTY-ONLY using */ writability, defaultEquality)
         
-        (all(List(book)) should (equal (book) or be (writable))) (defaultEquality, writability)
-        (all(List(book)) should (equal (stone) or be (writable))) (defaultEquality, writability)
-        (all(List(stone)) should (equal (stone) or be (writable))) (defaultEquality, writability)
+        (all(List(book)) should (equal (book) or be (writable))) (/* DOTTY-ONLY using */ defaultEquality, writability)
+        (all(List(book)) should (equal (stone) or be (writable))) (/* DOTTY-ONLY using */ defaultEquality, writability)
+        (all(List(stone)) should (equal (stone) or be (writable))) (/* DOTTY-ONLY using */ defaultEquality, writability)
       }
       
       it("should throw TestFailedException with correct stack depth when xs is not sorted") {
         val left1 = List(stone)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (be (book) or be (writable))) (writability)
+          (all(left1) should (be (book) or be (writable))) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught1.message === Some(allError(wasNotEqualTo(stone, book) + ", and " + wasNotWritable(stone), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -204,7 +204,7 @@ class ShouldBeWritableLogicalOrExplicitSpec extends AnyFunSpec with Matchers {
         
         val left2 = List(stone)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (be (writable) or be (book))) (writability)
+          (all(left2) should (be (writable) or be (book))) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught2.message === Some(allError(wasNotWritable(stone) + ", and " + wasNotEqualTo(stone, book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -212,7 +212,7 @@ class ShouldBeWritableLogicalOrExplicitSpec extends AnyFunSpec with Matchers {
         
         val left3 = List(stone)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (equal (book) or be (writable))) (defaultEquality, writability)
+          (all(left3) should (equal (book) or be (writable))) (/* DOTTY-ONLY using */ defaultEquality, writability)
         }
         assert(caught3.message === Some(allError(didNotEqual(stone, book) + ", and " + wasNotWritable(stone), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -220,7 +220,7 @@ class ShouldBeWritableLogicalOrExplicitSpec extends AnyFunSpec with Matchers {
         
         val left4 = List(stone)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (be (writable) or equal (book))) (writability, defaultEquality)
+          (all(left4) should (be (writable) or equal (book))) (/* DOTTY-ONLY using */ writability, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasNotWritable(stone) + ", and " + didNotEqual(stone, book), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))
@@ -230,27 +230,27 @@ class ShouldBeWritableLogicalOrExplicitSpec extends AnyFunSpec with Matchers {
     
     describe("when work with 'all(xs) should not be sorted'") {
       it("should do nothing when xs is not sorted") {
-        (all(List(stone)) should (not be writable or not be book)) (writability)
-        (all(List(book)) should (not be writable or not be stone)) (writability)
-        (all(List(stone)) should (not be writable or not be stone)) (writability)
+        (all(List(stone)) should (not be writable or not be book)) (/* DOTTY-ONLY using */ writability)
+        (all(List(book)) should (not be writable or not be stone)) (/* DOTTY-ONLY using */ writability)
+        (all(List(stone)) should (not be writable or not be stone)) (/* DOTTY-ONLY using */ writability)
         
-        (all(List(stone)) should (not be book or not be writable)) (writability)
-        (all(List(stone)) should (not be stone or not be writable)) (writability)
-        (all(List(book)) should (not be stone or not be writable)) (writability)
+        (all(List(stone)) should (not be book or not be writable)) (/* DOTTY-ONLY using */ writability)
+        (all(List(stone)) should (not be stone or not be writable)) (/* DOTTY-ONLY using */ writability)
+        (all(List(book)) should (not be stone or not be writable)) (/* DOTTY-ONLY using */ writability)
         
-        (all(List(stone)) should (not be writable or not equal book)) (writability, defaultEquality)
-        (all(List(book)) should (not be writable or not equal stone)) (writability, defaultEquality)
-        (all(List(stone)) should (not be writable or not equal stone)) (writability, defaultEquality)
+        (all(List(stone)) should (not be writable or not equal book)) (/* DOTTY-ONLY using */ writability, defaultEquality)
+        (all(List(book)) should (not be writable or not equal stone)) (/* DOTTY-ONLY using */ writability, defaultEquality)
+        (all(List(stone)) should (not be writable or not equal stone)) (/* DOTTY-ONLY using */ writability, defaultEquality)
         
-        (all(List(stone)) should (not equal book or not be writable)) (defaultEquality, writability)
-        (all(List(stone)) should (not equal stone or not be writable)) (defaultEquality, writability)
-        (all(List(book)) should (not equal stone or not be writable)) (defaultEquality, writability)
+        (all(List(stone)) should (not equal book or not be writable)) (/* DOTTY-ONLY using */ defaultEquality, writability)
+        (all(List(stone)) should (not equal stone or not be writable)) (/* DOTTY-ONLY using */ defaultEquality, writability)
+        (all(List(book)) should (not equal stone or not be writable)) (/* DOTTY-ONLY using */ defaultEquality, writability)
       }
       
       it("should throw TestFailedException with correct stack depth when xs is not sorted") {
         val left1 = List(book)
         val caught1 = intercept[TestFailedException] {
-          (all(left1) should (not be book or not be writable)) (writability)
+          (all(left1) should (not be book or not be writable)) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught1.message === Some(allError(wasEqualTo(book, book) + ", and " + wasWritable(book), thisLineNumber - 2, left1)))
         assert(caught1.failedCodeFileName === Some(fileName))
@@ -258,7 +258,7 @@ class ShouldBeWritableLogicalOrExplicitSpec extends AnyFunSpec with Matchers {
         
         val left2 = List(book)
         val caught2 = intercept[TestFailedException] {
-          (all(left2) should (not be writable or not be book)) (writability)
+          (all(left2) should (not be writable or not be book)) (/* DOTTY-ONLY using */ writability)
         }
         assert(caught2.message === Some(allError(wasWritable(book) + ", and " + wasEqualTo(book, book), thisLineNumber - 2, left2)))
         assert(caught2.failedCodeFileName === Some(fileName))
@@ -266,7 +266,7 @@ class ShouldBeWritableLogicalOrExplicitSpec extends AnyFunSpec with Matchers {
         
         val left3 = List(book)
         val caught3 = intercept[TestFailedException] {
-          (all(left3) should (not equal book or not be writable)) (defaultEquality, writability)
+          (all(left3) should (not equal book or not be writable)) (/* DOTTY-ONLY using */ defaultEquality, writability)
         }
         assert(caught3.message === Some(allError(equaled(book, book) + ", and " + wasWritable(book), thisLineNumber - 2, left3)))
         assert(caught3.failedCodeFileName === Some(fileName))
@@ -274,7 +274,7 @@ class ShouldBeWritableLogicalOrExplicitSpec extends AnyFunSpec with Matchers {
         
         val left4 = List(book)
         val caught4 = intercept[TestFailedException] {
-          (all(left4) should (not be writable or not equal book)) (writability, defaultEquality)
+          (all(left4) should (not be writable or not equal book)) (/* DOTTY-ONLY using */ writability, defaultEquality)
         }
         assert(caught4.message === Some(allError(wasWritable(book) + ", and " + equaled(book, book), thisLineNumber - 2, left4)))
         assert(caught4.failedCodeFileName === Some(fileName))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldContainElementNewSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldContainElementNewSpec.scala
@@ -57,9 +57,9 @@ class ShouldContainElementNewSpec extends AnyFunSpec with Explicitly {
         e2.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))
         e2.failedCodeLineNumber should be (Some(thisLineNumber - 5))
 
-        (Vector(2, 2) should contain (2)) (decided by defaultEquality[Int])
+        (Vector(2, 2) should contain (2)) (using decided by defaultEquality[Int])
         val e3 = intercept[TestFailedException] {
-          (Vector(2, 2) should not contain (2)) (decided by defaultEquality[Int])
+          (Vector(2, 2) should not contain (2)) (using decided by defaultEquality[Int])
         }
 
         e3.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))
@@ -90,9 +90,9 @@ class ShouldContainElementNewSpec extends AnyFunSpec with Explicitly {
         e2.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))
         e2.failedCodeLineNumber should be (Some(thisLineNumber - 5))
 
-        ("22" should contain ('2')) (decided by defaultEquality[Char])
+        ("22" should contain ('2')) (using decided by defaultEquality[Char])
         val e3 = intercept[TestFailedException] {
-          ("22" should not contain ('2')) (decided by defaultEquality[Char])
+          ("22" should not contain ('2')) (using decided by defaultEquality[Char])
         }
 
         e3.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))
@@ -123,9 +123,9 @@ class ShouldContainElementNewSpec extends AnyFunSpec with Explicitly {
         e2.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))
         e2.failedCodeLineNumber should be (Some(thisLineNumber - 5))
 
-        (Array(2, 2) should contain (2)) (decided by defaultEquality[Int])
+        (Array(2, 2) should contain (2)) (using decided by defaultEquality[Int])
         val e3 = intercept[TestFailedException] {
-          (Array(2, 2) should not contain (2)) (decided by defaultEquality[Int])
+          (Array(2, 2) should not contain (2)) (using decided by defaultEquality[Int])
         }
 
         e3.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))
@@ -160,9 +160,9 @@ class ShouldContainElementNewSpec extends AnyFunSpec with Explicitly {
         e2.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))
         e2.failedCodeLineNumber should be (Some(thisLineNumber - 5))
 
-        (javaSet should contain (2)) (decided by defaultEquality[Int])
+        (javaSet should contain (2)) (using decided by defaultEquality[Int])
         val e3 = intercept[TestFailedException] {
-          (javaSet should not contain (2)) (decided by defaultEquality[Int])
+          (javaSet should not contain (2)) (using decided by defaultEquality[Int])
         }
 
         e3.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldContainElementNewSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldContainElementNewSpec.scala
@@ -57,9 +57,9 @@ class ShouldContainElementNewSpec extends AnyFunSpec with Explicitly {
         e2.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))
         e2.failedCodeLineNumber should be (Some(thisLineNumber - 5))
 
-        (Vector(2, 2) should contain (2)) (using decided by defaultEquality[Int])
+        (Vector(2, 2) should contain (2)) (/* DOTTY-ONLY using */ decided by defaultEquality[Int])
         val e3 = intercept[TestFailedException] {
-          (Vector(2, 2) should not contain (2)) (using decided by defaultEquality[Int])
+          (Vector(2, 2) should not contain (2)) (/* DOTTY-ONLY using */ decided by defaultEquality[Int])
         }
 
         e3.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))
@@ -90,9 +90,9 @@ class ShouldContainElementNewSpec extends AnyFunSpec with Explicitly {
         e2.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))
         e2.failedCodeLineNumber should be (Some(thisLineNumber - 5))
 
-        ("22" should contain ('2')) (using decided by defaultEquality[Char])
+        ("22" should contain ('2')) (/* DOTTY-ONLY using */ decided by defaultEquality[Char])
         val e3 = intercept[TestFailedException] {
-          ("22" should not contain ('2')) (using decided by defaultEquality[Char])
+          ("22" should not contain ('2')) (/* DOTTY-ONLY using */ decided by defaultEquality[Char])
         }
 
         e3.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))
@@ -123,9 +123,9 @@ class ShouldContainElementNewSpec extends AnyFunSpec with Explicitly {
         e2.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))
         e2.failedCodeLineNumber should be (Some(thisLineNumber - 5))
 
-        (Array(2, 2) should contain (2)) (using decided by defaultEquality[Int])
+        (Array(2, 2) should contain (2)) (/* DOTTY-ONLY using */ decided by defaultEquality[Int])
         val e3 = intercept[TestFailedException] {
-          (Array(2, 2) should not contain (2)) (using decided by defaultEquality[Int])
+          (Array(2, 2) should not contain (2)) (/* DOTTY-ONLY using */ decided by defaultEquality[Int])
         }
 
         e3.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))
@@ -160,9 +160,9 @@ class ShouldContainElementNewSpec extends AnyFunSpec with Explicitly {
         e2.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))
         e2.failedCodeLineNumber should be (Some(thisLineNumber - 5))
 
-        (javaSet should contain (2)) (using decided by defaultEquality[Int])
+        (javaSet should contain (2)) (/* DOTTY-ONLY using */ decided by defaultEquality[Int])
         val e3 = intercept[TestFailedException] {
-          (javaSet should not contain (2)) (using decided by defaultEquality[Int])
+          (javaSet should not contain (2)) (/* DOTTY-ONLY using */ decided by defaultEquality[Int])
         }
 
         e3.failedCodeFileName should be (Some("ShouldContainElementNewSpec.scala"))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEqualExplicitlySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldEqualExplicitlySpec.scala
@@ -33,35 +33,35 @@ class ShouldEqualExplicitlySpec extends AnyFunSpec with Explicitly {
 
     it("should do nothing when equal") {
       intercept[TestFailedException] { 1 should equal (1) }
-      1 should equal (1) (defaultEquality)
-      1 should equal (1) (decided by defaultEquality)
-      (1 should equal (1)) (defaultEquality)
-      (1 should equal (1)) (decided by defaultEquality)
+      (1 should equal (1)) (/* DOTTY-ONLY using */ defaultEquality)
+      (1 should equal (1)) (/* DOTTY-ONLY using */ decided by defaultEquality)
+      (1 should equal (1)) (/* DOTTY-ONLY using */ defaultEquality)
+      (1 should equal (1)) (/* DOTTY-ONLY using */ decided by defaultEquality)
       intercept[TestFailedException] { 1 shouldEqual 1 }
-      (1 shouldEqual 1) (defaultEquality)
-      (1 shouldEqual 1) (decided by defaultEquality)
-      (1).shouldEqual(1)(defaultEquality)
-      (1).shouldEqual(1)(decided by defaultEquality)
+      (1 shouldEqual 1) (/* DOTTY-ONLY using */ defaultEquality)
+      (1 shouldEqual 1) (/* DOTTY-ONLY using */ decided by defaultEquality)
+      (1).shouldEqual(1)(/* DOTTY-ONLY using */ defaultEquality)
+      (1).shouldEqual(1)(/* DOTTY-ONLY using */ decided by defaultEquality)
     }
 
     it("should do nothing when not equal and used with not") {
       intercept[TestFailedException] { 1 should not { equal (2) } }
       intercept[TestFailedException] { 1 should not equal (2) }
-      1 should not { equal (2) } (defaultEquality)
-      1 should not { equal (2) } (decided by defaultEquality)
-      (1 should not equal (2)) (defaultEquality)
-      (1 should not equal (2)) (decided by defaultEquality)
+      (1 should not { equal (2) }) (/* DOTTY-ONLY using */ defaultEquality)
+      (1 should not { equal (2) }) (/* DOTTY-ONLY using */ decided by defaultEquality)
+      (1 should not equal (2)) (/* DOTTY-ONLY using */ defaultEquality)
+      (1 should not equal (2)) (/* DOTTY-ONLY using */ decided by defaultEquality)
 /*
       intercept[TestFailedException] { 1 shouldNot { equal (2) } }
       intercept[TestFailedException] { 1 shouldNot equal (2) }
-      1 shouldNot equal (2) (defaultEquality)
-      1 shouldNot equal (2) (decided by defaultEquality)
+      (1 shouldNot equal (2)) (/* DOTTY-ONLY using */ defaultEquality)
+      (1 shouldNot equal (2)) (/* DOTTY-ONLY using */ decided by defaultEquality)
 */
     }
 
     it("should do nothing when equal and used in a logical-and expression") {
       intercept[TestFailedException] { 1 should (equal (1) and equal (2 - 1)) }
-      1 should (equal (1) and equal (2 - 1)) (decided by defaultEquality)
+      (1 should (equal (1) and equal (2 - 1))) (/* DOTTY-ONLY using */ decided by defaultEquality)
       1 should (equal (1) (decided by defaultEquality) and equal (2 - 1) (decided by defaultEquality)) 
     }
 
@@ -70,36 +70,36 @@ class ShouldEqualExplicitlySpec extends AnyFunSpec with Explicitly {
         // Just to make sure these work strung together
         intercept[TestFailedException] { 1 should (equal (1) and equal (1) and equal (1) and equal (1)) }
         intercept[TestFailedException] { 1 should (equal (1) and equal (1) or equal (1) and equal (1) or equal (1)) }
-        intercept[TestFailedException] { 1 should (
+        (intercept[TestFailedException] { 1 should (
             equal (1) and
             equal (1) or
             equal (1) and
             equal (1) or
             equal (1)
-        ) }
-        1 should (equal (1) and equal (1) and equal (1) and equal (1)) (decided by defaultEquality)
-        1 should (equal (1) and equal (1) or equal (1) and equal (1) or equal (1)) (decided by defaultEquality)
-        1 should (
+        ) })
+        (1 should (equal (1) and equal (1) and equal (1) and equal (1))) (/* DOTTY-ONLY using */ decided by defaultEquality)
+        (1 should (equal (1) and equal (1) or equal (1) and equal (1) or equal (1))) (/* DOTTY-ONLY using */ decided by defaultEquality)
+        (1 should (
             equal (1) and
             equal (1) or
             equal (1) and
             equal (1) or
             equal (1)
-        ) (decided by defaultEquality)
+        )) (/* DOTTY-ONLY using */ decided by defaultEquality)
         1 should (equal (1) (decided by defaultEquality) and equal (1) (decided by defaultEquality) and equal (1) (decided by defaultEquality) and equal (1) (decided by defaultEquality))
         1 should (equal (1) (decided by defaultEquality) and equal (1) (decided by defaultEquality) or equal (1) (decided by defaultEquality) and equal (1) (decided by defaultEquality) or equal (1) (decided by defaultEquality))
-        1 should (
+        (1 should (
             equal (1) (decided by defaultEquality) and
             equal (1) (decided by defaultEquality) or
             equal (1) (decided by defaultEquality) and
             equal (1) (decided by defaultEquality) or
             equal (1) (decided by defaultEquality)
-        )
+        ))
     }
 
     it("should do nothing when equal and used in a logical-or expression") {
       intercept[TestFailedException] { 1 should { equal (1) or equal (2 - 1) } }
-      1 should (equal (1) or equal (2 - 1)) (decided by defaultEquality)
+      (1 should (equal (1) or equal (2 - 1))) (/* DOTTY-ONLY using */ decided by defaultEquality)
       1 should { equal (1) (decided by defaultEquality) or equal (2 - 1) (decided by defaultEquality) }
     }
 
@@ -109,8 +109,8 @@ class ShouldEqualExplicitlySpec extends AnyFunSpec with Explicitly {
       // Will back up on these MatcherGen1 and not ones, and do simpler MatcherGen1 and MatcherGen1 ones first
       // intercept[TestFailedException] { 1 should (not equal (2) and not equal (3 - 1)) }
 
-      1 should (not (equal (2)) and not (equal (3 - 1))) (decided by defaultEquality)
-      1 should (not equal (2) and (not equal (3 - 1))) (decided by defaultEquality)
+      (1 should (not (equal (2)) and not (equal (3 - 1)))) (/* DOTTY-ONLY using */ decided by defaultEquality)
+      (1 should (not equal (2) and (not equal (3 - 1)))) (/* DOTTY-ONLY using */ decided by defaultEquality)
       // 1 should (not equal (2) and not equal (3 - 1)) (decided by defaultEquality)
 
       1 should (not (equal (2) (decided by defaultEquality)) and not (equal (3 - 1) (decided by defaultEquality)))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistExplicitSpec.scala
@@ -58,12 +58,12 @@ class ShouldExistExplicitSpec extends AnyFunSpec {
   describe("The exist syntax when used with File") {
     
     it("should do nothing when the file exists") {
-      (something should exist) (existence)
+      (something should exist) (/* DOTTY-ONLY using */ existence)
     }
     
     it("should throw TFE with correct stack depth and message when the file does not exist") {
       val e = intercept[exceptions.TestFailedException] {
-        (nothing should exist) (existence)
+        (nothing should exist) (/* DOTTY-ONLY using */ existence)
       }
       assert(e.message === Some(doesNotExist(nothing)))
       assert(e.failedCodeFileName === Some(fileName))
@@ -71,12 +71,12 @@ class ShouldExistExplicitSpec extends AnyFunSpec {
     }
     
     it("should do nothing when it is used with not and the file does not exists") {
-      (nothing should not (exist)) (existence)
+      (nothing should not (exist)) (/* DOTTY-ONLY using */ existence)
     }
     
     it("should throw TFE with correct stack depth and message when it is used with not and  the file exists") {
       val e = intercept[exceptions.TestFailedException] {
-        (something should not (exist)) (existence)
+        (something should not (exist)) (/* DOTTY-ONLY using */ existence)
       }
       assert(e.message === Some(exists(something)))
       assert(e.failedCodeFileName === Some(fileName))
@@ -84,12 +84,12 @@ class ShouldExistExplicitSpec extends AnyFunSpec {
     }
     
     it("should do nothing when it is used with shouldNot and the file does not exists") {
-      (nothing shouldNot exist) (existence)
+      (nothing shouldNot exist) (/* DOTTY-ONLY using */ existence)
     }
     
     it("should throw TFE with correct stack depth and message when it is used with shouldNot and  the file exists") {
       val e = intercept[exceptions.TestFailedException] {
-        (something shouldNot exist) (existence)
+        (something shouldNot exist) (/* DOTTY-ONLY using */ existence)
       }
       assert(e.message === Some(exists(something)))
       assert(e.failedCodeFileName === Some(fileName))
@@ -100,13 +100,13 @@ class ShouldExistExplicitSpec extends AnyFunSpec {
   describe("The exist syntax when used with all(xs)") {
     
     it("should do nothing when the file exists") {
-      (all(List(something)) should exist) (existence)
+      (all(List(something)) should exist) (/* DOTTY-ONLY using */ existence)
     }
     
     it("should throw TFE with correct stack depth and message when the file does not exist") {
       val left = List(nothing)
       val e = intercept[exceptions.TestFailedException] {
-        (all(left) should exist) (existence)
+        (all(left) should exist) (/* DOTTY-ONLY using */ existence)
       }
       assert(e.message === Some(allError(left, doesNotExist(nothing), thisLineNumber - 2)))
       assert(e.failedCodeFileName === Some(fileName))
@@ -114,13 +114,13 @@ class ShouldExistExplicitSpec extends AnyFunSpec {
     }
     
     it("should do nothing when it is used with not and the file does not exists") {
-      (all(List(nothing)) should not (exist)) (existence)
+      (all(List(nothing)) should not (exist)) (/* DOTTY-ONLY using */ existence)
     }
     
     it("should throw TFE with correct stack depth and message when it is used with not and  the file exists") {
       val left = List(something)
       val e = intercept[exceptions.TestFailedException] {
-        (all(left) should not (exist)) (existence)
+        (all(left) should not (exist)) (/* DOTTY-ONLY using */ existence)
       }
       assert(e.message === Some(allError(left, exists(something), thisLineNumber - 2)))
       assert(e.failedCodeFileName === Some(fileName))
@@ -128,13 +128,13 @@ class ShouldExistExplicitSpec extends AnyFunSpec {
     }
     
     it("should do nothing when it is used with shouldNot and the file does not exists") {
-      (all(List(nothing)) shouldNot exist) (existence)
+      (all(List(nothing)) shouldNot exist) (/* DOTTY-ONLY using */ existence)
     }
     
     it("should throw TFE with correct stack depth and message when it is used with shouldNot and  the file exists") {
       val left = List(something)
       val e = intercept[exceptions.TestFailedException] {
-        (all(left) shouldNot exist) (existence)
+        (all(left) shouldNot exist) (/* DOTTY-ONLY using */ existence)
       }
       assert(e.message === Some(allError(left, exists(something), thisLineNumber - 2)))
       assert(e.failedCodeFileName === Some(fileName))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalAndExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalAndExplicitSpec.scala
@@ -70,36 +70,36 @@ class ShouldExistLogicalAndExplicitSpec extends AnyFunSpec {
   describe("The exist syntax when used with File") {
     
     it("should do nothing when the file exists") {
-      (something should (equal (something) and exist)) (defaultEquality, existence)
-      (something should (exist and equal (something))) (existence, defaultEquality)
-      (something should (be (something) and exist)) (existence)
-      (something should (exist and be (something))) (existence)
+      (something should (equal (something) and exist)) (/* DOTTY-ONLY using */ defaultEquality, existence)
+      (something should (exist and equal (something))) (/* DOTTY-ONLY using */ existence, defaultEquality)
+      (something should (be (something) and exist)) (/* DOTTY-ONLY using */ existence)
+      (something should (exist and be (something))) (/* DOTTY-ONLY using */ existence)
     }
     
     it("should throw TFE with correct stack depth and message when the file does not exist") {
       val e1 = intercept[exceptions.TestFailedException] {
-        (nothing should (equal (nothing) and exist)) (defaultEquality, existence)
+        (nothing should (equal (nothing) and exist)) (/* DOTTY-ONLY using */ defaultEquality, existence)
       }
       assert(e1.message === Some(equaled(nothing, nothing) + ", but " + doesNotExist(nothing)))
       assert(e1.failedCodeFileName === Some(fileName))
       assert(e1.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e2 = intercept[exceptions.TestFailedException] {
-        (something should (exist and equal (nothing))) (existence, defaultEquality)
+        (something should (exist and equal (nothing))) (/* DOTTY-ONLY using */ existence, defaultEquality)
       }
       assert(e2.message === Some(exists(something) + ", but " + didNotEqual(something, nothing)))
       assert(e2.failedCodeFileName === Some(fileName))
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        (nothing should (be (nothing) and exist)) (existence)
+        (nothing should (be (nothing) and exist)) (/* DOTTY-ONLY using */ existence)
       }
       assert(e3.message === Some(wasEqualTo(nothing, nothing) + ", but " + doesNotExist(nothing)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        (something should (exist and be (nothing))) (existence)
+        (something should (exist and be (nothing))) (/* DOTTY-ONLY using */ existence)
       }
       assert(e4.message === Some(exists(something) + ", but " + wasNotEqualTo(something, nothing)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -107,36 +107,36 @@ class ShouldExistLogicalAndExplicitSpec extends AnyFunSpec {
     }
     
     it("should do nothing when it is used with not and the file does not exists") {
-      (nothing should (equal (nothing) and not (exist))) (defaultEquality, existence)
-      (nothing should (not (exist) and equal (nothing))) (existence, defaultEquality)
-      (nothing should (be (nothing) and not (exist))) (existence)
-      (nothing should (not (exist) and be (nothing))) (existence)
+      (nothing should (equal (nothing) and not (exist))) (/* DOTTY-ONLY using */ defaultEquality, existence)
+      (nothing should (not (exist) and equal (nothing))) (/* DOTTY-ONLY using */ existence, defaultEquality)
+      (nothing should (be (nothing) and not (exist))) (/* DOTTY-ONLY using */ existence)
+      (nothing should (not (exist) and be (nothing))) (/* DOTTY-ONLY using */ existence)
     }
     
     it("should throw TFE with correct stack depth and message when it is used with not and  the file exists") {
       val e1 = intercept[exceptions.TestFailedException] {
-        (something should (equal (something) and not (exist))) (defaultEquality, existence)
+        (something should (equal (something) and not (exist))) (/* DOTTY-ONLY using */ defaultEquality, existence)
       }
       assert(e1.message === Some(equaled(something, something) + ", but " + exists(something)))
       assert(e1.failedCodeFileName === Some(fileName))
       assert(e1.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e2 = intercept[exceptions.TestFailedException] {
-        (nothing should (not (exist) and equal (something))) (existence, defaultEquality)
+        (nothing should (not (exist) and equal (something))) (/* DOTTY-ONLY using */ existence, defaultEquality)
       }
       assert(e2.message === Some(doesNotExist(nothing) + ", but " + didNotEqual(nothing, something)))
       assert(e2.failedCodeFileName === Some(fileName))
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        (something should (be (something) and not (exist))) (existence)
+        (something should (be (something) and not (exist))) (/* DOTTY-ONLY using */ existence)
       }
       assert(e3.message === Some(wasEqualTo(something, something) + ", but " + exists(something)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        (nothing should (not (exist) and be (something))) (existence)
+        (nothing should (not (exist) and be (something))) (/* DOTTY-ONLY using */ existence)
       }
       assert(e4.message === Some(doesNotExist(nothing) + ", but " + wasNotEqualTo(nothing, something)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -147,16 +147,16 @@ class ShouldExistLogicalAndExplicitSpec extends AnyFunSpec {
   describe("The exist syntax when used with all(xs)") {
     
     it("should do nothing when the file exists") {
-      (all(List(something)) should (equal (something) and exist)) (defaultEquality, existence)
-      (all(List(something)) should (exist and equal (something))) (existence, defaultEquality)
-      (all(List(something)) should (be (something) and exist)) (existence)
-      (all(List(something)) should (exist and be (something))) (existence)
+      (all(List(something)) should (equal (something) and exist)) (/* DOTTY-ONLY using */ defaultEquality, existence)
+      (all(List(something)) should (exist and equal (something))) (/* DOTTY-ONLY using */ existence, defaultEquality)
+      (all(List(something)) should (be (something) and exist)) (/* DOTTY-ONLY using */ existence)
+      (all(List(something)) should (exist and be (something))) (/* DOTTY-ONLY using */ existence)
     }
     
     it("should throw TFE with correct stack depth and message when the file does not exist") {
       val left1 = List(nothing)
       val e1 = intercept[exceptions.TestFailedException] {
-        (all(left1) should (equal (nothing) and exist)) (defaultEquality, existence)
+        (all(left1) should (equal (nothing) and exist)) (/* DOTTY-ONLY using */ defaultEquality, existence)
       }
       assert(e1.message === Some(allError(left1, equaled(nothing, nothing) + ", but " + doesNotExist(nothing), thisLineNumber - 2)))
       assert(e1.failedCodeFileName === Some(fileName))
@@ -164,7 +164,7 @@ class ShouldExistLogicalAndExplicitSpec extends AnyFunSpec {
       
       val left2 = List(something)
       val e2 = intercept[exceptions.TestFailedException] {
-        (all(left2) should (exist and equal (nothing))) (existence, defaultEquality)
+        (all(left2) should (exist and equal (nothing))) (/* DOTTY-ONLY using */ existence, defaultEquality)
       }
       assert(e2.message === Some(allError(left2, exists(something) + ", but " + didNotEqual(something, nothing), thisLineNumber - 2)))
       assert(e2.failedCodeFileName === Some(fileName))
@@ -172,7 +172,7 @@ class ShouldExistLogicalAndExplicitSpec extends AnyFunSpec {
       
       val left3 = List(nothing)
       val e3 = intercept[exceptions.TestFailedException] {
-        (all(left3) should (be (nothing) and exist)) (existence)
+        (all(left3) should (be (nothing) and exist)) (/* DOTTY-ONLY using */ existence)
       }
       assert(e3.message === Some(allError(left3, wasEqualTo(nothing, nothing) + ", but " + doesNotExist(nothing), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -180,7 +180,7 @@ class ShouldExistLogicalAndExplicitSpec extends AnyFunSpec {
       
       val left4 = List(something)
       val e4 = intercept[exceptions.TestFailedException] {
-        (all(left4) should (exist and be (nothing))) (existence)
+        (all(left4) should (exist and be (nothing))) (/* DOTTY-ONLY using */ existence)
       }
       assert(e4.message === Some(allError(left4, exists(something) + ", but " + wasNotEqualTo(something, nothing), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -188,16 +188,16 @@ class ShouldExistLogicalAndExplicitSpec extends AnyFunSpec {
     }
     
     it("should do nothing when it is used with not and the file does not exists") {
-      (all(List(nothing)) should (equal (nothing) and not (exist))) (defaultEquality, existence)
-      (all(List(nothing)) should (not (exist) and equal (nothing))) (existence, defaultEquality)
-      (all(List(nothing)) should (be (nothing) and not (exist))) (existence)
-      (all(List(nothing)) should (not (exist) and be (nothing))) (existence)
+      (all(List(nothing)) should (equal (nothing) and not (exist))) (/* DOTTY-ONLY using */ defaultEquality, existence)
+      (all(List(nothing)) should (not (exist) and equal (nothing))) (/* DOTTY-ONLY using */ existence, defaultEquality)
+      (all(List(nothing)) should (be (nothing) and not (exist))) (/* DOTTY-ONLY using */ existence)
+      (all(List(nothing)) should (not (exist) and be (nothing))) (/* DOTTY-ONLY using */ existence)
     }
     
     it("should throw TFE with correct stack depth and message when it is used with not and  the file exists") {
       val left1 = List(something)
       val e1 = intercept[exceptions.TestFailedException] {
-        (all(left1) should (equal (something) and not (exist))) (defaultEquality, existence)
+        (all(left1) should (equal (something) and not (exist))) (/* DOTTY-ONLY using */ defaultEquality, existence)
       }
       assert(e1.message === Some(allError(left1, equaled(something, something) + ", but " + exists(something), thisLineNumber - 2)))
       assert(e1.failedCodeFileName === Some(fileName))
@@ -205,7 +205,7 @@ class ShouldExistLogicalAndExplicitSpec extends AnyFunSpec {
       
       val left2 = List(nothing)
       val e2 = intercept[exceptions.TestFailedException] {
-        (all(left2) should (not (exist) and equal (something))) (existence, defaultEquality)
+        (all(left2) should (not (exist) and equal (something))) (/* DOTTY-ONLY using */ existence, defaultEquality)
       }
       assert(e2.message === Some(allError(left2, doesNotExist(nothing) + ", but " + didNotEqual(nothing, something), thisLineNumber - 2)))
       assert(e2.failedCodeFileName === Some(fileName))
@@ -213,7 +213,7 @@ class ShouldExistLogicalAndExplicitSpec extends AnyFunSpec {
       
       val left3 = List(something)
       val e3 = intercept[exceptions.TestFailedException] {
-        (all(left3) should (be (something) and not (exist))) (existence)
+        (all(left3) should (be (something) and not (exist))) (/* DOTTY-ONLY using */ existence)
       }
       assert(e3.message === Some(allError(left3, wasEqualTo(something, something) + ", but " + exists(something), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -221,7 +221,7 @@ class ShouldExistLogicalAndExplicitSpec extends AnyFunSpec {
       
       val left4 = List(nothing)
       val e4 = intercept[exceptions.TestFailedException] {
-        (all(left4) should (not (exist) and be (something))) (existence)
+        (all(left4) should (not (exist) and be (something))) (/* DOTTY-ONLY using */ existence)
       }
       assert(e4.message === Some(allError(left4, doesNotExist(nothing) + ", but " + wasNotEqualTo(nothing, something), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalOrExplicitSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/ShouldExistLogicalOrExplicitSpec.scala
@@ -70,47 +70,47 @@ class ShouldExistLogicalOrExplicitSpec extends AnyFunSpec {
   describe("The exist syntax when used with File") {
     
     it("should do nothing when the file exists") {
-      (something should (equal (something) or exist)) (defaultEquality, existence)
-      (something should (equal (nothing) or exist)) (defaultEquality, existence)
-      (nothing should (equal (nothing) or exist)) (defaultEquality, existence)
+      (something should (equal (something) or exist)) (/* DOTTY-ONLY using */ defaultEquality, existence)
+      (something should (equal (nothing) or exist)) (/* DOTTY-ONLY using */ defaultEquality, existence)
+      (nothing should (equal (nothing) or exist)) (/* DOTTY-ONLY using */ defaultEquality, existence)
       
-      (something should (exist or equal (something))) (existence, defaultEquality)
-      (nothing should (exist or equal (nothing))) (existence, defaultEquality)
-      (something should (exist or equal (nothing))) (existence, defaultEquality)
+      (something should (exist or equal (something))) (/* DOTTY-ONLY using */ existence, defaultEquality)
+      (nothing should (exist or equal (nothing))) (/* DOTTY-ONLY using */ existence, defaultEquality)
+      (something should (exist or equal (nothing))) (/* DOTTY-ONLY using */ existence, defaultEquality)
       
-      (something should (be (something) or exist)) (existence)
-      (something should (be (nothing) or exist)) (existence)
-      (nothing should (be (nothing) or exist)) (existence)
+      (something should (be (something) or exist)) (/* DOTTY-ONLY using */ existence)
+      (something should (be (nothing) or exist)) (/* DOTTY-ONLY using */ existence)
+      (nothing should (be (nothing) or exist)) (/* DOTTY-ONLY using */ existence)
       
-      (something should (exist or be (something))) (existence)
-      (nothing should (exist or be (nothing))) (existence)
-      (something should (exist or be (nothing))) (existence)
+      (something should (exist or be (something))) (/* DOTTY-ONLY using */ existence)
+      (nothing should (exist or be (nothing))) (/* DOTTY-ONLY using */ existence)
+      (something should (exist or be (nothing))) (/* DOTTY-ONLY using */ existence)
     }
     
     it("should throw TFE with correct stack depth and message when the file does not exist") {
       val e1 = intercept[exceptions.TestFailedException] {
-        (nothing should (equal (something) or exist)) (defaultEquality, existence)
+        (nothing should (equal (something) or exist)) (/* DOTTY-ONLY using */ defaultEquality, existence)
       }
       assert(e1.message === Some(didNotEqual(nothing, something) + ", and " + doesNotExist(nothing)))
       assert(e1.failedCodeFileName === Some(fileName))
       assert(e1.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e2 = intercept[exceptions.TestFailedException] {
-        (nothing should (exist or equal (something))) (existence, defaultEquality)
+        (nothing should (exist or equal (something))) (/* DOTTY-ONLY using */ existence, defaultEquality)
       }
       assert(e2.message === Some(doesNotExist(nothing) + ", and " + didNotEqual(nothing, something)))
       assert(e2.failedCodeFileName === Some(fileName))
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        (nothing should (be (something) or exist)) (existence)
+        (nothing should (be (something) or exist)) (/* DOTTY-ONLY using */ existence)
       }
       assert(e3.message === Some(wasNotEqualTo(nothing, something) + ", and " + doesNotExist(nothing)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        (nothing should (exist or be (something))) (existence)
+        (nothing should (exist or be (something))) (/* DOTTY-ONLY using */ existence)
       }
       assert(e4.message === Some(doesNotExist(nothing) + ", and " + wasNotEqualTo(nothing, something)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -118,47 +118,47 @@ class ShouldExistLogicalOrExplicitSpec extends AnyFunSpec {
     }
     
     it("should do nothing when it is used with not and the file does not exists") {
-      (nothing should (equal (nothing) or not (exist))) (defaultEquality, existence)
-      (nothing should (equal (something) or not (exist))) (defaultEquality, existence)
-      (something should (equal (something) or not (exist))) (defaultEquality, existence)
+      (nothing should (equal (nothing) or not (exist))) (/* DOTTY-ONLY using */ defaultEquality, existence)
+      (nothing should (equal (something) or not (exist))) (/* DOTTY-ONLY using */ defaultEquality, existence)
+      (something should (equal (something) or not (exist))) (/* DOTTY-ONLY using */ defaultEquality, existence)
       
-      (nothing should (not (exist) or equal (nothing))) (existence, defaultEquality)
-      (something should (not (exist) or equal (something))) (existence, defaultEquality)
-      (nothing should (not (exist) or equal (something))) (existence, defaultEquality)
+      (nothing should (not (exist) or equal (nothing))) (/* DOTTY-ONLY using */ existence, defaultEquality)
+      (something should (not (exist) or equal (something))) (/* DOTTY-ONLY using */ existence, defaultEquality)
+      (nothing should (not (exist) or equal (something))) (/* DOTTY-ONLY using */ existence, defaultEquality)
       
-      (nothing should (be (nothing) or not (exist))) (existence)
-      (nothing should (be (something) or not (exist))) (existence)
-      (something should (be (something) or not (exist))) (existence)
+      (nothing should (be (nothing) or not (exist))) (/* DOTTY-ONLY using */ existence)
+      (nothing should (be (something) or not (exist))) (/* DOTTY-ONLY using */ existence)
+      (something should (be (something) or not (exist))) (/* DOTTY-ONLY using */ existence)
       
-      (nothing should (not (exist) or be (nothing))) (existence)
-      (something should (not (exist) or be (something))) (existence)
-      (nothing should (not (exist) or be (something))) (existence)
+      (nothing should (not (exist) or be (nothing))) (/* DOTTY-ONLY using */ existence)
+      (something should (not (exist) or be (something))) (/* DOTTY-ONLY using */ existence)
+      (nothing should (not (exist) or be (something))) (/* DOTTY-ONLY using */ existence)
     }
     
     it("should throw TFE with correct stack depth and message when it is used with not and  the file exists") {
       val e1 = intercept[exceptions.TestFailedException] {
-        (something should (equal (nothing) or not (exist))) (defaultEquality, existence)
+        (something should (equal (nothing) or not (exist))) (/* DOTTY-ONLY using */ defaultEquality, existence)
       }
       assert(e1.message === Some(didNotEqual(something, nothing) + ", and " + exists(something)))
       assert(e1.failedCodeFileName === Some(fileName))
       assert(e1.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e2 = intercept[exceptions.TestFailedException] {
-        (something should (not (exist) or equal (nothing))) (existence, defaultEquality)
+        (something should (not (exist) or equal (nothing))) (/* DOTTY-ONLY using */ existence, defaultEquality)
       }
       assert(e2.message === Some(exists(something) + ", and " + didNotEqual(something, nothing)))
       assert(e2.failedCodeFileName === Some(fileName))
       assert(e2.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e3 = intercept[exceptions.TestFailedException] {
-        (something should (be (nothing) or not (exist))) (existence)
+        (something should (be (nothing) or not (exist))) (/* DOTTY-ONLY using */ existence)
       }
       assert(e3.message === Some(wasNotEqualTo(something, nothing) + ", and " + exists(something)))
       assert(e3.failedCodeFileName === Some(fileName))
       assert(e3.failedCodeLineNumber === Some(thisLineNumber - 4))
       
       val e4 = intercept[exceptions.TestFailedException] {
-        (something should (not (exist) or be (nothing))) (existence)
+        (something should (not (exist) or be (nothing))) (/* DOTTY-ONLY using */ existence)
       }
       assert(e4.message === Some(exists(something) + ", and " + wasNotEqualTo(something, nothing)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -169,27 +169,27 @@ class ShouldExistLogicalOrExplicitSpec extends AnyFunSpec {
   describe("The exist syntax when used with all(xs)") {
     
     it("should do nothing when the file exists") {
-      (all(List(something)) should (equal (something) or exist)) (defaultEquality, existence)
-      (all(List(something)) should (equal (nothing) or exist)) (defaultEquality, existence)
-      (all(List(nothing)) should (equal (nothing) or exist)) (defaultEquality, existence)
+      (all(List(something)) should (equal (something) or exist)) (/* DOTTY-ONLY using */ defaultEquality, existence)
+      (all(List(something)) should (equal (nothing) or exist)) (/* DOTTY-ONLY using */ defaultEquality, existence)
+      (all(List(nothing)) should (equal (nothing) or exist)) (/* DOTTY-ONLY using */ defaultEquality, existence)
       
-      (all(List(something)) should (exist or equal (something))) (existence, defaultEquality)
-      (all(List(nothing)) should (exist or equal (nothing))) (existence, defaultEquality)
-      (all(List(something)) should (exist or equal (nothing))) (existence, defaultEquality)
+      (all(List(something)) should (exist or equal (something))) (/* DOTTY-ONLY using */ existence, defaultEquality)
+      (all(List(nothing)) should (exist or equal (nothing))) (/* DOTTY-ONLY using */ existence, defaultEquality)
+      (all(List(something)) should (exist or equal (nothing))) (/* DOTTY-ONLY using */ existence, defaultEquality)
       
-      (all(List(something)) should (be (something) or exist)) (existence)
-      (all(List(something)) should (be (nothing) or exist)) (existence)
-      (all(List(nothing)) should (be (nothing) or exist)) (existence)
+      (all(List(something)) should (be (something) or exist)) (/* DOTTY-ONLY using */ existence)
+      (all(List(something)) should (be (nothing) or exist)) (/* DOTTY-ONLY using */ existence)
+      (all(List(nothing)) should (be (nothing) or exist)) (/* DOTTY-ONLY using */ existence)
       
-      (all(List(something)) should (exist or be (something))) (existence)
-      (all(List(nothing)) should (exist or be (nothing))) (existence)
-      (all(List(something)) should (exist or be (nothing))) (existence)
+      (all(List(something)) should (exist or be (something))) (/* DOTTY-ONLY using */ existence)
+      (all(List(nothing)) should (exist or be (nothing))) (/* DOTTY-ONLY using */ existence)
+      (all(List(something)) should (exist or be (nothing))) (/* DOTTY-ONLY using */ existence)
     }
     
     it("should throw TFE with correct stack depth and message when the file does not exist") {
       val left1 = List(nothing)
       val e1 = intercept[exceptions.TestFailedException] {
-        (all(left1) should (equal (something) or exist)) (defaultEquality, existence)
+        (all(left1) should (equal (something) or exist)) (/* DOTTY-ONLY using */ defaultEquality, existence)
       }
       assert(e1.message === Some(allError(left1, didNotEqual(nothing, something) + ", and " + doesNotExist(nothing), thisLineNumber - 2)))
       assert(e1.failedCodeFileName === Some(fileName))
@@ -197,7 +197,7 @@ class ShouldExistLogicalOrExplicitSpec extends AnyFunSpec {
       
       val left2 = List(nothing)
       val e2 = intercept[exceptions.TestFailedException] {
-        (all(left2) should (exist or equal (something))) (existence, defaultEquality)
+        (all(left2) should (exist or equal (something))) (/* DOTTY-ONLY using */ existence, defaultEquality)
       }
       assert(e2.message === Some(allError(left2, doesNotExist(nothing) + ", and " + didNotEqual(nothing, something), thisLineNumber - 2)))
       assert(e2.failedCodeFileName === Some(fileName))
@@ -205,7 +205,7 @@ class ShouldExistLogicalOrExplicitSpec extends AnyFunSpec {
       
       val left3 = List(nothing)
       val e3 = intercept[exceptions.TestFailedException] {
-        (all(left3) should (be (something) or exist)) (existence)
+        (all(left3) should (be (something) or exist)) (/* DOTTY-ONLY using */ existence)
       }
       assert(e3.message === Some(allError(left3, wasNotEqualTo(nothing, something) + ", and " + doesNotExist(nothing), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -213,7 +213,7 @@ class ShouldExistLogicalOrExplicitSpec extends AnyFunSpec {
       
       val left4 = List(nothing)
       val e4 = intercept[exceptions.TestFailedException] {
-        (all(left4) should (exist or be (something))) (existence)
+        (all(left4) should (exist or be (something))) (/* DOTTY-ONLY using */ existence)
       }
       assert(e4.message === Some(allError(left4, doesNotExist(nothing) + ", and " + wasNotEqualTo(nothing, something), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))
@@ -221,27 +221,27 @@ class ShouldExistLogicalOrExplicitSpec extends AnyFunSpec {
     }
     
     it("should do nothing when it is used with not and the file does not exists") {
-      (all(List(nothing)) should (equal (nothing) or not (exist))) (defaultEquality, existence)
-      (all(List(nothing)) should (equal (something) or not (exist))) (defaultEquality, existence)
-      (all(List(something)) should (equal (something) or not (exist))) (defaultEquality, existence)
+      (all(List(nothing)) should (equal (nothing) or not (exist))) (/* DOTTY-ONLY using */ defaultEquality, existence)
+      (all(List(nothing)) should (equal (something) or not (exist))) (/* DOTTY-ONLY using */ defaultEquality, existence)
+      (all(List(something)) should (equal (something) or not (exist))) (/* DOTTY-ONLY using */ defaultEquality, existence)
       
-      (all(List(nothing)) should (not (exist) or equal (nothing))) (existence, defaultEquality)
-      (all(List(something)) should (not (exist) or equal (something))) (existence, defaultEquality)
-      (all(List(nothing)) should (not (exist) or equal (something))) (existence, defaultEquality)
+      (all(List(nothing)) should (not (exist) or equal (nothing))) (/* DOTTY-ONLY using */ existence, defaultEquality)
+      (all(List(something)) should (not (exist) or equal (something))) (/* DOTTY-ONLY using */ existence, defaultEquality)
+      (all(List(nothing)) should (not (exist) or equal (something))) (/* DOTTY-ONLY using */ existence, defaultEquality)
       
-      (all(List(nothing)) should (be (nothing) or not (exist))) (existence)
-      (all(List(nothing)) should (be (something) or not (exist))) (existence)
-      (all(List(something)) should (be (something) or not (exist))) (existence)
+      (all(List(nothing)) should (be (nothing) or not (exist))) (/* DOTTY-ONLY using */ existence)
+      (all(List(nothing)) should (be (something) or not (exist))) (/* DOTTY-ONLY using */ existence)
+      (all(List(something)) should (be (something) or not (exist))) (/* DOTTY-ONLY using */ existence)
       
-      (all(List(nothing)) should (not (exist) or be (nothing))) (existence)
-      (all(List(something)) should (not (exist) or be (something))) (existence)
-      (all(List(nothing)) should (not (exist) or be (something))) (existence)
+      (all(List(nothing)) should (not (exist) or be (nothing))) (/* DOTTY-ONLY using */ existence)
+      (all(List(something)) should (not (exist) or be (something))) (/* DOTTY-ONLY using */ existence)
+      (all(List(nothing)) should (not (exist) or be (something))) (/* DOTTY-ONLY using */ existence)
     }
     
     it("should throw TFE with correct stack depth and message when it is used with not and  the file exists") {
       val left1 = List(something)
       val e1 = intercept[exceptions.TestFailedException] {
-        (all(left1) should (equal (nothing) or not (exist))) (defaultEquality, existence)
+        (all(left1) should (equal (nothing) or not (exist))) (/* DOTTY-ONLY using */ defaultEquality, existence)
       }
       assert(e1.message === Some(allError(left1, didNotEqual(something, nothing) + ", and " + exists(something), thisLineNumber - 2)))
       assert(e1.failedCodeFileName === Some(fileName))
@@ -249,7 +249,7 @@ class ShouldExistLogicalOrExplicitSpec extends AnyFunSpec {
       
       val left2 = List(something)
       val e2 = intercept[exceptions.TestFailedException] {
-        (all(left2) should (not (exist) or equal (nothing))) (existence, defaultEquality)
+        (all(left2) should (not (exist) or equal (nothing))) (/* DOTTY-ONLY using */ existence, defaultEquality)
       }
       assert(e2.message === Some(allError(left2, exists(something) + ", and " + didNotEqual(something, nothing), thisLineNumber - 2)))
       assert(e2.failedCodeFileName === Some(fileName))
@@ -257,7 +257,7 @@ class ShouldExistLogicalOrExplicitSpec extends AnyFunSpec {
       
       val left3 = List(something)
       val e3 = intercept[exceptions.TestFailedException] {
-        (all(left3) should (be (nothing) or not (exist))) (existence)
+        (all(left3) should (be (nothing) or not (exist))) (/* DOTTY-ONLY using */ existence)
       }
       assert(e3.message === Some(allError(left3, wasNotEqualTo(something, nothing) + ", and " + exists(something), thisLineNumber - 2)))
       assert(e3.failedCodeFileName === Some(fileName))
@@ -265,7 +265,7 @@ class ShouldExistLogicalOrExplicitSpec extends AnyFunSpec {
       
       val left4 = List(something)
       val e4 = intercept[exceptions.TestFailedException] {
-        (all(left4) should (not (exist) or be (nothing))) (existence)
+        (all(left4) should (not (exist) or be (nothing))) (/* DOTTY-ONLY using */ existence)
       }
       assert(e4.message === Some(allError(left4, exists(something) + ", and " + wasNotEqualTo(something, nothing), thisLineNumber - 2)))
       assert(e4.failedCodeFileName === Some(fileName))

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlSpec.scala
@@ -24,35 +24,35 @@ class StreamlinedXmlSpec extends AnyFunSpec with Matchers with StreamlinedXml {
   describe("Xml Equality of Elems (after being streamlined)") {
 
     it("should leave already-normalized XML alone") {
-      <summer></summer> should equal (<summer></summer>) (after being streamlined[Elem])
+      (<summer></summer> should equal (<summer></summer>)) (/* DOTTY-ONLY using */ after being streamlined[Elem])
     }
 
     it("should zap text that is only whitespace") {
 
-      <summer> </summer> should equal (<summer></summer>) (after being streamlined[Elem])
+      (<summer> </summer> should equal (<summer></summer>)) (/* DOTTY-ONLY using */ after being streamlined[Elem])
 
-      <summer>
-       </summer> should equal (<summer></summer>) (after being streamlined[Elem])
+      (<summer>
+       </summer> should equal (<summer></summer>)) (/* DOTTY-ONLY using */ after being streamlined[Elem])
 
-      <summer>
+      (<summer>
         <day></day>
-      </summer> should equal (<summer><day></day></summer>) (after being streamlined[Elem])
+      </summer> should equal (<summer><day></day></summer>)) (/* DOTTY-ONLY using */ after being streamlined[Elem])
 
-      <summer><day></day></summer> should equal (
+      (<summer><day></day></summer> should equal (
         <summer>
           <day></day>
         </summer>
-      ) (after being streamlined[Elem])
+      )) (/* DOTTY-ONLY using */ after being streamlined[Elem])
 
-      <summer><day>Dude!</day></summer> should equal (
+      (<summer><day>Dude!</day></summer> should equal (
         <summer>
           <day>
             Dude!
           </day>
         </summer>
-      ) (after being streamlined[Elem])
+      )) (/* DOTTY-ONLY using */ after being streamlined[Elem])
 
-      <div>{Text("My name is ")}{Text("Harry")}</div> should equal (<div>My name is Harry</div>) (after being streamlined[Elem])
+      (<div>{Text("My name is ")}{Text("Harry")}</div> should equal (<div>My name is Harry</div>)) (/* DOTTY-ONLY using */ after being streamlined[Elem])
     }
   }
 
@@ -60,39 +60,39 @@ class StreamlinedXmlSpec extends AnyFunSpec with Matchers with StreamlinedXml {
 
     it("should leave already-normalized XML alone") {
 
-      ((<summer></summer>: Node) shouldEqual (<summer></summer>)) (after being streamlined[Node])
+      ((<summer></summer>: Node) shouldEqual (<summer></summer>)) (/* DOTTY-ONLY using */ after being streamlined[Node])
 
-      ((Text("Bla"): Node) shouldEqual (Text("Bla"))) (after being streamlined[Node])
+      ((Text("Bla"): Node) shouldEqual (Text("Bla"))) (/* DOTTY-ONLY using */ after being streamlined[Node])
     }
 
     it("should zap text that is only whitespace, unless it is already a Text") {
 
-      (<summer> </summer>: Node) should equal (<summer></summer>) (after being streamlined[Node])
+      ((<summer> </summer>: Node) should equal (<summer></summer>)) (/* DOTTY-ONLY using */ after being streamlined[Node])
 
-      (<summer>
-      </summer>: Node) should equal (<summer></summer>) (after being streamlined[Node])
+      ((<summer>
+      </summer>: Node) should equal (<summer></summer>)) (/* DOTTY-ONLY using */ after being streamlined[Node])
 
-      (<summer>
+      ((<summer>
         <day></day>
-      </summer>: Node) should equal (<summer><day></day></summer>) (after being streamlined[Node])
+      </summer>: Node) should equal (<summer><day></day></summer>)) (/* DOTTY-ONLY using */ after being streamlined[Node])
 
-      <summer><day></day></summer> should equal (
+      (<summer><day></day></summer> should equal (
         <summer>
           <day></day>
         </summer>: Node
-      ) (after being streamlined[Node])
+      )) (/* DOTTY-ONLY using */ after being streamlined[Node])
 
-      <summer><day>Dude!</day></summer> should equal (
+      (<summer><day>Dude!</day></summer> should equal (
         <summer>
           <day>
             Dude!
           </day>
         </summer>: Node
-      ) (after being streamlined[Node])
+      )) (/* DOTTY-ONLY using */ after being streamlined[Node])
 
-      (Text("   "): Node) should equal (Text("   ")) (after being streamlined[Node])
+      ((Text("   "): Node) should equal (Text("   "))) (/* DOTTY-ONLY using */ after being streamlined[Node])
 
-      (<div>{Text("My name is ")}{Text("Harry")}</div>: Node) should equal (<div>My name is Harry</div>) (after being streamlined[Node])
+      ((<div>{Text("My name is ")}{Text("Harry")}</div>: Node) should equal (<div>My name is Harry</div>)) (/* DOTTY-ONLY using */ after being streamlined[Node])
     }
   }
 
@@ -100,39 +100,39 @@ class StreamlinedXmlSpec extends AnyFunSpec with Matchers with StreamlinedXml {
 
     it("should leave already-normalized XML alone") {
 
-      (<summer></summer>: NodeSeq) should equal (<summer></summer>) (after being streamlined[NodeSeq])
+      ((<summer></summer>: NodeSeq) should equal (<summer></summer>)) (/* DOTTY-ONLY using */ after being streamlined[NodeSeq])
 
-      (Text("Bla"): NodeSeq) should equal (Text("Bla")) (after being streamlined[NodeSeq])
+      ((Text("Bla"): NodeSeq) should equal (Text("Bla"))) (/* DOTTY-ONLY using */ after being streamlined[NodeSeq])
     }
 
     it("should zap text that is only whitespace, unless it is already a Text") {
 
-      (<summer> </summer>: NodeSeq) should equal (<summer></summer>) (after being streamlined[NodeSeq])
+      ((<summer> </summer>: NodeSeq) should equal (<summer></summer>)) (/* DOTTY-ONLY using */ after being streamlined[NodeSeq])
 
-      (<summer>
-      </summer>: NodeSeq) should equal (<summer></summer>) (after being streamlined[NodeSeq])
+      ((<summer>
+      </summer>: NodeSeq) should equal (<summer></summer>)) (/* DOTTY-ONLY using */ after being streamlined[NodeSeq])
 
-      (<summer>
+      ((<summer>
         <day></day>
-      </summer>: NodeSeq) should equal (<summer><day></day></summer>) (after being streamlined[NodeSeq])
+      </summer>: NodeSeq) should equal (<summer><day></day></summer>)) (/* DOTTY-ONLY using */ after being streamlined[NodeSeq])
 
-      <summer><day></day></summer> should equal (
+      (<summer><day></day></summer> should equal (
         <summer>
           <day></day>
         </summer>: NodeSeq
-      ) (after being streamlined[NodeSeq])
+      )) (/* DOTTY-ONLY using */ after being streamlined[NodeSeq])
 
-      <summer><day>Dude!</day></summer> should equal (
+      (<summer><day>Dude!</day></summer> should equal (
         <summer>
           <day>
             Dude!
           </day>
         </summer>: NodeSeq
-      ) (after being streamlined[NodeSeq])
+      )) (/* DOTTY-ONLY using */ after being streamlined[NodeSeq])
 
-      (Text("   "): NodeSeq) should equal (Text("   ")) (after being streamlined[NodeSeq])
+      ((Text("   "): NodeSeq) should equal (Text("   "))) (/* DOTTY-ONLY using */ after being streamlined[NodeSeq])
 
-      (<div>{Text("My name is ")}{Text("Harry")}</div>: NodeSeq) should equal (<div>My name is Harry</div>) (after being streamlined[NodeSeq])
+      ((<div>{Text("My name is ")}{Text("Harry")}</div>: NodeSeq) should equal (<div>My name is Harry</div>)) (/* DOTTY-ONLY using */ after being streamlined[NodeSeq])
     }
   }
 }

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/StreamlinedXmlSpec.scala
@@ -76,19 +76,19 @@ class StreamlinedXmlSpec extends AnyFunSpec with Matchers with StreamlinedXml {
         <day></day>
       </summer>: Node) should equal (<summer><day></day></summer>)) (/* DOTTY-ONLY using */ after being streamlined[Node])
 
-      (<summer><day></day></summer> should equal (
+      /* DOTTY-ONLY ( */ <summer><day></day></summer> should equal (
         <summer>
           <day></day>
         </summer>: Node
-      )) (/* DOTTY-ONLY using */ after being streamlined[Node])
+      ) /* DOTTY-ONLY ) */ (/* DOTTY-ONLY using */ after being streamlined[Node])
 
-      (<summer><day>Dude!</day></summer> should equal (
+      /* DOTTY-ONLY ( */ <summer><day>Dude!</day></summer> should equal (
         <summer>
           <day>
             Dude!
           </day>
         </summer>: Node
-      )) (/* DOTTY-ONLY using */ after being streamlined[Node])
+      ) /* DOTTY-ONLY ) */ (/* DOTTY-ONLY using */ after being streamlined[Node])
 
       ((Text("   "): Node) should equal (Text("   "))) (/* DOTTY-ONLY using */ after being streamlined[Node])
 
@@ -116,19 +116,19 @@ class StreamlinedXmlSpec extends AnyFunSpec with Matchers with StreamlinedXml {
         <day></day>
       </summer>: NodeSeq) should equal (<summer><day></day></summer>)) (/* DOTTY-ONLY using */ after being streamlined[NodeSeq])
 
-      (<summer><day></day></summer> should equal (
+      /* DOTTY-ONLY ( */ <summer><day></day></summer> should equal (
         <summer>
           <day></day>
         </summer>: NodeSeq
-      )) (/* DOTTY-ONLY using */ after being streamlined[NodeSeq])
+      ) /* DOTTY-ONLY ) */ (/* DOTTY-ONLY using */ after being streamlined[NodeSeq])
 
-      (<summer><day>Dude!</day></summer> should equal (
+      /* DOTTY-ONLY ( */ <summer><day>Dude!</day></summer> should equal (
         <summer>
           <day>
             Dude!
           </day>
         </summer>: NodeSeq
-      )) (/* DOTTY-ONLY using */ after being streamlined[NodeSeq])
+      ) /* DOTTY-ONLY ) */ (/* DOTTY-ONLY using */ after being streamlined[NodeSeq])
 
       ((Text("   "): NodeSeq) should equal (Text("   "))) (/* DOTTY-ONLY using */ after being streamlined[NodeSeq])
 

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherDeciderSpec.scala
@@ -228,15 +228,15 @@ class TheSameElementsAsContainMatcherDeciderSpec extends AnyFunSpec with Explici
     }
     
     it("should take specified normalization when 'should contain' is used") {
-      (List("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (using after being trimmed)
-      (Set("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (using after being trimmed)
-      (Array("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (using after being trimmed)
-      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain theSameElementsAs Map(1 -> "one", 2 -> "two ", 3 -> "three")) (using after being mapTrimmed)
+      (List("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Set("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Array("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain theSameElementsAs Map(1 -> "one", 2 -> "two ", 3 -> "three")) (/* DOTTY-ONLY using */ after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (using after being trimmed)
-      (javaSet("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (using after being trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain theSameElementsAs List(Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (using after being javaMapTrimmed)
+      (javaList("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaSet("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain theSameElementsAs List(Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (/* DOTTY-ONLY using */ after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -258,28 +258,28 @@ class TheSameElementsAsContainMatcherDeciderSpec extends AnyFunSpec with Explici
       val left1 = List(1, 2, 3)
       val right1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain theSameElementsAs right1) (using after being incremented)
+        (left1 should contain theSameElementsAs right1) (/* DOTTY-ONLY using */ after being incremented)
       }
       checkShouldContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val right2 = List(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain theSameElementsAs right2) (using after being incremented)
+        (left2 should contain theSameElementsAs right2) (/* DOTTY-ONLY using */ after being incremented)
       }
       checkShouldContainStackDepth(e2, left2, right2, thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val right3 = List(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain theSameElementsAs right3) (using after being incremented)
+        (left3 should contain theSameElementsAs right3) (/* DOTTY-ONLY using */ after being incremented)
       }
         checkShouldContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val right4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain theSameElementsAs right4) (using after being mapIncremented)
+        (left4 should contain theSameElementsAs right4) (/* DOTTY-ONLY using */ after being mapIncremented)
       }
       checkShouldContainStackDepth(e4, left4, right4, thisLineNumber - 2)
 
@@ -287,14 +287,14 @@ class TheSameElementsAsContainMatcherDeciderSpec extends AnyFunSpec with Explici
       val left5 = javaList(1, 2, 3)
       val right5 = List(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain theSameElementsAs right5) (using after being incremented)
+        (left5 should contain theSameElementsAs right5) (/* DOTTY-ONLY using */ after being incremented)
       }
       checkShouldContainStackDepth(e5, left5, right5, thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val right6 = List(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain theSameElementsAs right6) (using after being javaMapIncremented)
+        (left6 should contain theSameElementsAs right6) (/* DOTTY-ONLY using */ after being javaMapIncremented)
       }
       checkShouldContainStackDepth(e6, left6, right6, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -349,14 +349,14 @@ class TheSameElementsAsContainMatcherDeciderSpec extends AnyFunSpec with Explici
     
     it("should take passed in custom explicit equality when 'should contain' is used") {
       
-      (List("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Set("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Array("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> "ONE ", 2 -> "TWO", 3 -> " THREE") should contain theSameElementsAs Map(1 -> "one", 2 -> " two", 3 -> "three")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Set("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Array("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> "ONE ", 2 -> "TWO", 3 -> " THREE") should contain theSameElementsAs Map(1 -> "one", 2 -> " two", 3 -> "three")) (/* DOTTY-ONLY using */ decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "ONE "), Entry(2, "TWO"), Entry(3, " THREE")) should contain theSameElementsAs List(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "ONE "), Entry(2, "TWO"), Entry(3, " THREE")) should contain theSameElementsAs List(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
       
@@ -378,28 +378,28 @@ class TheSameElementsAsContainMatcherDeciderSpec extends AnyFunSpec with Explici
       val left1 = List("one ", " two", "three ")
       val right1 = List(" one", "two ", " three")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain theSameElementsAs right1) (using decided by reverseEquality afterBeing trimmed)
+        (left1 should contain theSameElementsAs right1) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Set("one ", " two", "three ")
       val right2 = List(" one", "two ", " three")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain theSameElementsAs right2) (using decided by reverseEquality afterBeing trimmed)
+        (left2 should contain theSameElementsAs right2) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, right2, thisLineNumber - 2)
         
       val left3 = Array("one ", " two", "three ")
       val right3 = List(" one", "two ", " three")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain theSameElementsAs right3) (using decided by reverseEquality afterBeing trimmed)
+        (left3 should contain theSameElementsAs right3) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val right4 = Map(1 -> " one", 2 -> "two ", 3 -> " three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain theSameElementsAs right4) (using decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should contain theSameElementsAs right4) (/* DOTTY-ONLY using */ decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, right4, thisLineNumber - 2)
 
@@ -407,14 +407,14 @@ class TheSameElementsAsContainMatcherDeciderSpec extends AnyFunSpec with Explici
       val left5 = javaList("one ", " two", "three ")
       val right5 = List(" one", "two ", " three")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain theSameElementsAs right5) (using decided by reverseEquality afterBeing trimmed)
+        (left5 should contain theSameElementsAs right5) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, right5, thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val right6 = List(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain theSameElementsAs right6) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should contain theSameElementsAs right6) (/* DOTTY-ONLY using */ decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, right6, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherDeciderSpec.scala
@@ -228,15 +228,15 @@ class TheSameElementsAsContainMatcherDeciderSpec extends AnyFunSpec with Explici
     }
     
     it("should take specified normalization when 'should contain' is used") {
-      (List("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (after being trimmed)
-      (Set("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (after being trimmed)
-      (Array("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (after being trimmed)
-      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain theSameElementsAs Map(1 -> "one", 2 -> "two ", 3 -> "three")) (after being mapTrimmed)
+      (List("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (using after being trimmed)
+      (Set("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (using after being trimmed)
+      (Array("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (using after being trimmed)
+      (Map(1 -> "one ", 2 -> "two", 3 -> "three ") should contain theSameElementsAs Map(1 -> "one", 2 -> "two ", 3 -> "three")) (using after being mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (after being trimmed)
-      (javaSet("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (after being trimmed)
-      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain theSameElementsAs List(Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (after being javaMapTrimmed)
+      (javaList("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (using after being trimmed)
+      (javaSet("1 ", "2", "3 ") should contain theSameElementsAs List("1", "2 ", "3")) (using after being trimmed)
+      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, "three ")) should contain theSameElementsAs List(Entry(1, "one"), Entry(2, "two "), Entry(3, "three"))) (using after being javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -258,28 +258,28 @@ class TheSameElementsAsContainMatcherDeciderSpec extends AnyFunSpec with Explici
       val left1 = List(1, 2, 3)
       val right1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain theSameElementsAs right1) (after being incremented)
+        (left1 should contain theSameElementsAs right1) (using after being incremented)
       }
       checkShouldContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val right2 = List(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain theSameElementsAs right2) (after being incremented)
+        (left2 should contain theSameElementsAs right2) (using after being incremented)
       }
       checkShouldContainStackDepth(e2, left2, right2, thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val right3 = List(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain theSameElementsAs right3) (after being incremented)
+        (left3 should contain theSameElementsAs right3) (using after being incremented)
       }
         checkShouldContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val right4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain theSameElementsAs right4) (after being mapIncremented)
+        (left4 should contain theSameElementsAs right4) (using after being mapIncremented)
       }
       checkShouldContainStackDepth(e4, left4, right4, thisLineNumber - 2)
 
@@ -287,14 +287,14 @@ class TheSameElementsAsContainMatcherDeciderSpec extends AnyFunSpec with Explici
       val left5 = javaList(1, 2, 3)
       val right5 = List(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain theSameElementsAs right5) (after being incremented)
+        (left5 should contain theSameElementsAs right5) (using after being incremented)
       }
       checkShouldContainStackDepth(e5, left5, right5, thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val right6 = List(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain theSameElementsAs right6) (after being javaMapIncremented)
+        (left6 should contain theSameElementsAs right6) (using after being javaMapIncremented)
       }
       checkShouldContainStackDepth(e6, left6, right6, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -349,14 +349,14 @@ class TheSameElementsAsContainMatcherDeciderSpec extends AnyFunSpec with Explici
     
     it("should take passed in custom explicit equality when 'should contain' is used") {
       
-      (List("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Set("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Array("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Map(1 -> "ONE ", 2 -> "TWO", 3 -> " THREE") should contain theSameElementsAs Map(1 -> "one", 2 -> " two", 3 -> "three")) (decided by mapLowerCaseEquality afterBeing mapTrimmed)
+      (List("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Set("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Array("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Map(1 -> "ONE ", 2 -> "TWO", 3 -> " THREE") should contain theSameElementsAs Map(1 -> "one", 2 -> " two", 3 -> "three")) (using decided by mapLowerCaseEquality afterBeing mapTrimmed)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (decided by lowerCaseEquality afterBeing trimmed)
-      (javaMap(Entry(1, "ONE "), Entry(2, "TWO"), Entry(3, " THREE")) should contain theSameElementsAs List(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
+      (javaList("A ", "B", " C") should contain theSameElementsAs List("a", "b ", "c")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (javaMap(Entry(1, "ONE "), Entry(2, "TWO"), Entry(3, " THREE")) should contain theSameElementsAs List(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (using decided by javaMapLowerCaseEquality afterBeing javaMapTrimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
       
@@ -378,28 +378,28 @@ class TheSameElementsAsContainMatcherDeciderSpec extends AnyFunSpec with Explici
       val left1 = List("one ", " two", "three ")
       val right1 = List(" one", "two ", " three")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain theSameElementsAs right1) (decided by reverseEquality afterBeing trimmed)
+        (left1 should contain theSameElementsAs right1) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Set("one ", " two", "three ")
       val right2 = List(" one", "two ", " three")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain theSameElementsAs right2) (decided by reverseEquality afterBeing trimmed)
+        (left2 should contain theSameElementsAs right2) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, right2, thisLineNumber - 2)
         
       val left3 = Array("one ", " two", "three ")
       val right3 = List(" one", "two ", " three")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain theSameElementsAs right3) (decided by reverseEquality afterBeing trimmed)
+        (left3 should contain theSameElementsAs right3) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       
       val left4 = Map(1 -> "one ", 2 -> " two", 3 -> "three ")
       val right4 = Map(1 -> " one", 2 -> "two ", 3 -> " three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain theSameElementsAs right4) (decided by mapReverseEquality afterBeing mapTrimmed)
+        (left4 should contain theSameElementsAs right4) (using decided by mapReverseEquality afterBeing mapTrimmed)
       }
       checkShouldContainStackDepth(e4, left4, right4, thisLineNumber - 2)
 
@@ -407,14 +407,14 @@ class TheSameElementsAsContainMatcherDeciderSpec extends AnyFunSpec with Explici
       val left5 = javaList("one ", " two", "three ")
       val right5 = List(" one", "two ", " three")
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain theSameElementsAs right5) (decided by reverseEquality afterBeing trimmed)
+        (left5 should contain theSameElementsAs right5) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e5, left5, right5, thisLineNumber - 2)
 
       val left6 = javaMap(Entry(1, "one "), Entry(2, " two"), Entry(3, "three "))
       val right6 = List(Entry(1, " one"), Entry(2, "two "), Entry(3, " three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain theSameElementsAs right6) (decided by javaMapReverseEquality afterBeing javaMapTrimmed)
+        (left6 should contain theSameElementsAs right6) (using decided by javaMapReverseEquality afterBeing javaMapTrimmed)
       }
       checkShouldContainStackDepth(e6, left6, right6, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherEqualitySpec.scala
@@ -152,21 +152,21 @@ class TheSameElementsAsContainMatcherEqualitySpec extends AnyFunSpec with Explic
     it("should take custom explicit equality in scope when 'should contain and should contain' is used") {
       val equality = new TrimEquality
       
-      (List("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (equality, equality)
-      (Set("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (equality, equality)
-      (Array("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (equality, equality)
+      (List("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
+      (Set("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
+      (Array("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
 
       val mapEquality = new MapTrimEquality
       
-      (Map(1 -> "one ", 2 -> "two", 3 -> " three") should (contain theSameElementsAs Map(1 -> " one", 2 -> " two", 3 -> "three ") and contain theSameElementsAs Map(1 -> "one ", 2 -> "two ", 3 -> " three"))) (mapEquality, mapEquality)
+      (Map(1 -> "one ", 2 -> "two", 3 -> " three") should (contain theSameElementsAs Map(1 -> " one", 2 -> " two", 3 -> "three ") and contain theSameElementsAs Map(1 -> "one ", 2 -> "two ", 3 -> " three"))) (using mapEquality, mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (equality, equality)
-      (javaSet("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (equality, equality)
+      (javaList("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
+      (javaSet("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
 
       val javaMapEquality = new JavaMapTrimEquality
       
-      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, " three")) should (contain theSameElementsAs List(Entry(1, " one"), Entry(2, " two"), Entry(3, "three ")) and contain theSameElementsAs List(Entry(1, "one "), Entry(2, "two "), Entry(3, " three")))) (javaMapEquality, javaMapEquality)
+      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, " three")) should (contain theSameElementsAs List(Entry(1, " one"), Entry(2, " two"), Entry(3, "three ")) and contain theSameElementsAs List(Entry(1, "one "), Entry(2, "two "), Entry(3, " three")))) (using javaMapEquality, javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -210,21 +210,21 @@ class TheSameElementsAsContainMatcherEqualitySpec extends AnyFunSpec with Explic
     it("should take custom explicit equality in scope when 'should contain or should contain' is used") {
       val equality = new TrimEquality
       
-      (List("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (equality, equality)
-      (Set("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (equality, equality)
-      (Array("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (equality, equality)
+      (List("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
+      (Set("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
+      (Array("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
 
       val mapEquality = new MapTrimEquality
       
-      (Map(1 -> "one ", 2 -> "two", 3 -> " three") should (contain theSameElementsAs Map(1 -> " one", 2 -> " two", 3 -> "three ") or contain theSameElementsAs Map(1 -> "one ", 2 -> "two ", 3 -> " three"))) (mapEquality, mapEquality)
+      (Map(1 -> "one ", 2 -> "two", 3 -> " three") should (contain theSameElementsAs Map(1 -> " one", 2 -> " two", 3 -> "three ") or contain theSameElementsAs Map(1 -> "one ", 2 -> "two ", 3 -> " three"))) (using mapEquality, mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (equality, equality)
-      (javaSet("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (equality, equality)
+      (javaList("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
+      (javaSet("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
 
       val javaMapEquality = new JavaMapTrimEquality
       
-      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, " three")) should (contain theSameElementsAs List(Entry(1, " one"), Entry(2, " two"), Entry(3, "three ")) or contain theSameElementsAs Map(1 -> "one ", 2 -> "two ", 3 -> " three"))) (javaMapEquality, javaMapEquality)
+      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, " three")) should (contain theSameElementsAs List(Entry(1, " one"), Entry(2, " two"), Entry(3, "three ")) or contain theSameElementsAs Map(1 -> "one ", 2 -> "two ", 3 -> " three"))) (using javaMapEquality, javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
       
@@ -352,18 +352,18 @@ class TheSameElementsAsContainMatcherEqualitySpec extends AnyFunSpec with Explic
         
     it("should take passed in custom explicit equality when 'should contain' is used") {
       val equality = new TrimEquality
-      (List("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (equality)
-      (Set("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (equality)
-      (Array("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (equality)
+      (List("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (using equality)
+      (Set("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (using equality)
+      (Array("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (using equality)
 
       val mapEquality = new MapTrimEquality
-      (Map(1 -> "one ", 2 -> "two", 3 -> " three") should contain theSameElementsAs Map(1 -> "one", 2 -> " two", 3 -> "three")) (mapEquality)
+      (Map(1 -> "one ", 2 -> "two", 3 -> " three") should contain theSameElementsAs Map(1 -> "one", 2 -> " two", 3 -> "three")) (using mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (equality)
+      (javaList("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (using equality)
 
       val javaMapEquality = new JavaMapTrimEquality
-      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, " three")) should contain theSameElementsAs List(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (javaMapEquality)
+      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, " three")) should contain theSameElementsAs List(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (using javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
       
@@ -390,21 +390,21 @@ class TheSameElementsAsContainMatcherEqualitySpec extends AnyFunSpec with Explic
       val left1 = List(1, 2, 3)
       val right1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain theSameElementsAs right1) (equality)
+        (left1 should contain theSameElementsAs right1) (using equality)
       }
       checkShouldContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val right2 = List(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain theSameElementsAs right2) (equality)
+        (left2 should contain theSameElementsAs right2) (using equality)
       }
       checkShouldContainStackDepth(e2, left2, right2, thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val right3 = List(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain theSameElementsAs right3) (equality)
+        (left3 should contain theSameElementsAs right3) (using equality)
       }
       checkShouldContainStackDepth(e3, left3, right3, thisLineNumber - 2)
         
@@ -413,7 +413,7 @@ class TheSameElementsAsContainMatcherEqualitySpec extends AnyFunSpec with Explic
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val right4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain theSameElementsAs right4) (mapEquality)
+        (left4 should contain theSameElementsAs right4) (using mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, right4, thisLineNumber - 2)
 
@@ -421,7 +421,7 @@ class TheSameElementsAsContainMatcherEqualitySpec extends AnyFunSpec with Explic
       val left5 = javaList(1, 2, 3)
       val right5 = List(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain theSameElementsAs right5) (equality)
+        (left5 should contain theSameElementsAs right5) (using equality)
       }
       checkShouldContainStackDepth(e5, left5, right5, thisLineNumber - 2)
 
@@ -430,7 +430,7 @@ class TheSameElementsAsContainMatcherEqualitySpec extends AnyFunSpec with Explic
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val right6 = List(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain theSameElementsAs right6) (javaMapEquality)
+        (left6 should contain theSameElementsAs right6) (using javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, right6, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsAsContainMatcherEqualitySpec.scala
@@ -152,21 +152,21 @@ class TheSameElementsAsContainMatcherEqualitySpec extends AnyFunSpec with Explic
     it("should take custom explicit equality in scope when 'should contain and should contain' is used") {
       val equality = new TrimEquality
       
-      (List("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
-      (Set("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
-      (Array("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
+      (List("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (/* DOTTY-ONLY using */ equality, equality)
+      (Set("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (/* DOTTY-ONLY using */ equality, equality)
+      (Array("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (/* DOTTY-ONLY using */ equality, equality)
 
       val mapEquality = new MapTrimEquality
       
-      (Map(1 -> "one ", 2 -> "two", 3 -> " three") should (contain theSameElementsAs Map(1 -> " one", 2 -> " two", 3 -> "three ") and contain theSameElementsAs Map(1 -> "one ", 2 -> "two ", 3 -> " three"))) (using mapEquality, mapEquality)
+      (Map(1 -> "one ", 2 -> "two", 3 -> " three") should (contain theSameElementsAs Map(1 -> " one", 2 -> " two", 3 -> "three ") and contain theSameElementsAs Map(1 -> "one ", 2 -> "two ", 3 -> " three"))) (/* DOTTY-ONLY using */ mapEquality, mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
-      (javaSet("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
+      (javaList("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (/* DOTTY-ONLY using */ equality, equality)
+      (javaSet("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") and contain theSameElementsAs List("1 ", "2 ", " 3"))) (/* DOTTY-ONLY using */ equality, equality)
 
       val javaMapEquality = new JavaMapTrimEquality
       
-      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, " three")) should (contain theSameElementsAs List(Entry(1, " one"), Entry(2, " two"), Entry(3, "three ")) and contain theSameElementsAs List(Entry(1, "one "), Entry(2, "two "), Entry(3, " three")))) (using javaMapEquality, javaMapEquality)
+      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, " three")) should (contain theSameElementsAs List(Entry(1, " one"), Entry(2, " two"), Entry(3, "three ")) and contain theSameElementsAs List(Entry(1, "one "), Entry(2, "two "), Entry(3, " three")))) (/* DOTTY-ONLY using */ javaMapEquality, javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -210,21 +210,21 @@ class TheSameElementsAsContainMatcherEqualitySpec extends AnyFunSpec with Explic
     it("should take custom explicit equality in scope when 'should contain or should contain' is used") {
       val equality = new TrimEquality
       
-      (List("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
-      (Set("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
-      (Array("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
+      (List("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (/* DOTTY-ONLY using */ equality, equality)
+      (Set("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (/* DOTTY-ONLY using */ equality, equality)
+      (Array("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (/* DOTTY-ONLY using */ equality, equality)
 
       val mapEquality = new MapTrimEquality
       
-      (Map(1 -> "one ", 2 -> "two", 3 -> " three") should (contain theSameElementsAs Map(1 -> " one", 2 -> " two", 3 -> "three ") or contain theSameElementsAs Map(1 -> "one ", 2 -> "two ", 3 -> " three"))) (using mapEquality, mapEquality)
+      (Map(1 -> "one ", 2 -> "two", 3 -> " three") should (contain theSameElementsAs Map(1 -> " one", 2 -> " two", 3 -> "three ") or contain theSameElementsAs Map(1 -> "one ", 2 -> "two ", 3 -> " three"))) (/* DOTTY-ONLY using */ mapEquality, mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
-      (javaSet("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (using equality, equality)
+      (javaList("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (/* DOTTY-ONLY using */ equality, equality)
+      (javaSet("1 ", "2", " 3") should (contain theSameElementsAs List(" 1", " 2", "3 ") or contain theSameElementsAs List("1 ", "2 ", " 3"))) (/* DOTTY-ONLY using */ equality, equality)
 
       val javaMapEquality = new JavaMapTrimEquality
       
-      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, " three")) should (contain theSameElementsAs List(Entry(1, " one"), Entry(2, " two"), Entry(3, "three ")) or contain theSameElementsAs Map(1 -> "one ", 2 -> "two ", 3 -> " three"))) (using javaMapEquality, javaMapEquality)
+      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, " three")) should (contain theSameElementsAs List(Entry(1, " one"), Entry(2, " two"), Entry(3, "three ")) or contain theSameElementsAs Map(1 -> "one ", 2 -> "two ", 3 -> " three"))) (/* DOTTY-ONLY using */ javaMapEquality, javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
       
@@ -352,18 +352,18 @@ class TheSameElementsAsContainMatcherEqualitySpec extends AnyFunSpec with Explic
         
     it("should take passed in custom explicit equality when 'should contain' is used") {
       val equality = new TrimEquality
-      (List("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (using equality)
-      (Set("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (using equality)
-      (Array("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (using equality)
+      (List("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (/* DOTTY-ONLY using */ equality)
+      (Set("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (/* DOTTY-ONLY using */ equality)
+      (Array("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (/* DOTTY-ONLY using */ equality)
 
       val mapEquality = new MapTrimEquality
-      (Map(1 -> "one ", 2 -> "two", 3 -> " three") should contain theSameElementsAs Map(1 -> "one", 2 -> " two", 3 -> "three")) (using mapEquality)
+      (Map(1 -> "one ", 2 -> "two", 3 -> " three") should contain theSameElementsAs Map(1 -> "one", 2 -> " two", 3 -> "three")) (/* DOTTY-ONLY using */ mapEquality)
 
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (using equality)
+      (javaList("1 ", "2", " 3") should contain theSameElementsAs List("1", "2 ", "3")) (/* DOTTY-ONLY using */ equality)
 
       val javaMapEquality = new JavaMapTrimEquality
-      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, " three")) should contain theSameElementsAs List(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (using javaMapEquality)
+      (javaMap(Entry(1, "one "), Entry(2, "two"), Entry(3, " three")) should contain theSameElementsAs List(Entry(1, "one"), Entry(2, " two"), Entry(3, "three"))) (/* DOTTY-ONLY using */ javaMapEquality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
       
@@ -390,21 +390,21 @@ class TheSameElementsAsContainMatcherEqualitySpec extends AnyFunSpec with Explic
       val left1 = List(1, 2, 3)
       val right1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain theSameElementsAs right1) (using equality)
+        (left1 should contain theSameElementsAs right1) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Set(1, 2, 3)
       val right2 = List(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain theSameElementsAs right2) (using equality)
+        (left2 should contain theSameElementsAs right2) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e2, left2, right2, thisLineNumber - 2)
         
       val left3 = Array(1, 2, 3)
       val right3 = List(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain theSameElementsAs right3) (using equality)
+        (left3 should contain theSameElementsAs right3) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e3, left3, right3, thisLineNumber - 2)
         
@@ -413,7 +413,7 @@ class TheSameElementsAsContainMatcherEqualitySpec extends AnyFunSpec with Explic
       val left4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val right4 = Map(1 -> "one", 2 -> "two", 3 -> "three")
       val e4 = intercept[exceptions.TestFailedException] {
-        (left4 should contain theSameElementsAs right4) (using mapEquality)
+        (left4 should contain theSameElementsAs right4) (/* DOTTY-ONLY using */ mapEquality)
       }
       checkShouldContainStackDepth(e4, left4, right4, thisLineNumber - 2)
 
@@ -421,7 +421,7 @@ class TheSameElementsAsContainMatcherEqualitySpec extends AnyFunSpec with Explic
       val left5 = javaList(1, 2, 3)
       val right5 = List(1, 2, 3)
       val e5 = intercept[exceptions.TestFailedException] {
-        (left5 should contain theSameElementsAs right5) (using equality)
+        (left5 should contain theSameElementsAs right5) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e5, left5, right5, thisLineNumber - 2)
 
@@ -430,7 +430,7 @@ class TheSameElementsAsContainMatcherEqualitySpec extends AnyFunSpec with Explic
       val left6 = javaMap(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val right6 = List(Entry(1, "one"), Entry(2, "two"), Entry(3, "three"))
       val e6 = intercept[exceptions.TestFailedException] {
-        (left6 should contain theSameElementsAs right6) (using javaMapEquality)
+        (left6 should contain theSameElementsAs right6) (/* DOTTY-ONLY using */ javaMapEquality)
       }
       checkShouldContainStackDepth(e6, left6, right6, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsInOrderAsContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsInOrderAsContainMatcherDeciderSpec.scala
@@ -80,18 +80,18 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
     }
     
     it("should take specified normalization when 'should contain' is used") {
-      (List("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (using after being trimmed)
-      (Array("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (using after being trimmed)
+      (List("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
+      (Array("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (using after being trimmed)
+      (javaList("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified normalization when 'should not contain' is used") {
-      (List(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (using after being incremented)
-      (Array(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (using after being incremented)
+      (List(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (/* DOTTY-ONLY using */ after being incremented)
+      (Array(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (/* DOTTY-ONLY using */ after being incremented)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (using after being incremented)
+      (javaList(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (/* DOTTY-ONLY using */ after being incremented)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -100,14 +100,14 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left1 = List(1, 2, 3)
       val right1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain theSameElementsInOrderAs right1) (using after being incremented)
+        (left1 should contain theSameElementsInOrderAs right1) (/* DOTTY-ONLY using */ after being incremented)
       }
       checkShouldContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Array(1, 2, 3)
       val right2 = List(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain theSameElementsInOrderAs right2) (using after being incremented)
+        (left2 should contain theSameElementsInOrderAs right2) (/* DOTTY-ONLY using */ after being incremented)
       }
         checkShouldContainStackDepth(e2, left2, right2, thisLineNumber - 2)
 
@@ -115,7 +115,7 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left3 = javaList(1, 2, 3)
       val right3 = List(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain theSameElementsInOrderAs right3) (using after being incremented)
+        (left3 should contain theSameElementsInOrderAs right3) (/* DOTTY-ONLY using */ after being incremented)
       }
       checkShouldContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -126,14 +126,14 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left1 = List("1 ", " 2", "3 ")
       val right1 = List(" 1", "2 ", " 3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain theSameElementsInOrderAs (right1)) (using after being trimmed)
+        (left1 should not contain theSameElementsInOrderAs (right1)) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Array("1 ", " 2", "3 ")
       val right2 = List(" 1", "2 ", " 3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain theSameElementsInOrderAs (right2)) (using after being trimmed)
+        (left2 should not contain theSameElementsInOrderAs (right2)) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, right2, thisLineNumber - 2)
 
@@ -141,25 +141,25 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left3 = javaList("1 ", " 2", "3 ")
       val right3 = List(" 1", "2 ", " 3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain theSameElementsInOrderAs (right3)) (using after being trimmed)
+        (left3 should not contain theSameElementsInOrderAs (right3)) (/* DOTTY-ONLY using */ after being trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take passed in custom explicit equality when 'should contain' is used") {
-      (List("A ", " B", "C ") should contain theSameElementsInOrderAs List(" a", "b ", " c")) (using decided by lowerCaseEquality afterBeing trimmed)
-      (Array("A ", " B", "C ") should contain theSameElementsInOrderAs List(" a", "b ", " c")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (List("A ", " B", "C ") should contain theSameElementsInOrderAs List(" a", "b ", " c")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
+      (Array("A ", " B", "C ") should contain theSameElementsInOrderAs List(" a", "b ", " c")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("A ", " B", "C ") should contain theSameElementsInOrderAs List(" a", "b ", " c")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (javaList("A ", " B", "C ") should contain theSameElementsInOrderAs List(" a", "b ", " c")) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take passed in custom explicit equality when 'should not contain' is used") {
-      (List("one ", " two", "three ") should not contain theSameElementsInOrderAs (List(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
-      (Array("one ", " two", "three ") should not contain theSameElementsInOrderAs (List(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
+      (List("one ", " two", "three ") should not contain theSameElementsInOrderAs (List(" one", "two ", " three"))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
+      (Array("one ", " two", "three ") should not contain theSameElementsInOrderAs (List(" one", "two ", " three"))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", " two", "three ") should not contain theSameElementsInOrderAs (List(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
+      (javaList("one ", " two", "three ") should not contain theSameElementsInOrderAs (List(" one", "two ", " three"))) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -168,14 +168,14 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left1 = List("one ", " two", "three ")
       val right1 = List(" one", "two ", " three")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain theSameElementsInOrderAs right1) (using decided by reverseEquality afterBeing trimmed)
+        (left1 should contain theSameElementsInOrderAs right1) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Array("one ", " two", "three ")
       val right2 = List(" one", "two ", " three")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain theSameElementsInOrderAs right2) (using decided by reverseEquality afterBeing trimmed)
+        (left2 should contain theSameElementsInOrderAs right2) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, right2, thisLineNumber - 2)
 
@@ -183,7 +183,7 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left3 = javaList("one ", " two", "three ")
       val right3 = List(" one", "two ", " three")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain theSameElementsInOrderAs right3) (using decided by reverseEquality afterBeing trimmed)
+        (left3 should contain theSameElementsInOrderAs right3) (/* DOTTY-ONLY using */ decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -194,14 +194,14 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left1 = List("ONE ", " TWO", "THREE ")
       val right1 = List("one", "two ", " three")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain theSameElementsInOrderAs (right1)) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left1 should not contain theSameElementsInOrderAs (right1)) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Array("ONE ", " TWO", "THREE ")
       val right2 = List("one", "two ", " three")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain theSameElementsInOrderAs (right2)) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left2 should not contain theSameElementsInOrderAs (right2)) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, right2, thisLineNumber - 2)
 
@@ -209,7 +209,7 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left3 = javaList("ONE ", " TWO", "THREE ")
       val right3 = List("one", "two ", " three")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain theSameElementsInOrderAs (right3)) (using decided by lowerCaseEquality afterBeing trimmed)
+        (left3 should not contain theSameElementsInOrderAs (right3)) (/* DOTTY-ONLY using */ decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsInOrderAsContainMatcherDeciderSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsInOrderAsContainMatcherDeciderSpec.scala
@@ -80,18 +80,18 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
     }
     
     it("should take specified normalization when 'should contain' is used") {
-      (List("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (after being trimmed)
-      (Array("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (after being trimmed)
+      (List("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (using after being trimmed)
+      (Array("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (using after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (after being trimmed)
+      (javaList("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (using after being trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take specified normalization when 'should not contain' is used") {
-      (List(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (after being incremented)
-      (Array(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (after being incremented)
+      (List(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (using after being incremented)
+      (Array(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (using after being incremented)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (after being incremented)
+      (javaList(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (using after being incremented)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -100,14 +100,14 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left1 = List(1, 2, 3)
       val right1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain theSameElementsInOrderAs right1) (after being incremented)
+        (left1 should contain theSameElementsInOrderAs right1) (using after being incremented)
       }
       checkShouldContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Array(1, 2, 3)
       val right2 = List(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain theSameElementsInOrderAs right2) (after being incremented)
+        (left2 should contain theSameElementsInOrderAs right2) (using after being incremented)
       }
         checkShouldContainStackDepth(e2, left2, right2, thisLineNumber - 2)
 
@@ -115,7 +115,7 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left3 = javaList(1, 2, 3)
       val right3 = List(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain theSameElementsInOrderAs right3) (after being incremented)
+        (left3 should contain theSameElementsInOrderAs right3) (using after being incremented)
       }
       checkShouldContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -126,14 +126,14 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left1 = List("1 ", " 2", "3 ")
       val right1 = List(" 1", "2 ", " 3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain theSameElementsInOrderAs (right1)) (after being trimmed)
+        (left1 should not contain theSameElementsInOrderAs (right1)) (using after being trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Array("1 ", " 2", "3 ")
       val right2 = List(" 1", "2 ", " 3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain theSameElementsInOrderAs (right2)) (after being trimmed)
+        (left2 should not contain theSameElementsInOrderAs (right2)) (using after being trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, right2, thisLineNumber - 2)
 
@@ -141,25 +141,25 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left3 = javaList("1 ", " 2", "3 ")
       val right3 = List(" 1", "2 ", " 3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain theSameElementsInOrderAs (right3)) (after being trimmed)
+        (left3 should not contain theSameElementsInOrderAs (right3)) (using after being trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take passed in custom explicit equality when 'should contain' is used") {
-      (List("A ", " B", "C ") should contain theSameElementsInOrderAs List(" a", "b ", " c")) (decided by lowerCaseEquality afterBeing trimmed)
-      (Array("A ", " B", "C ") should contain theSameElementsInOrderAs List(" a", "b ", " c")) (decided by lowerCaseEquality afterBeing trimmed)
+      (List("A ", " B", "C ") should contain theSameElementsInOrderAs List(" a", "b ", " c")) (using decided by lowerCaseEquality afterBeing trimmed)
+      (Array("A ", " B", "C ") should contain theSameElementsInOrderAs List(" a", "b ", " c")) (using decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("A ", " B", "C ") should contain theSameElementsInOrderAs List(" a", "b ", " c")) (decided by lowerCaseEquality afterBeing trimmed)
+      (javaList("A ", " B", "C ") should contain theSameElementsInOrderAs List(" a", "b ", " c")) (using decided by lowerCaseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take passed in custom explicit equality when 'should not contain' is used") {
-      (List("one ", " two", "three ") should not contain theSameElementsInOrderAs (List(" one", "two ", " three"))) (decided by reverseEquality afterBeing trimmed)
-      (Array("one ", " two", "three ") should not contain theSameElementsInOrderAs (List(" one", "two ", " three"))) (decided by reverseEquality afterBeing trimmed)
+      (List("one ", " two", "three ") should not contain theSameElementsInOrderAs (List(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
+      (Array("one ", " two", "three ") should not contain theSameElementsInOrderAs (List(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("one ", " two", "three ") should not contain theSameElementsInOrderAs (List(" one", "two ", " three"))) (decided by reverseEquality afterBeing trimmed)
+      (javaList("one ", " two", "three ") should not contain theSameElementsInOrderAs (List(" one", "two ", " three"))) (using decided by reverseEquality afterBeing trimmed)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -168,14 +168,14 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left1 = List("one ", " two", "three ")
       val right1 = List(" one", "two ", " three")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain theSameElementsInOrderAs right1) (decided by reverseEquality afterBeing trimmed)
+        (left1 should contain theSameElementsInOrderAs right1) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Array("one ", " two", "three ")
       val right2 = List(" one", "two ", " three")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain theSameElementsInOrderAs right2) (decided by reverseEquality afterBeing trimmed)
+        (left2 should contain theSameElementsInOrderAs right2) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e2, left2, right2, thisLineNumber - 2)
 
@@ -183,7 +183,7 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left3 = javaList("one ", " two", "three ")
       val right3 = List(" one", "two ", " three")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain theSameElementsInOrderAs right3) (decided by reverseEquality afterBeing trimmed)
+        (left3 should contain theSameElementsInOrderAs right3) (using decided by reverseEquality afterBeing trimmed)
       }
       checkShouldContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -194,14 +194,14 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left1 = List("ONE ", " TWO", "THREE ")
       val right1 = List("one", "two ", " three")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain theSameElementsInOrderAs (right1)) (decided by lowerCaseEquality afterBeing trimmed)
+        (left1 should not contain theSameElementsInOrderAs (right1)) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Array("ONE ", " TWO", "THREE ")
       val right2 = List("one", "two ", " three")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain theSameElementsInOrderAs (right2)) (decided by lowerCaseEquality afterBeing trimmed)
+        (left2 should not contain theSameElementsInOrderAs (right2)) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e2, left2, right2, thisLineNumber - 2)
 
@@ -209,7 +209,7 @@ class TheSameElementsInOrderAsContainMatcherDeciderSpec extends AnyFunSpec with 
       val left3 = javaList("ONE ", " TWO", "THREE ")
       val right3 = List("one", "two ", " three")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain theSameElementsInOrderAs (right3)) (decided by lowerCaseEquality afterBeing trimmed)
+        (left3 should not contain theSameElementsInOrderAs (right3)) (using decided by lowerCaseEquality afterBeing trimmed)
       }
       checkShouldNotContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsInOrderAsContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsInOrderAsContainMatcherEqualitySpec.scala
@@ -147,19 +147,19 @@ class TheSameElementsInOrderAsContainMatcherEqualitySpec extends AnyFunSpec with
     
     it("should take passed in custom explicit equality when 'should contain' is used") {
       implicit val equality = new TrimEquality
-      (List("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (using equality)
-      (Array("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (using equality)
+      (List("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ equality)
+      (Array("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (using equality)
+      (javaList("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take passed in custom explicit equality when 'should not contain' is used") {
       implicit val equality = new FalseEquality
-      (List(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (using equality)
-      (Array(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (using equality)
+      (List(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (/* DOTTY-ONLY using */ equality)
+      (Array(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (using equality)
+      (javaList(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (/* DOTTY-ONLY using */ equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -169,14 +169,14 @@ class TheSameElementsInOrderAsContainMatcherEqualitySpec extends AnyFunSpec with
       val left1 = List(1, 2, 3)
       val right1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain theSameElementsInOrderAs right1) (using equality)
+        (left1 should contain theSameElementsInOrderAs right1) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Array(1, 2, 3)
       val right2 = List(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain theSameElementsInOrderAs right2) (using equality)
+        (left2 should contain theSameElementsInOrderAs right2) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e2, left2, right2, thisLineNumber - 2)
 
@@ -184,7 +184,7 @@ class TheSameElementsInOrderAsContainMatcherEqualitySpec extends AnyFunSpec with
       val left3 = javaList(1, 2, 3)
       val right3 = List(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain theSameElementsInOrderAs right3) (using equality)
+        (left3 should contain theSameElementsInOrderAs right3) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -196,14 +196,14 @@ class TheSameElementsInOrderAsContainMatcherEqualitySpec extends AnyFunSpec with
       val left1 = List("1 ", " 2", "3 ")
       val right1 = List("1", "2 ", " 3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain theSameElementsInOrderAs (right1)) (using equality)
+        (left1 should not contain theSameElementsInOrderAs (right1)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Array("1 ", " 2", "3 ")
       val right2 = List("1", "2 ", " 3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain theSameElementsInOrderAs (right2)) (using equality)
+        (left2 should not contain theSameElementsInOrderAs (right2)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e2, left2, right2, thisLineNumber - 2)
 
@@ -211,7 +211,7 @@ class TheSameElementsInOrderAsContainMatcherEqualitySpec extends AnyFunSpec with
       val left3 = javaList("1 ", " 2", "3 ")
       val right3 = List("1", "2 ", " 3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain theSameElementsInOrderAs (right3)) (using equality)
+        (left3 should not contain theSameElementsInOrderAs (right3)) (/* DOTTY-ONLY using */ equality)
       }
       checkShouldNotContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsInOrderAsContainMatcherEqualitySpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/TheSameElementsInOrderAsContainMatcherEqualitySpec.scala
@@ -147,19 +147,19 @@ class TheSameElementsInOrderAsContainMatcherEqualitySpec extends AnyFunSpec with
     
     it("should take passed in custom explicit equality when 'should contain' is used") {
       implicit val equality = new TrimEquality
-      (List("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (equality)
-      (Array("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (equality)
+      (List("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (using equality)
+      (Array("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (using equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (equality)
+      (javaList("1 ", " 2", "3 ") should contain theSameElementsInOrderAs List(" 1", "2 ", " 3")) (using equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
     it("should take passed in custom explicit equality when 'should not contain' is used") {
       implicit val equality = new FalseEquality
-      (List(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (equality)
-      (Array(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (equality)
+      (List(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (using equality)
+      (Array(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (using equality)
       // SKIP-SCALATESTJS,NATIVE-START
-      (javaList(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (equality)
+      (javaList(1, 2, 3) should not contain theSameElementsInOrderAs (List(1, 2, 3))) (using equality)
       // SKIP-SCALATESTJS,NATIVE-END
     }
     
@@ -169,14 +169,14 @@ class TheSameElementsInOrderAsContainMatcherEqualitySpec extends AnyFunSpec with
       val left1 = List(1, 2, 3)
       val right1 = List(1, 2, 3)
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should contain theSameElementsInOrderAs right1) (equality)
+        (left1 should contain theSameElementsInOrderAs right1) (using equality)
       }
       checkShouldContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Array(1, 2, 3)
       val right2 = List(1, 2, 3)
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should contain theSameElementsInOrderAs right2) (equality)
+        (left2 should contain theSameElementsInOrderAs right2) (using equality)
       }
       checkShouldContainStackDepth(e2, left2, right2, thisLineNumber - 2)
 
@@ -184,7 +184,7 @@ class TheSameElementsInOrderAsContainMatcherEqualitySpec extends AnyFunSpec with
       val left3 = javaList(1, 2, 3)
       val right3 = List(1, 2, 3)
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should contain theSameElementsInOrderAs right3) (equality)
+        (left3 should contain theSameElementsInOrderAs right3) (using equality)
       }
       checkShouldContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END
@@ -196,14 +196,14 @@ class TheSameElementsInOrderAsContainMatcherEqualitySpec extends AnyFunSpec with
       val left1 = List("1 ", " 2", "3 ")
       val right1 = List("1", "2 ", " 3")
       val e1 = intercept[exceptions.TestFailedException] {
-        (left1 should not contain theSameElementsInOrderAs (right1)) (equality)
+        (left1 should not contain theSameElementsInOrderAs (right1)) (using equality)
       }
       checkShouldNotContainStackDepth(e1, left1, right1, thisLineNumber - 2)
         
       val left2 = Array("1 ", " 2", "3 ")
       val right2 = List("1", "2 ", " 3")
       val e2 = intercept[exceptions.TestFailedException] {
-        (left2 should not contain theSameElementsInOrderAs (right2)) (equality)
+        (left2 should not contain theSameElementsInOrderAs (right2)) (using equality)
       }
       checkShouldNotContainStackDepth(e2, left2, right2, thisLineNumber - 2)
 
@@ -211,7 +211,7 @@ class TheSameElementsInOrderAsContainMatcherEqualitySpec extends AnyFunSpec with
       val left3 = javaList("1 ", " 2", "3 ")
       val right3 = List("1", "2 ", " 3")
       val e3 = intercept[exceptions.TestFailedException] {
-        (left3 should not contain theSameElementsInOrderAs (right3)) (equality)
+        (left3 should not contain theSameElementsInOrderAs (right3)) (using equality)
       }
       checkShouldNotContainStackDepth(e3, left3, right3, thisLineNumber - 2)
       // SKIP-SCALATESTJS,NATIVE-END

--- a/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
+++ b/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
@@ -6049,7 +6049,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(resultOfAnWordApplication: ResultOfAnWordToSymbolApplication)(implicit toAnyRef: T <:< AnyRef): Assertion = {
+    //DOTTY-ONLY infix def shouldBe(resultOfAnWordApplication: ResultOfAnWordToSymbolApplication)(using toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-START 
     def shouldBe(resultOfAnWordApplication: ResultOfAnWordToSymbolApplication)(implicit toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-END  
@@ -6090,7 +6090,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe[U <: T](bePropertyMatcher: BePropertyMatcher[U])(implicit ev: T <:< AnyRef): Assertion = { // TODO: Try supporting this with 2.10 AnyVals
+    //DOTTY-ONLY infix def shouldBe[U <: T](bePropertyMatcher: BePropertyMatcher[U])(using ev: T <:< AnyRef): Assertion = { // TODO: Try supporting this with 2.10 AnyVals
     // SKIP-DOTTY-START 
     def shouldBe[U <: T](bePropertyMatcher: BePropertyMatcher[U])(implicit ev: T <:< AnyRef): Assertion = { // TODO: Try supporting this with 2.10 AnyVals
     // SKIP-DOTTY-END
@@ -6110,7 +6110,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe[U <: T](resultOfAWordApplication: ResultOfAWordToBePropertyMatcherApplication[U])(implicit ev: T <:< AnyRef): Assertion = {// TODO: Try supporting this with 2.10 AnyVals
+    //DOTTY-ONLY infix def shouldBe[U <: T](resultOfAWordApplication: ResultOfAWordToBePropertyMatcherApplication[U])(using ev: T <:< AnyRef): Assertion = {// TODO: Try supporting this with 2.10 AnyVals
     // SKIP-DOTTY-START 
     def shouldBe[U <: T](resultOfAWordApplication: ResultOfAWordToBePropertyMatcherApplication[U])(implicit ev: T <:< AnyRef): Assertion = {// TODO: Try supporting this with 2.10 AnyVals
     // SKIP-DOTTY-END
@@ -6130,7 +6130,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe[U <: T](resultOfAnWordApplication: ResultOfAnWordToBePropertyMatcherApplication[U])(implicit ev: T <:< AnyRef): Assertion = {// TODO: Try supporting this with 2.10 AnyVals
+    //DOTTY-ONLY infix def shouldBe[U <: T](resultOfAnWordApplication: ResultOfAnWordToBePropertyMatcherApplication[U])(using ev: T <:< AnyRef): Assertion = {// TODO: Try supporting this with 2.10 AnyVals
     // SKIP-DOTTY-START 
     def shouldBe[U <: T](resultOfAnWordApplication: ResultOfAnWordToBePropertyMatcherApplication[U])(implicit ev: T <:< AnyRef): Assertion = {// TODO: Try supporting this with 2.10 AnyVals
     // SKIP-DOTTY-END
@@ -6176,7 +6176,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldNot[TYPECLASS1[_]](rightMatcherFactory1: MatcherFactory1[T, TYPECLASS1])(implicit typeClass1: TYPECLASS1[T]): Assertion = {
+    //DOTTY-ONLY infix def shouldNot[TYPECLASS1[_]](rightMatcherFactory1: MatcherFactory1[T, TYPECLASS1])(using typeClass1: TYPECLASS1[T]): Assertion = {
     // SKIP-DOTTY-START 
     def shouldNot[TYPECLASS1[_]](rightMatcherFactory1: MatcherFactory1[T, TYPECLASS1])(implicit typeClass1: TYPECLASS1[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -6199,7 +6199,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *          ^
      * </pre>
      */
-    //DOTTY-ONLY infix def should[U](inv: TripleEqualsInvocation[U])(implicit constraint: T CanEqual U): Assertion = {
+    //DOTTY-ONLY infix def should[U](inv: TripleEqualsInvocation[U])(using constraint: T CanEqual U): Assertion = {
     // SKIP-DOTTY-START 
     def should[U](inv: TripleEqualsInvocation[U])(implicit constraint: T CanEqual U): Assertion = {
     // SKIP-DOTTY-END  
@@ -6225,7 +6225,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *          ^
      * </pre>
      */
-    //DOTTY-ONLY infix def should(inv: TripleEqualsInvocationOnSpread[T])(implicit ev: Numeric[T]): Assertion = {
+    //DOTTY-ONLY infix def should(inv: TripleEqualsInvocationOnSpread[T])(using ev: Numeric[T]): Assertion = {
     // SKIP-DOTTY-START 
     def should(inv: TripleEqualsInvocationOnSpread[T])(implicit ev: Numeric[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -6295,7 +6295,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def should(existWord: ExistWord)(implicit existence: Existence[T]): Assertion = {
+    //DOTTY-ONLY infix def should(existWord: ExistWord)(using existence: Existence[T]): Assertion = {
     // SKIP-DOTTY-START 
     def should(existWord: ExistWord)(implicit existence: Existence[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -6318,7 +6318,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def should(notExist: ResultOfNotExist)(implicit existence: Existence[T]): Assertion = {
+    //DOTTY-ONLY infix def should(notExist: ResultOfNotExist)(using existence: Existence[T]): Assertion = {
     // SKIP-DOTTY-START 
     def should(notExist: ResultOfNotExist)(implicit existence: Existence[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -6341,7 +6341,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldNot(existWord: ExistWord)(implicit existence: Existence[T]): Assertion = {
+    //DOTTY-ONLY infix def shouldNot(existWord: ExistWord)(using existence: Existence[T]): Assertion = {
     // SKIP-DOTTY-START 
     def shouldNot(existWord: ExistWord)(implicit existence: Existence[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -6364,7 +6364,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *             ^
      * </pre>
      */
-    //DOTTY-ONLY infix def should(startWithWord: StartWithWord)(implicit ev: T <:< String): ResultOfStartWithWordForCollectedString =
+    //DOTTY-ONLY infix def should(startWithWord: StartWithWord)(using ev: T <:< String): ResultOfStartWithWordForCollectedString =
     // SKIP-DOTTY-START 
     def should(startWithWord: StartWithWord)(implicit ev: T <:< String): ResultOfStartWithWordForCollectedString =
     // SKIP-DOTTY-END
@@ -6378,7 +6378,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *             ^
      * </pre>
      */
-    //DOTTY-ONLY infix def should(endWithWord: EndWithWord)(implicit ev: T <:< String): ResultOfEndWithWordForCollectedString =
+    //DOTTY-ONLY infix def should(endWithWord: EndWithWord)(using ev: T <:< String): ResultOfEndWithWordForCollectedString =
     // SKIP-DOTTY-START 
     def should(endWithWord: EndWithWord)(implicit ev: T <:< String): ResultOfEndWithWordForCollectedString =
     // SKIP-DOTTY-END
@@ -6392,7 +6392,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *             ^
      * </pre>
      */
-    //DOTTY-ONLY infix def should(includeWord: IncludeWord)(implicit ev: T <:< String): ResultOfIncludeWordForCollectedString =
+    //DOTTY-ONLY infix def should(includeWord: IncludeWord)(using ev: T <:< String): ResultOfIncludeWordForCollectedString =
     // SKIP-DOTTY-START 
     def should(includeWord: IncludeWord)(implicit ev: T <:< String): ResultOfIncludeWordForCollectedString =
     // SKIP-DOTTY-END
@@ -6406,7 +6406,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *             ^
      * </pre>
      */
-    //DOTTY-ONLY infix def should(fullyMatchWord: FullyMatchWord)(implicit ev: T <:< String): ResultOfFullyMatchWordForCollectedString =
+    //DOTTY-ONLY infix def should(fullyMatchWord: FullyMatchWord)(using ev: T <:< String): ResultOfFullyMatchWordForCollectedString =
     // SKIP-DOTTY-START 
     def should(fullyMatchWord: FullyMatchWord)(implicit ev: T <:< String): ResultOfFullyMatchWordForCollectedString =
     // SKIP-DOTTY-END
@@ -6420,7 +6420,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *             ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldNot(fullyMatchWord: FullyMatchWord)(implicit ev: T <:< String): ResultOfFullyMatchWordForCollectedString =
+    //DOTTY-ONLY infix def shouldNot(fullyMatchWord: FullyMatchWord)(using ev: T <:< String): ResultOfFullyMatchWordForCollectedString =
     // SKIP-DOTTY-START 
     def shouldNot(fullyMatchWord: FullyMatchWord)(implicit ev: T <:< String): ResultOfFullyMatchWordForCollectedString =
     // SKIP-DOTTY-END
@@ -6434,7 +6434,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *             ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldNot(startWithWord: StartWithWord)(implicit ev: T <:< String): ResultOfStartWithWordForCollectedString =
+    //DOTTY-ONLY infix def shouldNot(startWithWord: StartWithWord)(using ev: T <:< String): ResultOfStartWithWordForCollectedString =
     // SKIP-DOTTY-START 
     def shouldNot(startWithWord: StartWithWord)(implicit ev: T <:< String): ResultOfStartWithWordForCollectedString =
     // SKIP-DOTTY-END
@@ -6448,7 +6448,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *             ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldNot(endWithWord: EndWithWord)(implicit ev: T <:< String): ResultOfEndWithWordForCollectedString =
+    //DOTTY-ONLY infix def shouldNot(endWithWord: EndWithWord)(using ev: T <:< String): ResultOfEndWithWordForCollectedString =
     // SKIP-DOTTY-START 
     def shouldNot(endWithWord: EndWithWord)(implicit ev: T <:< String): ResultOfEndWithWordForCollectedString =
     // SKIP-DOTTY-END
@@ -6462,7 +6462,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *             ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldNot(includeWord: IncludeWord)(implicit ev: T <:< String): ResultOfIncludeWordForCollectedString =
+    //DOTTY-ONLY infix def shouldNot(includeWord: IncludeWord)(using ev: T <:< String): ResultOfIncludeWordForCollectedString =
     // SKIP-DOTTY-START 
     def shouldNot(includeWord: IncludeWord)(implicit ev: T <:< String): ResultOfIncludeWordForCollectedString =
     // SKIP-DOTTY-END
@@ -6492,7 +6492,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *                      ^
      * </pre>
      */
-    //DOTTY-ONLY infix def length(expectedLength: Long)(implicit len: Length[A]): Assertion = {
+    //DOTTY-ONLY infix def length(expectedLength: Long)(using len: Length[A]): Assertion = {
     // SKIP-DOTTY-START 
     def length(expectedLength: Long)(implicit len: Length[A]): Assertion = {
     // SKIP-DOTTY-END  
@@ -6524,7 +6524,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *                      ^
      * </pre>
      */
-    //DOTTY-ONLY infix def size(expectedSize: Long)(implicit sz: Size[A]): Assertion = {
+    //DOTTY-ONLY infix def size(expectedSize: Long)(using sz: Size[A]): Assertion = {
     // SKIP-DOTTY-START 
     def size(expectedSize: Long)(implicit sz: Size[A]): Assertion = {
     // SKIP-DOTTY-END  
@@ -6572,10 +6572,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *                              ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegexString: String): Assertion = 
-    // SKIP-DOTTY-START 
-    def regex(rightRegexString: String): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY */ def regex(rightRegexString: String): Assertion = 
       checkRegex(rightRegexString.r)
 
     /**
@@ -6586,10 +6583,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *                              ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(regexWithGroups: RegexWithGroups): Assertion = 
-    // SKIP-DOTTY-START 
-    def regex(regexWithGroups: RegexWithGroups): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY */ def regex(regexWithGroups: RegexWithGroups): Assertion = 
       checkRegex(regexWithGroups.regex, regexWithGroups.groups)
 
     /**
@@ -6600,10 +6594,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *                              ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegex: Regex): Assertion = 
-    // SKIP-DOTTY-START 
-    def regex(rightRegex: Regex): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY */ def regex(rightRegex: Regex): Assertion = 
       checkRegex(rightRegex)
 
     private def checkRegex(rightRegex: Regex, groups: IndexedSeq[String] = IndexedSeq.empty): Assertion = {
@@ -6652,10 +6643,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *                            ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegexString: String): Assertion = 
-    // SKIP-DOTTY-START 
-    def regex(rightRegexString: String): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY */ def regex(rightRegexString: String): Assertion = 
       checkRegex(rightRegexString.r)
 
     /**
@@ -6666,10 +6654,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *                            ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(regexWithGroups: RegexWithGroups): Assertion = 
-    // SKIP-DOTTY-START 
-    def regex(regexWithGroups: RegexWithGroups): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY */ def regex(regexWithGroups: RegexWithGroups): Assertion = 
       checkRegex(regexWithGroups.regex, regexWithGroups.groups)
 
     /**
@@ -6680,10 +6665,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *                            ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegex: Regex): Assertion = 
-    // SKIP-DOTTY-START 
-    def regex(rightRegex: Regex): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY */ def regex(rightRegex: Regex): Assertion = 
       checkRegex(rightRegex)
 
     private def checkRegex(rightRegex: Regex, groups: IndexedSeq[String] = IndexedSeq.empty): Assertion = {
@@ -6732,10 +6714,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *                            ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegexString: String): Assertion = 
-    // SKIP-DOTTY-START 
-    def regex(rightRegexString: String): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY */ def regex(rightRegexString: String): Assertion = 
       checkRegex(rightRegexString.r)
 
     /**
@@ -6746,10 +6725,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *                            ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(regexWithGroups: RegexWithGroups): Assertion = 
-    // SKIP-DOTTY-START 
-    def regex(regexWithGroups: RegexWithGroups): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY */ def regex(regexWithGroups: RegexWithGroups): Assertion = 
       checkRegex(regexWithGroups.regex, regexWithGroups.groups)
 
     /**
@@ -6760,10 +6736,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *                            ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegex: Regex): Assertion = 
-    // SKIP-DOTTY-START 
-    def regex(rightRegex: Regex): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY */ def regex(rightRegex: Regex): Assertion = 
       checkRegex(rightRegex)
 
     private def checkRegex(rightRegex: Regex, groups: IndexedSeq[String] = IndexedSeq.empty): Assertion = {
@@ -6812,10 +6785,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *                              ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegexString: String): Assertion = 
-    // SKIP-DOTTY-START 
-    def regex(rightRegexString: String): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY */ def regex(rightRegexString: String): Assertion = 
       checkRegex(rightRegexString.r)
 
     /**
@@ -6826,10 +6796,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *                              ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(regexWithGroups: RegexWithGroups): Assertion = 
-    // SKIP-DOTTY-START 
-    def regex(regexWithGroups: RegexWithGroups): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY */ def regex(regexWithGroups: RegexWithGroups): Assertion = 
       checkRegex(regexWithGroups.regex, regexWithGroups.groups)
 
     /**
@@ -6840,10 +6807,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *                               ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegex: Regex): Assertion = 
-    // SKIP-DOTTY-START 
-    def regex(rightRegex: Regex): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY */ def regex(rightRegex: Regex): Assertion = 
       checkRegex(rightRegex)
 
     private def checkRegex(rightRegex: Regex, groups: IndexedSeq[String] = IndexedSeq.empty): Assertion = {
@@ -6883,7 +6847,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def all[E, C[_]](xs: C[E])(using collecting: Collecting[E, C[E]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[E] = 
+  // SKIP-DOTTY-START 
   def all[E, C[_]](xs: C[E])(implicit collecting: Collecting[E, C[E]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[E] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(AllCollected, collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -6894,7 +6861,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
     * ^
     * </pre>
     */
+  //DOTTY-ONLY def all[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](xs: MAP[K, V])(implicit collecting: Collecting[(K, V), Iterable[(K, V)]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[(K, V)] =
+  // SKIP-DOTTY-START  
   def all[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](xs: MAP[K, V])(implicit collecting: Collecting[(K, V), Iterable[(K, V)]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[(K, V)] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(AllCollected, collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -6905,7 +6875,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def all[K, V, JMAP[k, v] <: java.util.Map[k, v]](xs: JMAP[K, V])(using collecting: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[org.scalatest.Entry[K, V]] =
+  // SKIP-DOTTY-START 
   def all[K, V, JMAP[k, v] <: java.util.Map[k, v]](xs: JMAP[K, V])(implicit collecting: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[org.scalatest.Entry[K, V]] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(AllCollected, collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -6916,7 +6889,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def all(xs: String)(using collecting: Collecting[Char, String], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[Char] =
+  // SKIP-DOTTY-START 
   def all(xs: String)(implicit collecting: Collecting[Char, String], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[Char] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(AllCollected, collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -6927,7 +6903,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def atLeast[E, C[_]](num: Int, xs: C[E])(using collecting: Collecting[E, C[E]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[E] =
+  // SKIP-DOTTY-START 
   def atLeast[E, C[_]](num: Int, xs: C[E])(implicit collecting: Collecting[E, C[E]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[E] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(AtLeastCollected(num), collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -6938,7 +6917,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
     * ^
     * </pre>
     */
+  //DOTTY-ONLY def atLeast[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](num: Int, xs: MAP[K, V])(using collecting: Collecting[(K, V), Iterable[(K, V)]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[(K, V)] =
+  // SKIP-DOTTY-START  
   def atLeast[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](num: Int, xs: MAP[K, V])(implicit collecting: Collecting[(K, V), Iterable[(K, V)]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[(K, V)] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(AtLeastCollected(num), collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -6949,7 +6931,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def atLeast[K, V, JMAP[k, v] <: java.util.Map[k, v]](num: Int, xs: JMAP[K, V])(using collecting: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[org.scalatest.Entry[K, V]] =
+  // SKIP-DOTTY-START 
   def atLeast[K, V, JMAP[k, v] <: java.util.Map[k, v]](num: Int, xs: JMAP[K, V])(implicit collecting: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[org.scalatest.Entry[K, V]] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(AtLeastCollected(num), collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -6960,7 +6945,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def atLeast(num: Int, xs: String)(using collecting: Collecting[Char, String], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[Char] =
+  // SKIP-DOTTY-START 
   def atLeast(num: Int, xs: String)(implicit collecting: Collecting[Char, String], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[Char] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(AtLeastCollected(num), collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -6971,7 +6959,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def every[E, C[_]](xs: C[E])(using collecting: Collecting[E, C[E]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[E] =
+  // SKIP-DOTTY-START 
   def every[E, C[_]](xs: C[E])(implicit collecting: Collecting[E, C[E]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[E] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(EveryCollected, collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -6982,7 +6973,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
     * ^
     * </pre>
     */
+  //DOTTY-ONLY def every[K, V, MAP[k, v] <: scala.collection.Map[k, v]](xs: MAP[K, V])(using collecting: Collecting[(K, V), Iterable[(K, V)]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[(K, V)] =
+  // SKIP-DOTTY-START  
   def every[K, V, MAP[k, v] <: scala.collection.Map[k, v]](xs: MAP[K, V])(implicit collecting: Collecting[(K, V), Iterable[(K, V)]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[(K, V)] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(EveryCollected, collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -6994,7 +6988,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def every[K, V, JMAP[k, v] <: java.util.Map[k, v]](xs: JMAP[K, V])(using collecting: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[org.scalatest.Entry[K, V]] =
+  // SKIP-DOTTY-START 
   def every[K, V, JMAP[k, v] <: java.util.Map[k, v]](xs: JMAP[K, V])(implicit collecting: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[org.scalatest.Entry[K, V]] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(EveryCollected, collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7005,7 +7002,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def every(xs: String)(implicit collecting: Collecting[Char, String], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[Char] =
+  // SKIP-DOTTY-START 
   def every(xs: String)(implicit collecting: Collecting[Char, String], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[Char] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(EveryCollected, collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7016,7 +7016,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def exactly[E, C[_]](num: Int, xs: C[E])(using collecting: Collecting[E, C[E]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[E] =
+  // SKIP-DOTTY-START  
   def exactly[E, C[_]](num: Int, xs: C[E])(implicit collecting: Collecting[E, C[E]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[E] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(ExactlyCollected(num), collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7027,7 +7030,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
     * ^
     * </pre>
     */
+  //DOTTY-ONLY def exactly[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](num: Int, xs: MAP[K, V])(using collecting: Collecting[(K, V), Iterable[(K, V)]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[(K, V)] =
+  // SKIP-DOTTY-START  
   def exactly[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](num: Int, xs: MAP[K, V])(implicit collecting: Collecting[(K, V), Iterable[(K, V)]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[(K, V)] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(ExactlyCollected(num), collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7038,7 +7044,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def exactly[K, V, JMAP[k, v] <: java.util.Map[k, v]](num: Int, xs: JMAP[K, V])(using collecting: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[org.scalatest.Entry[K, V]] =
+  // SKIP-DOTTY-START 
   def exactly[K, V, JMAP[k, v] <: java.util.Map[k, v]](num: Int, xs: JMAP[K, V])(implicit collecting: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[org.scalatest.Entry[K, V]] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(ExactlyCollected(num), collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7049,7 +7058,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def exactly(num: Int, xs: String)(using collecting: Collecting[Char, String], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[Char] =
+  // SKIP-DOTTY-START 
   def exactly(num: Int, xs: String)(implicit collecting: Collecting[Char, String], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[Char] =
+  // SKIP-DOTTY-END 
     new ResultOfCollectedAny(ExactlyCollected(num), collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7059,8 +7071,11 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * no(xs) should fullymatch regex ("Hel*o world".r)
    * ^
    * </pre>
-   */ 
+   */
+  //DOTTY-ONLY def no[E, C[_]](xs: C[E])(using collecting: Collecting[E, C[E]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[E] =
+  // SKIP-DOTTY-START  
   def no[E, C[_]](xs: C[E])(implicit collecting: Collecting[E, C[E]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[E] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(NoCollected, collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7071,7 +7086,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def no[K, V, JMAP[k, v] <: java.util.Map[k, v]](xs: JMAP[K, V])(using collecting: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[org.scalatest.Entry[K, V]] =
+  // SKIP-DOTTY-START 
   def no[K, V, JMAP[k, v] <: java.util.Map[k, v]](xs: JMAP[K, V])(implicit collecting: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[org.scalatest.Entry[K, V]] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(NoCollected, collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7082,7 +7100,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def no(xs: String)(using collecting: Collecting[Char, String], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[Char] =
+  // SKIP-DOTTY-START 
   def no(xs: String)(implicit collecting: Collecting[Char, String], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[Char] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(NoCollected, collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7093,7 +7114,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def between[E, C[_]](from: Int, upTo:Int, xs: C[E])(using collecting: Collecting[E, C[E]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[E] =
+  // SKIP-DOTTY-START 
   def between[E, C[_]](from: Int, upTo:Int, xs: C[E])(implicit collecting: Collecting[E, C[E]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[E] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(BetweenCollected(from, upTo), collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7104,7 +7128,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def between[K, V, JMAP[k, v] <: java.util.Map[k, v]](from: Int, upTo:Int, xs: JMAP[K, V])(using collecting: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[org.scalatest.Entry[K, V]] =
+  // SKIP-DOTTY-START  
   def between[K, V, JMAP[k, v] <: java.util.Map[k, v]](from: Int, upTo:Int, xs: JMAP[K, V])(implicit collecting: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[org.scalatest.Entry[K, V]] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(BetweenCollected(from, upTo), collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7115,7 +7142,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def between(from: Int, upTo:Int, xs: String)(using collecting: Collecting[Char, String], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[Char] =
+  // SKIP-DOTTY-START 
   def between(from: Int, upTo:Int, xs: String)(implicit collecting: Collecting[Char, String], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[Char] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(BetweenCollected(from, upTo), collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7126,7 +7156,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def atMost[E, C[_]](num: Int, xs: C[E])(using collecting: Collecting[E, C[E]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[E] =
+  // SKIP-DOTTY-START 
   def atMost[E, C[_]](num: Int, xs: C[E])(implicit collecting: Collecting[E, C[E]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[E] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(AtMostCollected(num), collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7137,7 +7170,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
     * ^
     * </pre>
     */
+  //DOTTY-ONLY def atMost[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](num: Int, xs: MAP[K, V])(using collecting: Collecting[(K, V), Iterable[(K, V)]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[(K, V)] =
+  // SKIP-DOTTY-START   
   def atMost[K, V, MAP[k, v] <: scala.collection.GenMap[k, v]](num: Int, xs: MAP[K, V])(implicit collecting: Collecting[(K, V), Iterable[(K, V)]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[(K, V)] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(AtMostCollected(num), collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7148,7 +7184,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def atMost[K, V, JMAP[k, v] <: java.util.Map[k, v]](num: Int, xs: JMAP[K, V])(using collecting: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[org.scalatest.Entry[K, V]] =
+  // SKIP-DOTTY-START 
   def atMost[K, V, JMAP[k, v] <: java.util.Map[k, v]](num: Int, xs: JMAP[K, V])(implicit collecting: Collecting[org.scalatest.Entry[K, V], JMAP[K, V]], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[org.scalatest.Entry[K, V]] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(AtMostCollected(num), collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7159,7 +7198,10 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
+  //DOTTY-ONLY def atMost(num: Int, xs: String)(using collecting: Collecting[Char, String], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[Char] =
+  // SKIP-DOTTY-START 
   def atMost(num: Int, xs: String)(implicit collecting: Collecting[Char, String], prettifier: Prettifier, pos: source.Position): ResultOfCollectedAny[Char] =
+  // SKIP-DOTTY-END
     new ResultOfCollectedAny(AtMostCollected(num), collecting.iterableFrom(xs), xs, prettifier, pos)
 
   /**
@@ -7170,7 +7212,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
-  def a[T: ClassTag]: ResultOfATypeInvocation[T] =
+  /* DOTTY-ONLY infix */ def a[T: ClassTag]: ResultOfATypeInvocation[T] =
     new ResultOfATypeInvocation(classTag)
 
   /**
@@ -7181,7 +7223,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
    * ^
    * </pre>
    */
-  def an[T : ClassTag]: ResultOfAnTypeInvocation[T] =
+  /* DOTTY-ONLY infix */ def an[T : ClassTag]: ResultOfAnTypeInvocation[T] =
     new ResultOfAnTypeInvocation(classTag)
 
   /**

--- a/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
+++ b/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
@@ -4008,7 +4008,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(theSameElementsInOrderAs: ResultOfTheSameElementsInOrderAsApplication)(implicit sequencing: Sequencing[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(theSameElementsInOrderAs: ResultOfTheSameElementsInOrderAsApplication)(using sequencing: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(theSameElementsInOrderAs: ResultOfTheSameElementsInOrderAsApplication)(implicit sequencing: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-END
@@ -4030,7 +4030,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(only: ResultOfOnlyApplication)(implicit aggregating: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(only: ResultOfOnlyApplication)(using aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(only: ResultOfOnlyApplication)(implicit aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4072,7 +4072,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(only: ResultOfInOrderOnlyApplication)(implicit sequencing: Sequencing[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(only: ResultOfInOrderOnlyApplication)(using sequencing: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(only: ResultOfInOrderOnlyApplication)(implicit sequencing: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4104,7 +4104,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(only: ResultOfAllOfApplication)(implicit aggregating: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(only: ResultOfAllOfApplication)(using aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(only: ResultOfAllOfApplication)(implicit aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4138,7 +4138,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(only: ResultOfAllElementsOfApplication)(implicit evidence: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(only: ResultOfAllElementsOfApplication)(using evidence: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(only: ResultOfAllElementsOfApplication)(implicit evidence: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4172,7 +4172,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(inOrder: ResultOfInOrderApplication)(implicit sequencing: Sequencing[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(inOrder: ResultOfInOrderApplication)(using sequencing: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(inOrder: ResultOfInOrderApplication)(implicit sequencing: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4206,7 +4206,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(inOrderElementsOf: ResultOfInOrderElementsOfApplication)(implicit evidence: Sequencing[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(inOrderElementsOf: ResultOfInOrderElementsOfApplication)(using evidence: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(inOrderElementsOf: ResultOfInOrderElementsOfApplication)(implicit evidence: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4240,7 +4240,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(atMostOneOf: ResultOfAtMostOneOfApplication)(implicit aggregating: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(atMostOneOf: ResultOfAtMostOneOfApplication)(using aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(atMostOneOf: ResultOfAtMostOneOfApplication)(implicit aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4274,7 +4274,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(atMostOneElementOf: ResultOfAtMostOneElementOfApplication)(implicit evidence: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(atMostOneElementOf: ResultOfAtMostOneElementOfApplication)(using evidence: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(atMostOneElementOf: ResultOfAtMostOneElementOfApplication)(implicit evidence: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4308,7 +4308,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                          ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(resultOfKeyWordApplication: ResultOfKeyWordApplication)(implicit keyMapping: KeyMapping[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(resultOfKeyWordApplication: ResultOfKeyWordApplication)(using keyMapping: KeyMapping[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(resultOfKeyWordApplication: ResultOfKeyWordApplication)(implicit keyMapping: KeyMapping[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4341,7 +4341,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                          ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(resultOfValueWordApplication: ResultOfValueWordApplication)(implicit valueMapping: ValueMapping[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(resultOfValueWordApplication: ResultOfValueWordApplication)(using valueMapping: ValueMapping[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(resultOfValueWordApplication: ResultOfValueWordApplication)(implicit valueMapping: ValueMapping[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4374,7 +4374,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                        ^
      * </pre>
      */
-    //DOTTY-ONLY infix def startWith(right: String)(implicit ev: T <:< String): Assertion = {
+    //DOTTY-ONLY infix def startWith(right: String)(using ev: T <:< String): Assertion = {
     // SKIP-DOTTY-START 
     def startWith(right: String)(implicit ev: T <:< String): Assertion = {
     // SKIP-DOTTY-END  
@@ -4410,7 +4410,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      * or a <code>scala.util.matching.Regex</code>.
      * </p>
      */
-    //DOTTY-ONLY infix def startWith(resultOfRegexWordApplication: ResultOfRegexWordApplication)(implicit ev: T <:< String): Assertion = {
+    //DOTTY-ONLY infix def startWith(resultOfRegexWordApplication: ResultOfRegexWordApplication)(using ev: T <:< String): Assertion = {
     // SKIP-DOTTY-START 
     def startWith(resultOfRegexWordApplication: ResultOfRegexWordApplication)(implicit ev: T <:< String): Assertion = {
     // SKIP-DOTTY-END  
@@ -4442,7 +4442,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                        ^
      * </pre>
      */
-    //DOTTY-ONLY infix def endWith(expectedSubstring: String)(implicit ev: T <:< String): Assertion = {
+    //DOTTY-ONLY infix def endWith(expectedSubstring: String)(using ev: T <:< String): Assertion = {
     // SKIP-DOTTY-START 
     def endWith(expectedSubstring: String)(implicit ev: T <:< String): Assertion = {
     // SKIP-DOTTY-END  
@@ -4473,7 +4473,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                        ^
      * </pre>
      */
-    //DOTTY-ONLY infix def endWith(resultOfRegexWordApplication: ResultOfRegexWordApplication)(implicit ev: T <:< String): Assertion = {
+    //DOTTY-ONLY infix def endWith(resultOfRegexWordApplication: ResultOfRegexWordApplication)(using ev: T <:< String): Assertion = {
     // SKIP-DOTTY-START 
     def endWith(resultOfRegexWordApplication: ResultOfRegexWordApplication)(implicit ev: T <:< String): Assertion = {
     // SKIP-DOTTY-END  
@@ -4510,7 +4510,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      * or a <code>scala.util.matching.Regex</code>.
      * </p>
      */
-    //DOTTY-ONLY infix def include(resultOfRegexWordApplication: ResultOfRegexWordApplication)(implicit ev: T <:< String): Assertion = {
+    //DOTTY-ONLY infix def include(resultOfRegexWordApplication: ResultOfRegexWordApplication)(using ev: T <:< String): Assertion = {
     // SKIP-DOTTY-START 
     def include(resultOfRegexWordApplication: ResultOfRegexWordApplication)(implicit ev: T <:< String): Assertion = {
     // SKIP-DOTTY-END  
@@ -4542,7 +4542,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                        ^
      * </pre>
      */
-    //DOTTY-ONLY infix def include(expectedSubstring: String)(implicit ev: T <:< String): Assertion = {
+    //DOTTY-ONLY infix def include(expectedSubstring: String)(using ev: T <:< String): Assertion = {
     // SKIP-DOTTY-START 
     def include(expectedSubstring: String)(implicit ev: T <:< String): Assertion = {
     // SKIP-DOTTY-END  
@@ -4578,7 +4578,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      * or a <code>scala.util.matching.Regex</code>.
      * </p>
      */
-    //DOTTY-ONLY infix def fullyMatch(resultOfRegexWordApplication: ResultOfRegexWordApplication)(implicit ev: T <:< String): Assertion = {
+    //DOTTY-ONLY infix def fullyMatch(resultOfRegexWordApplication: ResultOfRegexWordApplication)(using ev: T <:< String): Assertion = {
     // SKIP-DOTTY-START 
     def fullyMatch(resultOfRegexWordApplication: ResultOfRegexWordApplication)(implicit ev: T <:< String): Assertion = {
     // SKIP-DOTTY-END  
@@ -4627,7 +4627,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def oneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit containing: Containing[T]): Assertion = {
+    //DOTTY-ONLY infix def oneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def oneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4661,7 +4661,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def oneElementOf(elements: Iterable[Any])(implicit containing: Containing[T]): Assertion = {
+    //DOTTY-ONLY infix def oneElementOf(elements: Iterable[Any])(using containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def oneElementOf(elements: Iterable[Any])(implicit containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4693,7 +4693,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def atLeastOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit aggregating: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def atLeastOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def atLeastOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4727,7 +4727,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def atLeastOneElementOf(elements: Iterable[Any])(implicit aggregating: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def atLeastOneElementOf(elements: Iterable[Any])(using aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def atLeastOneElementOf(elements: Iterable[Any])(implicit aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4759,7 +4759,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def noneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit containing: Containing[T]): Assertion = {
+    //DOTTY-ONLY infix def noneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def noneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-END
@@ -4793,7 +4793,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def noElementsOf(elements: Iterable[Any])(implicit containing: Containing[T]): Assertion = {
+    //DOTTY-ONLY infix def noElementsOf(elements: Iterable[Any])(using containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def noElementsOf(elements: Iterable[Any])(implicit containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4825,7 +4825,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def theSameElementsAs(right: Iterable[_])(implicit aggregating: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def theSameElementsAs(right: Iterable[_])(using aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def theSameElementsAs(right: Iterable[_])(implicit aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4856,7 +4856,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def theSameElementsInOrderAs(right: Iterable[_])(implicit sequencing: Sequencing[T]): Assertion = {
+    //DOTTY-ONLY infix def theSameElementsInOrderAs(right: Iterable[_])(using sequencing: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def theSameElementsInOrderAs(right: Iterable[_])(implicit sequencing: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4887,7 +4887,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def only(right: Any*)(implicit aggregating: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def only(right: Any*)(using aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def only(right: Any*)(implicit aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4930,7 +4930,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def inOrderOnly(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit sequencing: Sequencing[T]): Assertion = {
+    //DOTTY-ONLY infix def inOrderOnly(firstEle: Any, secondEle: Any, remainingEles: Any*)(using sequencing: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def inOrderOnly(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit sequencing: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4964,7 +4964,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def allOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit aggregating: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def allOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def allOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -4998,7 +4998,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def allElementsOf(elements: Iterable[Any])(implicit aggregating: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def allElementsOf(elements: Iterable[Any])(using aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def allElementsOf(elements: Iterable[Any])(implicit aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  

--- a/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
+++ b/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
@@ -1876,7 +1876,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      * book should have (convertSymbolToHavePropertyMatcherGenerator('title).apply("A Tale of Two Cities"))
      * </pre>
      */
-    def apply(expectedValue: Any): HavePropertyMatcher[AnyRef, Any] =
+    /* DOTTY-ONLY infix */ def apply(expectedValue: Any): HavePropertyMatcher[AnyRef, Any] =
       new HavePropertyMatcher[AnyRef, Any] {
 
         /**
@@ -1902,7 +1902,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
          * </p>
          * TODO continue the story
          */
-        def apply(objectWithProperty: AnyRef): HavePropertyMatchResult[Any] = {
+        /* DOTTY-ONLY infix */ def apply(objectWithProperty: AnyRef): HavePropertyMatchResult[Any] = {
         
           // If 'empty passed, propertyName would be "empty"
           val propertyName = symbol.name
@@ -1969,10 +1969,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *             ^
      * </pre>
      */
-    //DOTTY-ONLY infix def a(aMatcher: AMatcher[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def a(aMatcher: AMatcher[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def a(aMatcher: AMatcher[T]): Assertion = {
       val matcherResult = aMatcher(left)
       if (matcherResult.matches != shouldBeTrue) {
         indicateFailure(if (shouldBeTrue) matcherResult.failureMessage(prettifier) else matcherResult.negatedFailureMessage(prettifier), None, pos)
@@ -1987,10 +1984,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *             ^
      * </pre>
      */
-    //DOTTY-ONLY infix def an(anMatcher: AnMatcher[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def an(anMatcher: AnMatcher[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def an(anMatcher: AnMatcher[T]): Assertion = {
       val matcherResult = anMatcher(left)
       if (matcherResult.matches != shouldBeTrue) {
         indicateFailure(if (shouldBeTrue) matcherResult.failureMessage(prettifier) else matcherResult.negatedFailureMessage(prettifier), None, pos)
@@ -2005,7 +1999,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                  ^
      * </pre>
      */
-    //DOTTY-ONLY infix def theSameInstanceAs(right: AnyRef)(implicit toAnyRef: T <:< AnyRef): Assertion = {
+    //DOTTY-ONLY infix def theSameInstanceAs(right: AnyRef)(using toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-START 
     def theSameInstanceAs(right: AnyRef)(implicit toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-END  
@@ -2046,7 +2040,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def a(symbol: Symbol)(implicit toAnyRef: T <:< AnyRef): Assertion = {
+    //DOTTY-ONLY infix def a(symbol: Symbol)(using toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-START 
     def a(symbol: Symbol)(implicit toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-END  
@@ -2067,7 +2061,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                   ^
      * </pre>
      */
-    //DOTTY-ONLY infix def a(bePropertyMatcher: BePropertyMatcher[T])(implicit ev: T <:< AnyRef): Assertion = { // TODO: Try expanding this to 2.10 AnyVals
+    //DOTTY-ONLY infix def a(bePropertyMatcher: BePropertyMatcher[T])(using ev: T <:< AnyRef): Assertion = { // TODO: Try expanding this to 2.10 AnyVals
     // SKIP-DOTTY-START 
     def a(bePropertyMatcher: BePropertyMatcher[T])(implicit ev: T <:< AnyRef): Assertion = { // TODO: Try expanding this to 2.10 AnyVals
     // SKIP-DOTTY-END
@@ -2087,7 +2081,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                 ^
      * </pre>
      */
-    //DOTTY-ONLY infix def an(symbol: Symbol)(implicit toAnyRef: T <:< AnyRef): Assertion = {
+    //DOTTY-ONLY infix def an(symbol: Symbol)(using toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-START 
     def an(symbol: Symbol)(implicit toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-END  
@@ -2107,7 +2101,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                ^
      * </pre>
      */
-    //DOTTY-ONLY infix def an(beTrueMatcher: BePropertyMatcher[T])(implicit ev: T <:< AnyRef): Assertion = { // TODO: Try expanding this to 2.10 AnyVals
+    //DOTTY-ONLY infix def an(beTrueMatcher: BePropertyMatcher[T])(using ev: T <:< AnyRef): Assertion = { // TODO: Try expanding this to 2.10 AnyVals
     // SKIP-DOTTY-START 
     def an(beTrueMatcher: BePropertyMatcher[T])(implicit ev: T <:< AnyRef): Assertion = { // TODO: Try expanding this to 2.10 AnyVals
     // SKIP-DOTTY-END
@@ -2125,7 +2119,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def definedAt[U](right: U)(implicit ev: T <:< PartialFunction[U, _]): Assertion = {
+    //DOTTY-ONLY infix def definedAt[U](right: U)(using ev: T <:< PartialFunction[U, _]): Assertion = {
     // SKIP-DOTTY-START 
     def definedAt[U](right: U)(implicit ev: T <:< PartialFunction[U, _]): Assertion = {
     // SKIP-DOTTY-END  
@@ -2158,7 +2152,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                                     ^
      * </pre>
      */
-    def apply(regexString: String): ResultOfRegexWordApplication = 
+    /* DOTTY-ONLY infix */ def apply(regexString: String): ResultOfRegexWordApplication = 
       new ResultOfRegexWordApplication(regexString, IndexedSeq.empty)
 
     /**
@@ -2169,7 +2163,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                                     ^
      * </pre>
      */
-    def apply(regex: Regex): ResultOfRegexWordApplication = 
+    /* DOTTY-ONLY infix */ def apply(regex: Regex): ResultOfRegexWordApplication = 
       new ResultOfRegexWordApplication(regex, IndexedSeq.empty)
 
     /**
@@ -2180,7 +2174,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                                    ^
      * </pre>
      */
-    def apply(regexWithGroups: RegexWithGroups) =
+    /* DOTTY-ONLY infix */ def apply(regexWithGroups: RegexWithGroups) =
       new ResultOfRegexWordApplication(regexWithGroups.regex, regexWithGroups.groups)
 
     /**
@@ -2205,10 +2199,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegexString: String): Assertion =
-    // SKIP-DOTTY-START 
-    def regex(rightRegexString: String): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY infix */ def regex(rightRegexString: String): Assertion = 
       regex(rightRegexString.r)
     
     /**
@@ -2219,10 +2210,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(regexWithGroups: RegexWithGroups): Assertion = {
-    // SKIP-DOTTY-START 
-    def regex(regexWithGroups: RegexWithGroups): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def regex(regexWithGroups: RegexWithGroups): Assertion = {
       val result = includeRegexWithGroups(left, regexWithGroups.regex, regexWithGroups.groups)
       if (result.matches != shouldBeTrue)
         indicateFailure(if (shouldBeTrue) result.failureMessage(prettifier) else result.negatedFailureMessage(prettifier), None, pos)
@@ -2237,10 +2225,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegex: Regex): Assertion = {
-    // SKIP-DOTTY-START 
-    def regex(rightRegex: Regex): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def regex(rightRegex: Regex): Assertion = {
       if (rightRegex.findFirstIn(left).isDefined != shouldBeTrue)
         indicateFailure(if (shouldBeTrue) FailureMessages.didNotIncludeRegex(prettifier, left, rightRegex) else FailureMessages.includedRegex(prettifier, left, rightRegex), None, pos)
       else indicateSuccess(shouldBeTrue, FailureMessages.includedRegex(prettifier, left, rightRegex), FailureMessages.didNotIncludeRegex(prettifier, left, rightRegex))
@@ -2270,10 +2255,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegexString: String): Assertion =
-    // SKIP-DOTTY-START 
-    def regex(rightRegexString: String): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY infix */ def regex(rightRegexString: String): Assertion = 
       regex(rightRegexString.r)
 
     /**
@@ -2284,10 +2266,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(regexWithGroups: RegexWithGroups): Assertion = {
-    // SKIP-DOTTY-START 
-    def regex(regexWithGroups: RegexWithGroups): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def regex(regexWithGroups: RegexWithGroups): Assertion = {
       val result = startWithRegexWithGroups(left, regexWithGroups.regex, regexWithGroups.groups)
       if (result.matches != shouldBeTrue)
         indicateFailure(if (shouldBeTrue) result.failureMessage(prettifier) else result.negatedFailureMessage(prettifier), None, pos)
@@ -2302,10 +2281,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegex: Regex): Assertion = {
-    // SKIP-DOTTY-START 
-    def regex(rightRegex: Regex): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def regex(rightRegex: Regex): Assertion = {
       if (rightRegex.pattern.matcher(left).lookingAt != shouldBeTrue)
         indicateFailure(if (shouldBeTrue) FailureMessages.didNotStartWithRegex(prettifier, left, rightRegex) else FailureMessages.startedWithRegex(prettifier, left, rightRegex), None, pos)
       else indicateSuccess(shouldBeTrue, FailureMessages.startedWithRegex(prettifier, left, rightRegex), FailureMessages.didNotStartWithRegex(prettifier, left, rightRegex))
@@ -2335,10 +2311,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegexString: String): Assertion =
-    // SKIP-DOTTY-START 
-    def regex(rightRegexString: String): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY infix */ def regex(rightRegexString: String): Assertion = 
       regex(rightRegexString.r)
 
     /**
@@ -2349,10 +2322,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(regexWithGroups: RegexWithGroups): Assertion = {
-    // SKIP-DOTTY-START 
-    def regex(regexWithGroups: RegexWithGroups): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def regex(regexWithGroups: RegexWithGroups): Assertion = {
       val result = endWithRegexWithGroups(left, regexWithGroups.regex, regexWithGroups.groups)
       if (result.matches != shouldBeTrue)
         indicateFailure(if (shouldBeTrue) result.failureMessage(prettifier) else result.negatedFailureMessage(prettifier), None, pos)
@@ -2367,10 +2337,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegex: Regex): Assertion = {
-    // SKIP-DOTTY-START 
-    def regex(rightRegex: Regex): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def regex(rightRegex: Regex): Assertion = {
       val allMatches = rightRegex.findAllIn(left)
       if ((allMatches.hasNext && (allMatches.end == left.length)) != shouldBeTrue)
         indicateFailure(if (shouldBeTrue) FailureMessages.didNotEndWithRegex(prettifier, left, rightRegex) else FailureMessages.endedWithRegex(prettifier, left, rightRegex), None, pos)
@@ -2401,10 +2368,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegexString: String): Assertion =
-    // SKIP-DOTTY-START 
-    def regex(rightRegexString: String): Assertion = 
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY infix */ def regex(rightRegexString: String): Assertion = 
       regex(rightRegexString.r)
     
 
@@ -2416,10 +2380,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(regexWithGroups: RegexWithGroups): Assertion = {
-    // SKIP-DOTTY-START 
-    def regex(regexWithGroups: RegexWithGroups): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def regex(regexWithGroups: RegexWithGroups): Assertion = {
       val result = fullyMatchRegexWithGroups(left, regexWithGroups.regex, regexWithGroups.groups)
       if (result.matches != shouldBeTrue)
         indicateFailure(if (shouldBeTrue) result.failureMessage(prettifier) else result.negatedFailureMessage(prettifier), None, pos)
@@ -2434,10 +2395,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                          ^
      * </pre>
      */
-    //DOTTY-ONLY infix def regex(rightRegex: Regex): Assertion = {
-    // SKIP-DOTTY-START 
-    def regex(rightRegex: Regex): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def regex(rightRegex: Regex): Assertion = {
       if (rightRegex.pattern.matcher(left).matches != shouldBeTrue)
         indicateFailure(if (shouldBeTrue) FailureMessages.didNotFullyMatchRegex(prettifier, left, rightRegex) else FailureMessages.fullyMatchedRegex(prettifier, left, rightRegex), None, pos)
       else indicateSuccess(shouldBeTrue, FailureMessages.fullyMatchedRegex(prettifier, left, rightRegex), FailureMessages.didNotFullyMatchRegex(prettifier, left, rightRegex))
@@ -2474,7 +2432,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *               ^
    * </pre>
    */
-  def equal[T](spread: Spread[T]): Matcher[T] = {
+  /* DOTTY-ONLY infix */ def equal[T](spread: Spread[T]): Matcher[T] = {
     new Matcher[T] {
       def apply(left: T): MatchResult = {
         MatchResult(
@@ -2496,7 +2454,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *               ^
    * </pre>
    */ 
-  def equal(o: Null): Matcher[AnyRef] =
+  /* DOTTY-ONLY infix */ def equal(o: Null): Matcher[AnyRef] =
     new Matcher[AnyRef] {
       def apply(left: AnyRef): MatchResult = {
         MatchResult(
@@ -2528,7 +2486,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                            ^
      * </pre>
      */
-    def apply(expectedKey: Any): ResultOfKeyWordApplication = 
+    /* DOTTY-ONLY infix */ def apply(expectedKey: Any): ResultOfKeyWordApplication = 
       new ResultOfKeyWordApplication(expectedKey)
 
     /**
@@ -2565,7 +2523,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                            ^
      * </pre>
      */ 
-    def apply(expectedValue: Any): ResultOfValueWordApplication =
+    /* DOTTY-ONLY infix */ def apply(expectedValue: Any): ResultOfValueWordApplication =
       new ResultOfValueWordApplication(expectedValue)
 
     /**
@@ -2602,7 +2560,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                         ^
      * </pre>
      */
-    def apply(symbol: Symbol): ResultOfAWordToSymbolApplication =
+    /* DOTTY-ONLY infix */ def apply(symbol: Symbol): ResultOfAWordToSymbolApplication =
       new ResultOfAWordToSymbolApplication(symbol)
 
     /**
@@ -2614,7 +2572,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                         ^
      * </pre>
      */
-    def apply[T](beTrueMatcher: BePropertyMatcher[T]): ResultOfAWordToBePropertyMatcherApplication[T] = 
+    /* DOTTY-ONLY infix */ def apply[T](beTrueMatcher: BePropertyMatcher[T]): ResultOfAWordToBePropertyMatcherApplication[T] = 
       new ResultOfAWordToBePropertyMatcherApplication(beTrueMatcher)
 
     /**
@@ -2625,7 +2583,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                        ^
      * </pre>
      */
-    def apply[T](aMatcher: AMatcher[T]): ResultOfAWordToAMatcherApplication[T] = 
+    /* DOTTY-ONLY infix */ def apply[T](aMatcher: AMatcher[T]): ResultOfAWordToAMatcherApplication[T] = 
       new ResultOfAWordToAMatcherApplication(aMatcher)
 
     /**
@@ -2662,7 +2620,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                          ^
      * </pre>
      */
-    def apply(symbol: Symbol): ResultOfAnWordToSymbolApplication = 
+    /* DOTTY-ONLY infix */ def apply(symbol: Symbol): ResultOfAnWordToSymbolApplication = 
       new ResultOfAnWordToSymbolApplication(symbol)
 
     /**
@@ -2674,7 +2632,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                          ^
      * </pre>
      */
-    def apply[T](beTrueMatcher: BePropertyMatcher[T]): ResultOfAnWordToBePropertyMatcherApplication[T] = 
+    /* DOTTY-ONLY infix */ def apply[T](beTrueMatcher: BePropertyMatcher[T]): ResultOfAnWordToBePropertyMatcherApplication[T] = 
       new ResultOfAnWordToBePropertyMatcherApplication(beTrueMatcher)
 
     /**
@@ -2685,7 +2643,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                         ^
      * </pre>
      */
-    def apply[T](anMatcher: AnMatcher[T]): ResultOfAnWordToAnMatcherApplication[T] = 
+    /* DOTTY-ONLY infix */ def apply[T](anMatcher: AnMatcher[T]): ResultOfAnWordToAnMatcherApplication[T] = 
       new ResultOfAnWordToAnMatcherApplication(anMatcher)
 
     /**
@@ -2722,7 +2680,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                                           ^
      * </pre>
      */
-    def apply(anyRef: AnyRef): ResultOfTheSameInstanceAsApplication =
+    /* DOTTY-ONLY infix */ def apply(anyRef: AnyRef): ResultOfTheSameInstanceAsApplication =
       new ResultOfTheSameInstanceAsApplication(anyRef)
 
     /**
@@ -2776,7 +2734,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      * <code>scala.Seq</code>, <code>java.lang.String</code>, and <code>java.util.List</code>.
      * </p>
      */
-    //DOTTY-ONLY infix def length(expectedLength: Long)(implicit len: Length[A]): Assertion = {
+    //DOTTY-ONLY infix def length(expectedLength: Long)(using len: Length[A]): Assertion = {
     // SKIP-DOTTY-START 
     def length(expectedLength: Long)(implicit len: Length[A]): Assertion = {
     // SKIP-DOTTY-END  
@@ -2801,7 +2759,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      * <code>Traversable</code> and <code>java.util.Collection</code>.
      * </p>
      */
-    //DOTTY-ONLY infix def size(expectedSize: Long)(implicit sz: Size[A]): Assertion = {
+    //DOTTY-ONLY infix def size(expectedSize: Long)(using sz: Size[A]): Assertion = {
     // SKIP-DOTTY-START 
     def size(expectedSize: Long)(implicit sz: Size[A]): Assertion = {
     // SKIP-DOTTY-END  
@@ -2819,7 +2777,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def message(expectedMessage: String)(implicit messaging: Messaging[A]): Assertion = {
+    //DOTTY-ONLY infix def message(expectedMessage: String)(using messaging: Messaging[A]): Assertion = {
     // SKIP-DOTTY-START 
     def message(expectedMessage: String)(implicit messaging: Messaging[A]): Assertion = {
     // SKIP-DOTTY-END  
@@ -2844,8 +2802,11 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    * num should (not be &lt; (10) and not be &gt; (17))
    *                    ^
    * </pre>
-   */ 
+   */
+  //DOTTY-ONLY infix def <[T : Ordering] (right: T): ResultOfLessThanComparison[T] =
+  // SKIP-DOTTY-START  
   def <[T : Ordering] (right: T): ResultOfLessThanComparison[T] =
+  // SKIP-DOTTY-END
     new ResultOfLessThanComparison(right)
 
   /**
@@ -2855,8 +2816,11 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    * num should (not be &gt; (10) and not be &lt; (7))
    *                    ^
    * </pre>
-   */ 
+   */
+  //DOTTY-ONLY infix def >[T : Ordering] (right: T): ResultOfGreaterThanComparison[T] =
+  // SKIP-DOTTY-START  
   def >[T : Ordering] (right: T): ResultOfGreaterThanComparison[T] =
+  // SKIP-DOTTY-END
     new ResultOfGreaterThanComparison(right)
 
   /**
@@ -2867,7 +2831,10 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                    ^
    * </pre>
    */ 
+  //DOTTY-ONLY infix def <=[T : Ordering] (right: T): ResultOfLessThanOrEqualToComparison[T] =
+  // SKIP-DOTTY-START 
   def <=[T : Ordering] (right: T): ResultOfLessThanOrEqualToComparison[T] =
+  // SKIP-DOTTY-END
     new ResultOfLessThanOrEqualToComparison(right)
 
   /**
@@ -2878,7 +2845,10 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                    ^
    * </pre>
    */ 
+  //DOTTY-ONLY infix def >=[T : Ordering] (right: T): ResultOfGreaterThanOrEqualToComparison[T] =
+  // SKIP-DOTTY-START 
   def >=[T : Ordering] (right: T): ResultOfGreaterThanOrEqualToComparison[T] =
+  // SKIP-DOTTY-END
     new ResultOfGreaterThanOrEqualToComparison(right)
 
   /**
@@ -2889,7 +2859,10 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                     ^
    * </pre>
    */
+  //DOTTY-ONLY infix def definedAt[T](right: T): ResultOfDefinedAt[T] =
+  // SKIP-DOTTY-START 
   def definedAt[T](right: T): ResultOfDefinedAt[T] =
+  // SKIP-DOTTY-END
     new ResultOfDefinedAt(right)
 
   /**
@@ -2900,7 +2873,10 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
+  //DOTTY-ONLY infix def oneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using pos: source.Position) = { 
+  // SKIP-DOTTY-START 
   def oneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit pos: source.Position) = {
+  // SKIP-DOTTY-END
     val xs = firstEle :: secondEle :: remainingEles.toList
     if (xs.distinct.size != xs.size)
       throw new NotAllowedException(FailureMessages.oneOfDuplicate, pos)
@@ -2915,7 +2891,10 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
+  //DOTTY-ONLY infix def oneElementOf(elements: Iterable[Any]) = {
+  // SKIP-DOTTY-START 
   def oneElementOf(elements: Iterable[Any]) = {
+  // SKIP-DOTTY-END  
     val xs = elements.toList
     new ResultOfOneElementOfApplication(xs)
   }
@@ -2928,7 +2907,10 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
+  //DOTTY-ONLY infix def atLeastOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using pos: source.Position) = { 
+  // SKIP-DOTTY-START
   def atLeastOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit pos: source.Position) = {
+  // SKIP-DOTTY-END
     val xs = firstEle :: secondEle :: remainingEles.toList
     if (xs.distinct.size != xs.size)
       throw new NotAllowedException(FailureMessages.atLeastOneOfDuplicate, pos)
@@ -2943,7 +2925,10 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
+  //DOTTY-ONLY infix def atLeastOneElementOf(elements: Iterable[Any]) = {
+  // SKIP-DOTTY-START
   def atLeastOneElementOf(elements: Iterable[Any]) = {
+  // SKIP-DOTTY-END  
     val xs = elements.toList
     new ResultOfAtLeastOneElementOfApplication(xs)
   }
@@ -2956,7 +2941,10 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
+  //DOTTY-ONLY infix def noneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using pos: source.Position) = {
+  // SKIP-DOTTY-START 
   def noneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit pos: source.Position) = {
+  // SKIP-DOTTY-END
     val xs = firstEle :: secondEle :: remainingEles.toList
     if (xs.distinct.size != xs.size)
       throw new NotAllowedException(FailureMessages.noneOfDuplicate, pos)
@@ -2971,7 +2959,10 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
+  //DOTTY-ONLY infix def noElementsOf(elements: Iterable[Any]) = {
+  // SKIP-DOTTY-START 
   def noElementsOf(elements: Iterable[Any]) = {
+  // SKIP-DOTTY-END
     val xs = elements.toList
     new ResultOfNoElementsOfApplication(xs)
   }
@@ -2984,7 +2975,10 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
+  //DOTTY-ONLY infix def theSameElementsAs(xs: Iterable[_]) = 
+  // SKIP-DOTTY-START 
   def theSameElementsAs(xs: Iterable[_]) = 
+  // SKIP-DOTTY-END
     new ResultOfTheSameElementsAsApplication(xs)
 
   /**

--- a/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
+++ b/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
@@ -2803,10 +2803,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                    ^
    * </pre>
    */
-  //DOTTY-ONLY infix def <[T : Ordering] (right: T): ResultOfLessThanComparison[T] =
-  // SKIP-DOTTY-START  
-  def <[T : Ordering] (right: T): ResultOfLessThanComparison[T] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def <[T : Ordering] (right: T): ResultOfLessThanComparison[T] =
     new ResultOfLessThanComparison(right)
 
   /**
@@ -2817,10 +2814,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                    ^
    * </pre>
    */
-  //DOTTY-ONLY infix def >[T : Ordering] (right: T): ResultOfGreaterThanComparison[T] =
-  // SKIP-DOTTY-START  
-  def >[T : Ordering] (right: T): ResultOfGreaterThanComparison[T] =
-  // SKIP-DOTTY-END
+ /* DOTTY-ONLY infix */ def >[T : Ordering] (right: T): ResultOfGreaterThanComparison[T] =
     new ResultOfGreaterThanComparison(right)
 
   /**
@@ -2831,10 +2825,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                    ^
    * </pre>
    */ 
-  //DOTTY-ONLY infix def <=[T : Ordering] (right: T): ResultOfLessThanOrEqualToComparison[T] =
-  // SKIP-DOTTY-START 
-  def <=[T : Ordering] (right: T): ResultOfLessThanOrEqualToComparison[T] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def <=[T : Ordering] (right: T): ResultOfLessThanOrEqualToComparison[T] =
     new ResultOfLessThanOrEqualToComparison(right)
 
   /**
@@ -2845,10 +2836,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                    ^
    * </pre>
    */ 
-  //DOTTY-ONLY infix def >=[T : Ordering] (right: T): ResultOfGreaterThanOrEqualToComparison[T] =
-  // SKIP-DOTTY-START 
-  def >=[T : Ordering] (right: T): ResultOfGreaterThanOrEqualToComparison[T] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def >=[T : Ordering] (right: T): ResultOfGreaterThanOrEqualToComparison[T] =
     new ResultOfGreaterThanOrEqualToComparison(right)
 
   /**
@@ -2859,10 +2847,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                     ^
    * </pre>
    */
-  //DOTTY-ONLY infix def definedAt[T](right: T): ResultOfDefinedAt[T] =
-  // SKIP-DOTTY-START 
-  def definedAt[T](right: T): ResultOfDefinedAt[T] =
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def definedAt[T](right: T): ResultOfDefinedAt[T] =
     new ResultOfDefinedAt(right)
 
   /**
@@ -2891,10 +2876,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
-  //DOTTY-ONLY infix def oneElementOf(elements: Iterable[Any]) = {
-  // SKIP-DOTTY-START 
-  def oneElementOf(elements: Iterable[Any]) = {
-  // SKIP-DOTTY-END  
+  /* DOTTY-ONLY infix */ def oneElementOf(elements: Iterable[Any]) = {
     val xs = elements.toList
     new ResultOfOneElementOfApplication(xs)
   }
@@ -2925,10 +2907,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
-  //DOTTY-ONLY infix def atLeastOneElementOf(elements: Iterable[Any]) = {
-  // SKIP-DOTTY-START
-  def atLeastOneElementOf(elements: Iterable[Any]) = {
-  // SKIP-DOTTY-END  
+  /* DOTTY-ONLY infix */ def atLeastOneElementOf(elements: Iterable[Any]) = {
     val xs = elements.toList
     new ResultOfAtLeastOneElementOfApplication(xs)
   }
@@ -2959,10 +2938,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
-  //DOTTY-ONLY infix def noElementsOf(elements: Iterable[Any]) = {
-  // SKIP-DOTTY-START 
-  def noElementsOf(elements: Iterable[Any]) = {
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def noElementsOf(elements: Iterable[Any]) = {
     val xs = elements.toList
     new ResultOfNoElementsOfApplication(xs)
   }

--- a/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
+++ b/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
@@ -5030,7 +5030,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def inOrder(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit sequencing: Sequencing[T]): Assertion = {
+    //DOTTY-ONLY infix def inOrder(firstEle: Any, secondEle: Any, remainingEles: Any*)(using sequencing: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def inOrder(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit sequencing: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -5064,7 +5064,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def inOrderElementsOf(elements: Iterable[Any])(implicit sequencing: Sequencing[T]): Assertion = {
+    //DOTTY-ONLY infix def inOrderElementsOf(elements: Iterable[Any])(using sequencing: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def inOrderElementsOf(elements: Iterable[Any])(implicit sequencing: Sequencing[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -5096,7 +5096,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                        ^
      * </pre>
      */
-    //DOTTY-ONLY infix def atMostOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit aggregating: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def atMostOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def atMostOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -5130,7 +5130,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                        ^
      * </pre>
      */
-    //DOTTY-ONLY infix def atMostOneElementOf(elements: Iterable[Any])(implicit aggregating: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def atMostOneElementOf(elements: Iterable[Any])(using aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def atMostOneElementOf(elements: Iterable[Any])(implicit aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -5162,7 +5162,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                              ^
      * </pre>
      */
-    //DOTTY-ONLY infix def key(expectedKey: Any)(implicit keyMapping: KeyMapping[T]): Assertion = {
+    //DOTTY-ONLY infix def key(expectedKey: Any)(using keyMapping: KeyMapping[T]): Assertion = {
     // SKIP-DOTTY-START 
     def key(expectedKey: Any)(implicit keyMapping: KeyMapping[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -5193,7 +5193,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                              ^
      * </pre>
      */
-    //DOTTY-ONLY infix def value(expectedValue: Any)(implicit valueMapping: ValueMapping[T]): Assertion = {
+    //DOTTY-ONLY infix def value(expectedValue: Any)(using valueMapping: ValueMapping[T]): Assertion = {
     // SKIP-DOTTY-START 
     def value(expectedValue: Any)(implicit valueMapping: ValueMapping[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -5242,7 +5242,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                   ^
      * </pre>
      */
-    //DOTTY-ONLY infix def theSameInstanceAs(right: AnyRef)(implicit toAnyRef: T <:< AnyRef): Assertion = {
+    //DOTTY-ONLY infix def theSameInstanceAs(right: AnyRef)(using toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-START 
     def theSameInstanceAs(right: AnyRef)(implicit toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-END  
@@ -5274,7 +5274,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                   ^
      * </pre>
      */
-    //DOTTY-ONLY infix def a(symbol: Symbol)(implicit toAnyRef: T <:< AnyRef): Assertion = {
+    //DOTTY-ONLY infix def a(symbol: Symbol)(using toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-START 
     def a(symbol: Symbol)(implicit toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-END  
@@ -5307,7 +5307,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                   ^
      * </pre>
      */
-    //DOTTY-ONLY infix def an(symbol: Symbol)(implicit toAnyRef: T <:< AnyRef): Assertion = {
+    //DOTTY-ONLY infix def an(symbol: Symbol)(using toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-START 
     def an(symbol: Symbol)(implicit toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-END  
@@ -5342,7 +5342,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                      ^
      * </pre>
      */
-    //DOTTY-ONLY infix def a[U <: T](bePropertyMatcher: BePropertyMatcher[U])(implicit ev: T <:< AnyRef): Assertion = { // TODO: Try supporting 2.10 AnyVals
+    //DOTTY-ONLY infix def a[U <: T](bePropertyMatcher: BePropertyMatcher[U])(using ev: T <:< AnyRef): Assertion = { // TODO: Try supporting 2.10 AnyVals
     // SKIP-DOTTY-START 
     def a[U <: T](bePropertyMatcher: BePropertyMatcher[U])(implicit ev: T <:< AnyRef): Assertion = { // TODO: Try supporting 2.10 AnyVals
     // SKIP-DOTTY-END
@@ -5376,7 +5376,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                      ^
      * </pre>
      */
-    //DOTTY-ONLY infix def an[U <: T](beTrueMatcher: BePropertyMatcher[U])(implicit ev: T <:< AnyRef): Assertion = { // TODO: Try supporting 2.10 AnyVals
+    //DOTTY-ONLY infix def an[U <: T](beTrueMatcher: BePropertyMatcher[U])(using ev: T <:< AnyRef): Assertion = { // TODO: Try supporting 2.10 AnyVals
     // SKIP-DOTTY-START 
     def an[U <: T](beTrueMatcher: BePropertyMatcher[U])(implicit ev: T <:< AnyRef): Assertion = { // TODO: Try supporting 2.10 AnyVals
     // SKIP-DOTTY-END
@@ -5409,7 +5409,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                   ^
      * </pre>
      */
-    //DOTTY-ONLY infix def definedAt[U](right: U)(implicit ev: T <:< PartialFunction[U, _]): Assertion = {
+    //DOTTY-ONLY infix def definedAt[U](right: U)(using ev: T <:< PartialFunction[U, _]): Assertion = {
     // SKIP-DOTTY-START 
     def definedAt[U](right: U)(implicit ev: T <:< PartialFunction[U, _]): Assertion = {
     // SKIP-DOTTY-END  
@@ -5459,7 +5459,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                           ^
      * </pre>
      */
-    def apply(right: Symbol): Matcher[Array[T]] =
+    /* DOTTY-ONLY infix */ def apply(right: Symbol): Matcher[Array[T]] =
       new Matcher[Array[T]] {
         def apply(left: Array[T]): MatchResult = matchSymbolToPredicateMethod(deep(left), right, false, false, prettifier, pos)
       }
@@ -5512,10 +5512,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def should(rightMatcher: Matcher[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def should(rightMatcher: Matcher[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def should(rightMatcher: Matcher[T]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         val result = rightMatcher(e)
         result match {
@@ -5545,7 +5542,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *          ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldEqual(right: Any)(implicit equality: Equality[T]): Assertion = {
+    //DOTTY-ONLY infix def shouldEqual(right: Any)(using equality: Equality[T]): Assertion = {
     // SKIP-DOTTY-START 
     def shouldEqual(right: Any)(implicit equality: Equality[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -5567,10 +5564,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *        ^doCollected
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldEqual(spread: Spread[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def shouldEqual(spread: Spread[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def shouldEqual(spread: Spread[T]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         if (!spread.isWithin(e)) {
           indicateFailure(FailureMessages.didNotEqualPlusOrMinus(prettifier, e, spread.pivot, spread.tolerance), None, pos)
@@ -5587,7 +5581,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(sortedWord: SortedWord)(implicit sortable: Sortable[T]): Assertion = {
+    //DOTTY-ONLY infix def shouldBe(sortedWord: SortedWord)(using sortable: Sortable[T]): Assertion = {
     // SKIP-DOTTY-START 
     def shouldBe(sortedWord: SortedWord)(implicit sortable: Sortable[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -5606,7 +5600,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(readableWord: ReadableWord)(implicit readability: Readability[T]): Assertion = {
+    //DOTTY-ONLY infix def shouldBe(readableWord: ReadableWord)(using readability: Readability[T]): Assertion = {
     // SKIP-DOTTY-START 
     def shouldBe(readableWord: ReadableWord)(implicit readability: Readability[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -5625,7 +5619,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(writableWord: WritableWord)(implicit writability: Writability[T]): Assertion = {
+    //DOTTY-ONLY infix def shouldBe(writableWord: WritableWord)(using writability: Writability[T]): Assertion = {
     // SKIP-DOTTY-START 
     def shouldBe(writableWord: WritableWord)(implicit writability: Writability[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -5644,7 +5638,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(emptyWord: EmptyWord)(implicit emptiness: Emptiness[T]): Assertion = {
+    //DOTTY-ONLY infix def shouldBe(emptyWord: EmptyWord)(using emptiness: Emptiness[T]): Assertion = {
     // SKIP-DOTTY-START 
     def shouldBe(emptyWord: EmptyWord)(implicit emptiness: Emptiness[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -5663,7 +5657,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(definedWord: DefinedWord)(implicit definition: Definition[T]): Assertion = {
+    //DOTTY-ONLY infix def shouldBe(definedWord: DefinedWord)(using definition: Definition[T]): Assertion = {
     // SKIP-DOTTY-START 
     def shouldBe(definedWord: DefinedWord)(implicit definition: Definition[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -5682,10 +5676,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(aType: ResultOfATypeInvocation[_]): Assertion = {
-    // SKIP-DOTTY-START 
-    def shouldBe(aType: ResultOfATypeInvocation[_]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def shouldBe(aType: ResultOfATypeInvocation[_]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         if (!aType.clazz.isAssignableFrom(e.getClass))
           indicateFailure(FailureMessages.wasNotAnInstanceOf(prettifier, e, UnquotedString(aType.clazz.getName), UnquotedString(e.getClass.getName)), None, pos)
@@ -5701,10 +5692,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(anType: ResultOfAnTypeInvocation[_]): Assertion = {
-    // SKIP-DOTTY-START 
-    def shouldBe(anType: ResultOfAnTypeInvocation[_]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def shouldBe(anType: ResultOfAnTypeInvocation[_]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         if (!anType.clazz.isAssignableFrom(e.getClass))
           indicateFailure(FailureMessages.wasNotAnInstanceOf(prettifier, e, UnquotedString(anType.clazz.getName), UnquotedString(e.getClass.getName)), None, pos)
@@ -5720,7 +5708,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *        ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldEqual(right: Null)(implicit ev: T <:< AnyRef): Assertion = {
+    //DOTTY-ONLY infix def shouldEqual(right: Null)(using ev: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-START 
     def shouldEqual(right: Null)(implicit ev: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-END  
@@ -5740,7 +5728,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def should[TYPECLASS1[_]](rightMatcherFactory1: MatcherFactory1[T, TYPECLASS1])(implicit typeClass1: TYPECLASS1[T]): Assertion = {
+    //DOTTY-ONLY infix def should[TYPECLASS1[_]](rightMatcherFactory1: MatcherFactory1[T, TYPECLASS1])(using typeClass1: TYPECLASS1[T]): Assertion = {
     // SKIP-DOTTY-START 
     def should[TYPECLASS1[_]](rightMatcherFactory1: MatcherFactory1[T, TYPECLASS1])(implicit typeClass1: TYPECLASS1[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -5774,7 +5762,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def should[TYPECLASS1[_], TYPECLASS2[_]](rightMatcherFactory2: MatcherFactory2[T, TYPECLASS1, TYPECLASS2])(implicit typeClass1: TYPECLASS1[T], typeClass2: TYPECLASS2[T]): Assertion = {
+    //DOTTY-ONLY infix def should[TYPECLASS1[_], TYPECLASS2[_]](rightMatcherFactory2: MatcherFactory2[T, TYPECLASS1, TYPECLASS2])(using typeClass1: TYPECLASS1[T], typeClass2: TYPECLASS2[T]): Assertion = {
     // SKIP-DOTTY-START 
     def should[TYPECLASS1[_], TYPECLASS2[_]](rightMatcherFactory2: MatcherFactory2[T, TYPECLASS1, TYPECLASS2])(implicit typeClass1: TYPECLASS1[T], typeClass2: TYPECLASS2[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -5808,10 +5796,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def should(beWord: BeWord): ResultOfBeWordForCollectedAny[T] =
-    // SKIP-DOTTY-START 
-    def should(beWord: BeWord): ResultOfBeWordForCollectedAny[T] =
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY infix */ def should(beWord: BeWord): ResultOfBeWordForCollectedAny[T] =
       new ResultOfBeWordForCollectedAny[T](collected, xs, original, true, prettifier, pos)
 
     /**
@@ -5822,10 +5807,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def should(notWord: NotWord): ResultOfNotWordForCollectedAny[T] =
-    // SKIP-DOTTY-START 
-    def should(notWord: NotWord): ResultOfNotWordForCollectedAny[T] =
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY infix */ def should(notWord: NotWord): ResultOfNotWordForCollectedAny[T] =
       new ResultOfNotWordForCollectedAny(collected, xs, original, false, prettifier, pos)
 
     /**
@@ -5838,10 +5820,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *        ^
      * </pre>
      */
-    //DOTTY-ONLY infix def should(haveWord: HaveWord): ResultOfHaveWordForCollectedExtent[T] =
-    // SKIP-DOTTY-START 
-    def should(haveWord: HaveWord): ResultOfHaveWordForCollectedExtent[T] =
-    // SKIP-DOTTY-END
+    /* DOTTY-ONLY infix */ def should(haveWord: HaveWord): ResultOfHaveWordForCollectedExtent[T] =
       new ResultOfHaveWordForCollectedExtent(collected, xs, original, true, prettifier, pos)
 
     /**
@@ -5853,9 +5832,9 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      * </pre>
      */
     // SKIP-DOTTY-START 
-    def shouldBe(right: Any): Assertion = {
+    def shouldBe[R](right: Any): Assertion = {
     // SKIP-DOTTY-END
-    //DOTTY-ONLY infix def shouldBe[R](right: R)(implicit caneq: scala.CanEqual[T, R]): Assertion = {
+    //DOTTY-ONLY infix def shouldBe[R](right: R)(using caneq: scala.CanEqual[T, R]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         if (e != right) {
           val (eee, rightee) = Suite.getObjectsForFailureMessage(e, right)
@@ -5873,10 +5852,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *              ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(comparison: ResultOfLessThanComparison[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def shouldBe(comparison: ResultOfLessThanComparison[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def shouldBe(comparison: ResultOfLessThanComparison[T]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         if (!comparison(e)) {
           indicateFailure(
@@ -5900,10 +5876,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *              ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(comparison: ResultOfLessThanOrEqualToComparison[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def shouldBe(comparison: ResultOfLessThanOrEqualToComparison[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def shouldBe(comparison: ResultOfLessThanOrEqualToComparison[T]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         if (!comparison(e)) {
           indicateFailure(
@@ -5927,10 +5900,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *               ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(comparison: ResultOfGreaterThanComparison[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def shouldBe(comparison: ResultOfGreaterThanComparison[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def shouldBe(comparison: ResultOfGreaterThanComparison[T]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         if (!comparison(e)) {
           indicateFailure(
@@ -5954,10 +5924,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *               ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(comparison: ResultOfGreaterThanOrEqualToComparison[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def shouldBe(comparison: ResultOfGreaterThanOrEqualToComparison[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def shouldBe(comparison: ResultOfGreaterThanOrEqualToComparison[T]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         if (!comparison(e)) {
           indicateFailure(
@@ -5981,10 +5948,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(beMatcher: BeMatcher[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def shouldBe(beMatcher: BeMatcher[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def shouldBe(beMatcher: BeMatcher[T]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         val result = beMatcher.apply(e)
         if (!result.matches)
@@ -6001,10 +5965,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(spread: Spread[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def shouldBe(spread: Spread[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def shouldBe(spread: Spread[T]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         if (!spread.isWithin(e))
           indicateFailure(FailureMessages.wasNotPlusOrMinus(prettifier, e, spread.pivot, spread.tolerance), None, pos)
@@ -6020,7 +5981,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(resultOfSameInstanceAsApplication: ResultOfTheSameInstanceAsApplication)(implicit toAnyRef: T <:< AnyRef): Assertion = {
+    //DOTTY-ONLY infix def shouldBe(resultOfSameInstanceAsApplication: ResultOfTheSameInstanceAsApplication)(using toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-START 
     def shouldBe(resultOfSameInstanceAsApplication: ResultOfTheSameInstanceAsApplication)(implicit toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-END  
@@ -6047,7 +6008,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(symbol: Symbol)(implicit toAnyRef: T <:< AnyRef): Assertion = {
+    //DOTTY-ONLY infix def shouldBe(symbol: Symbol)(using toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-START 
     def shouldBe(symbol: Symbol)(implicit toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-END  
@@ -6067,7 +6028,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
      *         ^
      * </pre>
      */
-    //DOTTY-ONLY infix def shouldBe(resultOfAWordApplication: ResultOfAWordToSymbolApplication)(implicit toAnyRef: T <:< AnyRef): Assertion = {
+    //DOTTY-ONLY infix def shouldBe(resultOfAWordApplication: ResultOfAWordToSymbolApplication)(using toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-START 
     def shouldBe(resultOfAWordApplication: ResultOfAWordToSymbolApplication)(implicit toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-END  

--- a/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
+++ b/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
@@ -2951,10 +2951,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
-  //DOTTY-ONLY infix def theSameElementsAs(xs: Iterable[_]) = 
-  // SKIP-DOTTY-START 
-  def theSameElementsAs(xs: Iterable[_]) = 
-  // SKIP-DOTTY-END
+  /* DOTTY-ONLY infix */ def theSameElementsAs(xs: Iterable[_]) = 
     new ResultOfTheSameElementsAsApplication(xs)
 
   /**
@@ -2965,7 +2962,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
-  def theSameElementsInOrderAs(xs: Iterable[_]) = 
+  /* DOTTY-ONLY infix */ def theSameElementsInOrderAs(xs: Iterable[_]) = 
     new ResultOfTheSameElementsInOrderAsApplication(xs)
 
   /**
@@ -2976,7 +2973,10 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
+  //DOTTY-ONLY infix def only(xs: Any*)(using pos: source.Position) = {
+  // SKIP-DOTTY-START 
   def only(xs: Any*)(implicit pos: source.Position) = {
+  // SKIP-DOTTY-END  
     if (xs.isEmpty)
       throw new NotAllowedException(FailureMessages.onlyEmpty, pos)
     if (xs.distinct.size != xs.size)
@@ -2992,7 +2992,10 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
+  //DOTTY-ONLY infix def inOrderOnly[T](firstEle: Any, secondEle: Any, remainingEles: Any*)(using pos: source.Position) = {
+  // SKIP-DOTTY-START 
   def inOrderOnly[T](firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit pos: source.Position) = {
+  // SKIP-DOTTY-END  
     val xs = firstEle :: secondEle :: remainingEles.toList
     if (xs.distinct.size != xs.size)
       throw new NotAllowedException(FailureMessages.inOrderOnlyDuplicate, pos)
@@ -3007,7 +3010,10 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
+  //DOTTY-ONLY infix def allOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using pos: source.Position) = {
+  // SKIP-DOTTY-START 
   def allOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit pos: source.Position) = {
+  // SKIP-DOTTY-END  
     val xs = firstEle :: secondEle :: remainingEles.toList
     if (xs.distinct.size != xs.size)
       throw new NotAllowedException(FailureMessages.allOfDuplicate, pos)
@@ -3022,7 +3028,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
-  def allElementsOf[R](elements: Iterable[R]) = {
+  /* DOTTY-ONLY infix */ def allElementsOf[R](elements: Iterable[R]) = {
     val xs = elements.toList
     new ResultOfAllElementsOfApplication(xs)
   }
@@ -3035,7 +3041,10 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
+  //DOTTY-ONLY infix def inOrder(firstEle: Any, secondEle: Any, remainingEles: Any*)(using pos: source.Position) = {
+  // SKIP-DOTTY-START 
   def inOrder(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit pos: source.Position) = {
+  // SKIP-DOTTY-END
     val xs = firstEle :: secondEle :: remainingEles.toList
     if (xs.distinct.size != xs.size)
       throw new NotAllowedException(FailureMessages.inOrderDuplicate, pos)
@@ -3050,7 +3059,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
-  def inOrderElementsOf[R](elements: Iterable[R]) = {
+  /* DOTTY-ONLY infix */ def inOrderElementsOf[R](elements: Iterable[R]) = {
     val xs = elements.toList
     new ResultOfInOrderElementsOfApplication(xs)
   }
@@ -3063,7 +3072,10 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
+  //DOTTY-ONLY infix def atMostOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(using pos: source.Position) = {
+  // SKIP-DOTTY-START 
   def atMostOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*)(implicit pos: source.Position) = {
+  // SKIP-DOTTY-END  
     val xs = firstEle :: secondEle :: remainingEles.toList
     if (xs.distinct.size != xs.size)
       throw new NotAllowedException(FailureMessages.atMostOneOfDuplicate, pos)
@@ -3078,7 +3090,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                               ^
    * </pre>
    */
-  def atMostOneElementOf[R](elements: Iterable[R]) = {
+  /* DOTTY-ONLY infix */ def atMostOneElementOf[R](elements: Iterable[R]) = {
     val xs = elements.toList
     new ResultOfAtMostOneElementOfApplication(xs)
   }
@@ -3091,7 +3103,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                                ^
    * </pre>
    */
-  def thrownBy(fun: => Any) = 
+  /* DOTTY-ONLY infix */ def thrownBy(fun: => Any) = 
     new ResultOfThrownByApplication(fun)
 
   /**
@@ -3102,7 +3114,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
    *                           ^
    * </pre>
    */
-  def message(expectedMessage: String) = 
+  /* DOTTY-ONLY infix */ def message(expectedMessage: String) = 
     new ResultOfMessageWordApplication(expectedMessage)
 
 /*
@@ -3208,7 +3220,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def equal(right: Any)(implicit equality: Equality[T]): Assertion = {
+    //DOTTY-ONLY infix def equal(right: Any)(using equality: Equality[T]): Assertion = {
     // SKIP-DOTTY-START 
     def equal(right: Any)(implicit equality: Equality[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -3227,10 +3239,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(right: Any): Assertion = {
-    // SKIP-DOTTY-START 
-    def be(right: Any): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def be(right: Any): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         if ((e == right) != shouldBeTrue)
           indicateFailure(if (shouldBeTrue) FailureMessages.wasNotEqualTo(prettifier, e, right) else FailureMessages.wasEqualTo(prettifier, e, right), None, pos)
@@ -3246,10 +3255,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(comparison: ResultOfLessThanOrEqualToComparison[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def be(comparison: ResultOfLessThanOrEqualToComparison[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def be(comparison: ResultOfLessThanOrEqualToComparison[T]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         if (comparison(e) != shouldBeTrue) {
           indicateFailure(if (shouldBeTrue) FailureMessages.wasNotLessThanOrEqualTo(prettifier, e, comparison.right) else FailureMessages.wasLessThanOrEqualTo(prettifier, e, comparison.right), None, pos)
@@ -3266,10 +3272,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(comparison: ResultOfGreaterThanOrEqualToComparison[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def be(comparison: ResultOfGreaterThanOrEqualToComparison[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def be(comparison: ResultOfGreaterThanOrEqualToComparison[T]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         if (comparison(e) != shouldBeTrue) {
           indicateFailure(if (shouldBeTrue) FailureMessages.wasNotGreaterThanOrEqualTo(prettifier, e, comparison.right) else FailureMessages.wasGreaterThanOrEqualTo(prettifier, e, comparison.right), None, pos)
@@ -3286,10 +3289,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(comparison: ResultOfLessThanComparison[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def be(comparison: ResultOfLessThanComparison[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def be(comparison: ResultOfLessThanComparison[T]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         if (comparison(e) != shouldBeTrue) {
           indicateFailure(if (shouldBeTrue) FailureMessages.wasNotLessThan(prettifier, e, comparison.right) else FailureMessages.wasLessThan(prettifier, e, comparison.right), None, pos)
@@ -3306,10 +3306,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(comparison: ResultOfGreaterThanComparison[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def be(comparison: ResultOfGreaterThanComparison[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def be(comparison: ResultOfGreaterThanComparison[T]): Assertion = {  
       doCollected(collected, xs, original, prettifier, pos) { e =>
         if (comparison(e) != shouldBeTrue) {
           indicateFailure(if (shouldBeTrue) FailureMessages.wasNotGreaterThan(prettifier, e, comparison.right) else FailureMessages.wasGreaterThan(prettifier, e, comparison.right), None, pos)
@@ -3331,10 +3328,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      * </p>
      */
     @deprecated("The deprecation period for the be === syntax has expired. Please use should equal, should ===, shouldEqual, should be, or shouldBe instead.", "1.9.2")
-    //DOTTY-ONLY infix def be(comparison: TripleEqualsInvocation[_]): Nothing = {
-    // SKIP-DOTTY-START
-    def be(comparison: TripleEqualsInvocation[_]): Nothing = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def be(comparison: TripleEqualsInvocation[_]): Nothing = {
       throw new NotAllowedException(FailureMessages.beTripleEqualsNotAllowed, pos)
     }
 
@@ -3347,10 +3341,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(beMatcher: BeMatcher[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def be(beMatcher: BeMatcher[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def be(beMatcher: BeMatcher[T]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         val result = beMatcher(e)
         if (result.matches != shouldBeTrue) {
@@ -3369,10 +3360,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(bePropertyMatcher: BePropertyMatcher[T]): Assertion = {
-    // SKIP-DOTTY-START 
-    def be(bePropertyMatcher: BePropertyMatcher[T]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def be(bePropertyMatcher: BePropertyMatcher[T]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         val result = bePropertyMatcher(e)
         if (result.matches != shouldBeTrue) {
@@ -3391,10 +3379,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be[U >: T](resultOfAWordApplication: ResultOfAWordToBePropertyMatcherApplication[U]): Assertion = {
-    // SKIP-DOTTY-START 
-    def be[U >: T](resultOfAWordApplication: ResultOfAWordToBePropertyMatcherApplication[U]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def be[U >: T](resultOfAWordApplication: ResultOfAWordToBePropertyMatcherApplication[U]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         val result = resultOfAWordApplication.bePropertyMatcher(e)
         if (result.matches != shouldBeTrue) {
@@ -3413,10 +3398,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                           ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be[U >: T](resultOfAnWordApplication: ResultOfAnWordToBePropertyMatcherApplication[U]): Assertion = {
-    // SKIP-DOTTY-START 
-    def be[U >: T](resultOfAnWordApplication: ResultOfAnWordToBePropertyMatcherApplication[U]): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def be[U >: T](resultOfAnWordApplication: ResultOfAnWordToBePropertyMatcherApplication[U]): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         val result = resultOfAnWordApplication.bePropertyMatcher(e)
         if (result.matches != shouldBeTrue) {

--- a/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
+++ b/jvm/shouldmatchers/src/main/scala/org/scalatest/matchers/should/Matchers.scala
@@ -3416,10 +3416,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(resultOfSameInstanceAsApplication: ResultOfTheSameInstanceAsApplication): Assertion = {
-    // SKIP-DOTTY-START 
-    def be(resultOfSameInstanceAsApplication: ResultOfTheSameInstanceAsApplication): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def be(resultOfSameInstanceAsApplication: ResultOfTheSameInstanceAsApplication): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
         e match {
           case ref: AnyRef =>
@@ -3441,7 +3438,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be[U](resultOfDefinedAt: ResultOfDefinedAt[U])(implicit ev: T <:< PartialFunction[U, _]): Assertion = {
+    //DOTTY-ONLY infix def be[U](resultOfDefinedAt: ResultOfDefinedAt[U])(using ev: T <:< PartialFunction[U, _]): Assertion = {
     // SKIP-DOTTY-START 
     def be[U](resultOfDefinedAt: ResultOfDefinedAt[U])(implicit ev: T <:< PartialFunction[U, _]): Assertion = {
     // SKIP-DOTTY-END  
@@ -3466,7 +3463,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      * </pre>
      *
      */
-    //DOTTY-ONLY infix def have(resultOfLengthWordApplication: ResultOfLengthWordApplication)(implicit len: Length[T]): Assertion = {
+    //DOTTY-ONLY infix def have(resultOfLengthWordApplication: ResultOfLengthWordApplication)(using len: Length[T]): Assertion = {
     // SKIP-DOTTY-START 
     def have(resultOfLengthWordApplication: ResultOfLengthWordApplication)(implicit len: Length[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -3489,7 +3486,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      * </pre>
      *
      */
-    //DOTTY-ONLY infix def have(resultOfSizeWordApplication: ResultOfSizeWordApplication)(implicit sz: Size[T]): Assertion = {
+    //DOTTY-ONLY infix def have(resultOfSizeWordApplication: ResultOfSizeWordApplication)(using sz: Size[T]): Assertion = {
     // SKIP-DOTTY-START 
     def have(resultOfSizeWordApplication: ResultOfSizeWordApplication)(implicit sz: Size[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -3512,10 +3509,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                       ^
      * </pre>
      */
-    //DOTTY-ONLY infix def have[U >: T](firstPropertyMatcher: HavePropertyMatcher[U, _], propertyMatchers: HavePropertyMatcher[U, _]*): Assertion = {
-    // SKIP-DOTTY-START 
-    def have[U >: T](firstPropertyMatcher: HavePropertyMatcher[U, _], propertyMatchers: HavePropertyMatcher[U, _]*): Assertion = {
-    // SKIP-DOTTY-END  
+    /* DOTTY-ONLY infix */ def have[U >: T](firstPropertyMatcher: HavePropertyMatcher[U, _], propertyMatchers: HavePropertyMatcher[U, _]*): Assertion = {
       doCollected(collected, xs, original, prettifier, pos) { e =>
 
         val results =
@@ -3603,7 +3597,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(o: Null)(implicit ev: T <:< AnyRef): Assertion = {
+    //DOTTY-ONLY infix def be(o: Null)(using ev: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-START 
     def be(o: Null)(implicit ev: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-END  
@@ -3624,7 +3618,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(symbol: Symbol)(implicit toAnyRef: T <:< AnyRef): Assertion = {
+    //DOTTY-ONLY infix def be(symbol: Symbol)(using toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-START 
     def be(symbol: Symbol)(implicit toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-END  
@@ -3645,7 +3639,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(resultOfAWordApplication: ResultOfAWordToSymbolApplication)(implicit toAnyRef: T <:< AnyRef): Assertion = {
+    //DOTTY-ONLY infix def be(resultOfAWordApplication: ResultOfAWordToSymbolApplication)(using toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-START 
     def be(resultOfAWordApplication: ResultOfAWordToSymbolApplication)(implicit toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-END  
@@ -3666,7 +3660,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(resultOfAnWordApplication: ResultOfAnWordToSymbolApplication)(implicit toAnyRef: T <:< AnyRef): Assertion = {
+    //DOTTY-ONLY infix def be(resultOfAnWordApplication: ResultOfAnWordToSymbolApplication)(using toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-START 
     def be(resultOfAnWordApplication: ResultOfAnWordToSymbolApplication)(implicit toAnyRef: T <:< AnyRef): Assertion = {
     // SKIP-DOTTY-END  
@@ -3688,7 +3682,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(sortedWord: SortedWord)(implicit sortable: Sortable[T]): Assertion = {
+    //DOTTY-ONLY infix def be(sortedWord: SortedWord)(using sortable: Sortable[T]): Assertion = {
     // SKIP-DOTTY-START 
     def be(sortedWord: SortedWord)(implicit sortable: Sortable[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -3708,7 +3702,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(readableWord: ReadableWord)(implicit readability: Readability[T]): Assertion = {
+    //DOTTY-ONLY infix def be(readableWord: ReadableWord)(using readability: Readability[T]): Assertion = {
     // SKIP-DOTTY-START 
     def be(readableWord: ReadableWord)(implicit readability: Readability[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -3728,7 +3722,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(writableWord: WritableWord)(implicit writability: Writability[T]): Assertion = {
+    //DOTTY-ONLY infix def be(writableWord: WritableWord)(using writability: Writability[T]): Assertion = {
     // SKIP-DOTTY-START 
     def be(writableWord: WritableWord)(implicit writability: Writability[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -3748,7 +3742,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(emptyWord: EmptyWord)(implicit emptiness: Emptiness[T]): Assertion = {
+    //DOTTY-ONLY infix def be(emptyWord: EmptyWord)(using emptiness: Emptiness[T]): Assertion = {
     // SKIP-DOTTY-START 
     def be(emptyWord: EmptyWord)(implicit emptiness: Emptiness[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -3768,7 +3762,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                    ^
      * </pre>
      */
-    //DOTTY-ONLY infix def be(definedWord: DefinedWord)(implicit definition: Definition[T]): Assertion = {
+    //DOTTY-ONLY infix def be(definedWord: DefinedWord)(using definition: Definition[T]): Assertion = {
     // SKIP-DOTTY-START 
     def be(definedWord: DefinedWord)(implicit definition: Definition[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -3788,7 +3782,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(nullValue: Null)(implicit containing: Containing[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(nullValue: Null)(using containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(nullValue: Null)(implicit containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -3808,7 +3802,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(expectedElement: Any)(implicit containing: Containing[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(expectedElement: Any)(using containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(expectedElement: Any)(implicit containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -3829,7 +3823,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(oneOf: ResultOfOneOfApplication)(implicit containing: Containing[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(oneOf: ResultOfOneOfApplication)(using containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(oneOf: ResultOfOneOfApplication)(implicit containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-END
@@ -3860,7 +3854,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(oneElementOf: ResultOfOneElementOfApplication)(implicit containing: Containing[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(oneElementOf: ResultOfOneElementOfApplication)(using containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(oneElementOf: ResultOfOneElementOfApplication)(implicit containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-END
@@ -3882,7 +3876,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(atLeastOneOf: ResultOfAtLeastOneOfApplication)(implicit aggregating: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(atLeastOneOf: ResultOfAtLeastOneOfApplication)(using aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(atLeastOneOf: ResultOfAtLeastOneOfApplication)(implicit aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -3915,7 +3909,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(atLeastOneElementOf: ResultOfAtLeastOneElementOfApplication)(implicit evidence: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(atLeastOneElementOf: ResultOfAtLeastOneElementOfApplication)(using evidence: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(atLeastOneElementOf: ResultOfAtLeastOneElementOfApplication)(implicit evidence: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -3937,7 +3931,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(noneOf: ResultOfNoneOfApplication)(implicit containing: Containing[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(noneOf: ResultOfNoneOfApplication)(using containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(noneOf: ResultOfNoneOfApplication)(implicit containing: Containing[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -3970,7 +3964,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(noElementsOf: ResultOfNoElementsOfApplication)(implicit evidence: Containing[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(noElementsOf: ResultOfNoElementsOfApplication)(using evidence: Containing[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(noElementsOf: ResultOfNoElementsOfApplication)(implicit evidence: Containing[T]): Assertion = {
     // SKIP-DOTTY-END  
@@ -3992,7 +3986,7 @@ trait Matchers extends Assertions with Tolerance with ShouldVerb with MatcherWor
      *                     ^
      * </pre>
      */
-    //DOTTY-ONLY infix def contain(theSameElementsAs: ResultOfTheSameElementsAsApplication)(implicit aggregating: Aggregating[T]): Assertion = {
+    //DOTTY-ONLY infix def contain(theSameElementsAs: ResultOfTheSameElementsAsApplication)(using aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-START 
     def contain(theSameElementsAs: ResultOfTheSameElementsAsApplication)(implicit aggregating: Aggregating[T]): Assertion = {
     // SKIP-DOTTY-END  

--- a/project/GenFactoriesDotty.scala
+++ b/project/GenFactoriesDotty.scala
@@ -57,7 +57,7 @@ import scala.language.higherKinds
  * (in <code>TC1</code>, <code>TC2</code>, <em>etc.</em>) means <em>typeclass</em>.
  * This class's <code>matcher</code> factory method will produce a <code>Matcher[T]</code>, where <code>T</code> is a subtype of (or the same type
  * as) <code>SC</code>, given a typeclass instance for each <code>TC<em>n</em></code>
- * implicit parameter (for example, a <code>TC1[T]</code>, <code>TC2[T]</code>, <em>etc.</em>).
+ * using parameter (for example, a <code>TC1[T]</code>, <code>TC2[T]</code>, <em>etc.</em>).
  * </p>
  *
  * @author Bill Venners
@@ -68,7 +68,7 @@ abstract class MatcherFactory$arity$[-SC, $typeConstructors$] { thisMatcherFacto
   /**
    * Factory method that will produce a <code>Matcher[T]</code>, where <code>T</code> is a subtype of (or the same type
    * as) <code>SC</code>, given a typeclass instance for each <code>TC<em>n</em></code>
-   * implicit parameter (for example, a <code>TC1[T]</code>, <code>TC2[T]</code>, <em>etc.</em>).
+   * using parameter (for example, a <code>TC1[T]</code>, <code>TC2[T]</code>, <em>etc.</em>).
    */
   def matcher[T <: SC : $colonSeparatedTCNs$]: Matcher[T]
 
@@ -494,7 +494,7 @@ $endif$
    *                 ^
    * </pre>
    */
-  infix def and(containWord: ContainWord)(implicit prettifier: Prettifier, pos: source.Position): AndContainWord = new AndContainWord(prettifier, pos)
+  infix def and(containWord: ContainWord)(using prettifier: Prettifier, pos: source.Position): AndContainWord = new AndContainWord(prettifier, pos)
 
   /**
    * This class is part of the ScalaTest matchers DSL. Please see the documentation for <a href="../Matchers.html"><code>Matchers</code></a> for an overview of
@@ -1493,7 +1493,7 @@ $endif$
    *                 ^
    * </pre>
    */
-  infix def and(notWord: NotWord)(implicit prettifier: Prettifier, pos: source.Position): AndNotWord = new AndNotWord(prettifier, pos)
+  infix def and(notWord: NotWord)(using prettifier: Prettifier, pos: source.Position): AndNotWord = new AndNotWord(prettifier, pos)
 
   /**
    * This method enables the following syntax:
@@ -1789,7 +1789,7 @@ $endif$
    *                  ^
    * </pre>
    */
-  infix def or(containWord: ContainWord)(implicit prettifier: Prettifier, pos: source.Position): OrContainWord = new OrContainWord(prettifier, pos)
+  infix def or(containWord: ContainWord)(using prettifier: Prettifier, pos: source.Position): OrContainWord = new OrContainWord(prettifier, pos)
 
   /**
    * This class is part of the ScalaTest matchers DSL. Please see the documentation for <a href="../Matchers.html"><code>Matchers</code></a> for an overview of
@@ -2785,7 +2785,7 @@ $endif$
    *                 ^
    * </pre>
    */
-  infix def or(notWord: NotWord)(implicit prettifier: Prettifier, pos: source.Position): OrNotWord = new OrNotWord(prettifier, pos)
+  infix def or(notWord: NotWord)(using prettifier: Prettifier, pos: source.Position): OrNotWord = new OrNotWord(prettifier, pos)
 
   /**
    * This method enables the following syntax:
@@ -2811,7 +2811,7 @@ $endif$
 }
 
 /**
- * Companion object containing an implicit method that converts a <code>MatcherFactory$arity$</code> to a <code>Matcher</code>.
+ * Companion object containing an given method that converts a <code>MatcherFactory$arity$</code> to a <code>Matcher</code>.
  *
  * @author Bill Venners
  */

--- a/project/GenFactoriesDotty.scala
+++ b/project/GenFactoriesDotty.scala
@@ -978,7 +978,7 @@ $endif$
      * </p>
      */
     infix def be(tripleEqualsInvocation: TripleEqualsInvocation[_]): MatcherFactory$arity$[SC, $commaSeparatedTCNs$] =
-      thisMatcherFactory.and(MatcherWords.not.be(tripleEqualsInvocation)(pos))
+      thisMatcherFactory.and(MatcherWords.not.be(tripleEqualsInvocation)(using pos))
 
     // SKIP-SCALATESTJS,NATIVE-START
     /**
@@ -2273,7 +2273,7 @@ $endif$
      * </p>
      */
     infix def be(tripleEqualsInvocation: TripleEqualsInvocation[_]): MatcherFactory$arity$[SC, $commaSeparatedTCNs$] =
-      thisMatcherFactory.or(MatcherWords.not.be(tripleEqualsInvocation)(pos))
+      thisMatcherFactory.or(MatcherWords.not.be(tripleEqualsInvocation)(using pos))
 
     // SKIP-SCALATESTJS,NATIVE-START
     /**

--- a/project/GenFactoriesDotty.scala
+++ b/project/GenFactoriesDotty.scala
@@ -340,7 +340,7 @@ $endif$
      * </pre>
      */
     infix def inOrderOnly(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Sequencing] =
-      thisMatcherFactory.and(MatcherWords.contain.inOrderOnly(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      thisMatcherFactory.and(MatcherWords.contain.inOrderOnly(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
@@ -351,7 +351,7 @@ $endif$
      * </pre>
      */
     infix def allOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Aggregating] =
-      thisMatcherFactory.and(MatcherWords.contain.allOf(firstEle, secondEle, remainingEles  .toList: _*)(prettifier, pos))
+      thisMatcherFactory.and(MatcherWords.contain.allOf(firstEle, secondEle, remainingEles  .toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
@@ -373,7 +373,7 @@ $endif$
      * </pre>
      */
     infix def inOrder(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Sequencing] =
-      thisMatcherFactory.and(MatcherWords.contain.inOrder(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      thisMatcherFactory.and(MatcherWords.contain.inOrder(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
@@ -395,7 +395,7 @@ $endif$
      * </pre>
      */
     infix def oneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Containing] =
-      thisMatcherFactory.and(MatcherWords.contain.oneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      thisMatcherFactory.and(MatcherWords.contain.oneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
@@ -417,7 +417,7 @@ $endif$
      * </pre>
      */
     infix def atLeastOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Aggregating] =
-      thisMatcherFactory.and(MatcherWords.contain.atLeastOneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      thisMatcherFactory.and(MatcherWords.contain.atLeastOneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
@@ -439,7 +439,7 @@ $endif$
      * </pre>
      */
     infix def only(right: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Aggregating] =
-      thisMatcherFactory.and(MatcherWords.contain.only(right.toList: _*)(prettifier, pos))
+      thisMatcherFactory.and(MatcherWords.contain.only(right.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
@@ -450,7 +450,7 @@ $endif$
      * </pre>
      */
     infix def noneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Containing] =
-      thisMatcherFactory.and(MatcherWords.contain.noneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      thisMatcherFactory.and(MatcherWords.contain.noneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
@@ -472,7 +472,7 @@ $endif$
      * </pre>
      */
     infix def atMostOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Aggregating] =
-      thisMatcherFactory.and(MatcherWords.contain.atMostOneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      thisMatcherFactory.and(MatcherWords.contain.atMostOneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
@@ -1635,7 +1635,7 @@ $endif$
      * </pre>
      */
     infix def inOrderOnly(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Sequencing] =
-      thisMatcherFactory.or(MatcherWords.contain.inOrderOnly(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      thisMatcherFactory.or(MatcherWords.contain.inOrderOnly(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
@@ -1646,7 +1646,7 @@ $endif$
      * </pre>
      */
     infix def allOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Aggregating] =
-      thisMatcherFactory.or(MatcherWords.contain.allOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      thisMatcherFactory.or(MatcherWords.contain.allOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
@@ -1668,7 +1668,7 @@ $endif$
      * </pre>
      */
     infix def inOrder(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Sequencing] =
-      thisMatcherFactory.or(MatcherWords.contain.inOrder(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      thisMatcherFactory.or(MatcherWords.contain.inOrder(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
@@ -1690,7 +1690,7 @@ $endif$
      * </pre>
      */
     infix def oneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Containing] =
-      thisMatcherFactory.or(MatcherWords.contain.oneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      thisMatcherFactory.or(MatcherWords.contain.oneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
@@ -1712,7 +1712,7 @@ $endif$
      * </pre>
      */
     infix def atLeastOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Aggregating] =
-      thisMatcherFactory.or(MatcherWords.contain.atLeastOneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      thisMatcherFactory.or(MatcherWords.contain.atLeastOneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
@@ -1734,7 +1734,7 @@ $endif$
      * </pre>
      */
     infix def only(right: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Aggregating] =
-      thisMatcherFactory.or(MatcherWords.contain.only(right.toList: _*)(prettifier, pos))
+      thisMatcherFactory.or(MatcherWords.contain.only(right.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
@@ -1745,7 +1745,7 @@ $endif$
      * </pre>
      */
     infix def noneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Containing] =
-      thisMatcherFactory.or(MatcherWords.contain.noneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      thisMatcherFactory.or(MatcherWords.contain.noneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:
@@ -1767,7 +1767,7 @@ $endif$
      * </pre>
      */
     infix def atMostOneOf(firstEle: Any, secondEle: Any, remainingEles: Any*): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Aggregating] =
-      thisMatcherFactory.or(MatcherWords.contain.atMostOneOf(firstEle, secondEle, remainingEles.toList: _*)(prettifier, pos))
+      thisMatcherFactory.or(MatcherWords.contain.atMostOneOf(firstEle, secondEle, remainingEles.toList: _*)(using prettifier, pos))
 
     /**
      * This method enables the following syntax given a <code>MatcherFactory$arity$</code>:

--- a/project/GenFactoriesDotty.scala
+++ b/project/GenFactoriesDotty.scala
@@ -283,7 +283,7 @@ $endif$
      *                             ^
      * </pre>
      */
-    def apply(expectedElement: Any): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Containing] = thisMatcherFactory.and(MatcherWords.contain(expectedElement))
+    infix def apply(expectedElement: Any): MatcherFactory$arityPlusOne$[SC, $commaSeparatedTCNs$, Containing] = thisMatcherFactory.and(MatcherWords.contain(expectedElement))
 
     // And some, the ones that would by themselves already generate a Matcher, just return a MatcherFactoryN where N is the same.
 


### PR DESCRIPTION
Changed to use 'using' for implicit parameters and mark DSL functions with 'infix' in Matchers.scala