### PR TITLE
Matchers DSL Missing Scaladoc

### DIFF
--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfLengthWordApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfLengthWordApplication.scala
@@ -28,8 +28,15 @@ import org.scalactic.Prettifier
  */
 final class ResultOfLengthWordApplication(val expectedLength: Long) {
 
-  // TODO: SCALADOC
-  def apply[T : Length](resultOfOfTypeInvocation: ResultOfOfTypeInvocation[T]): HavePropertyMatcher[T, Long] = { 
+  /**
+   * This method enables the following syntax:
+   *
+   * <pre class="stHighlight">
+   * book should have (length (220) (of [Book]))
+   *                                ^
+   * </pre>
+   */
+  def apply[T : Length](resultOfOfTypeInvocation: ResultOfOfTypeInvocation[T]): HavePropertyMatcher[T, Long] = {
     new HavePropertyMatcher[T, Long] {
       def apply(t: T): HavePropertyMatchResult[Long] = {
         val len = implicitly[Length[T]]
@@ -45,7 +52,7 @@ final class ResultOfLengthWordApplication(val expectedLength: Long) {
   }
   
   /**
-   * Overrides toString to return "length (X)", where X is the expectedLength
+   * Returns a human-readable representation of this matcher.
    */
   override def toString: String = "length (" + Prettifier.default(expectedLength) + ")"
 }

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfMessageWordApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfMessageWordApplication.scala
@@ -25,12 +25,18 @@ import org.scalactic.Prettifier
  * the matchers DSL.
  *
  * @author Bill Venners
- * @author Chee Seng
  */
 final class ResultOfMessageWordApplication(val expectedMessage: String) {
 
-  // TODO: SCALADOC
-  def apply[T : Messaging](resultOfOfTypeInvocation: ResultOfOfTypeInvocation[T]): HavePropertyMatcher[T, String] = {  
+  /**
+   * This method enables the following syntax:
+   *
+   * <pre class="stHighlight">
+   * book should have (message ("A Tale of Two Cities") (of [Book]))
+   *                                  ^
+   * </pre>
+   */
+  def apply[T : Messaging](resultOfOfTypeInvocation: ResultOfOfTypeInvocation[T]): HavePropertyMatcher[T, String] = {
     new HavePropertyMatcher[T, String] {
       def apply(t: T): HavePropertyMatchResult[String] = {
         val messaging = implicitly[Messaging[T]]
@@ -46,7 +52,7 @@ final class ResultOfMessageWordApplication(val expectedMessage: String) {
   }
   
   /**
-   * Overrides toString to return "message (\"XXX\")", where XXX is expectedMessage
+   * Returns a human-readable representation of this matcher.
    */
   override def toString: String = "message (" + Prettifier.default(expectedMessage) + ")"
 }

--- a/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfSizeWordApplication.scala
+++ b/jvm/matchers-core/src/main/scala/org/scalatest/matchers/dsl/ResultOfSizeWordApplication.scala
@@ -28,8 +28,15 @@ import org.scalactic.Prettifier
  */
 final class ResultOfSizeWordApplication(val expectedSize: Long) {
 
-  // TODO: SCALADOC
-  def apply[T : Size](resultOfOfTypeInvocation: ResultOfOfTypeInvocation[T]): HavePropertyMatcher[T, Long] = {  
+  /**
+   * This method enables the following syntax:
+   *
+   * <pre class="stHighlight">
+   * book should have (size (220) (of [Book]))
+   *                              ^
+   * </pre>
+   */
+  def apply[T : Size](resultOfOfTypeInvocation: ResultOfOfTypeInvocation[T]): HavePropertyMatcher[T, Long] = {
     new HavePropertyMatcher[T, Long] {
       def apply(t: T): HavePropertyMatchResult[Long] = {
         val sz = implicitly[Size[T]]
@@ -45,7 +52,7 @@ final class ResultOfSizeWordApplication(val expectedSize: Long) {
   }
   
   /**
-   * Overrides toString to return "size (X)", where X is expectedSize
+   * Returns a human-readable representation of this matcher.
    */
   override def toString: String = "size (" + Prettifier.default(expectedSize) + ")"
 }


### PR DESCRIPTION
Added missing scaladoc to ResultOfLengthWordApplication.scala, ResultOfMessageWordApplication.scala and ResultOfSizeWordApplication.scala.