### PR TITLE
SBT Framework Blocking Problem Fix

### DIFF
--- a/jvm/core/src/main/resources/org/scalatest/ScalaTestBundle.properties
+++ b/jvm/core/src/main/resources/org/scalatest/ScalaTestBundle.properties
@@ -727,6 +727,6 @@ commonmarkClassNotFound=Commonmark HtmlRenderer class not found, please add comm
 unableToSerializePayload=Warning: Unable to serialize payload of type {0} for {1}, wrapping it as NotSerializableWrapperException.
 unableToSerializeThrowable=Warning: Unable to serialize throwable of type {0} for {1}, setting it as NotSerializableWrapperException.
 unableToReadSerializedEvent=Warning: Unable to read from client, please check on client for further details of the problem.
-unableToContinueRun=Fatal: Existing as unable to continue running tests, after 3 failing attempts to read event from server socket.
+unableToContinueRun=Fatal: Unable to continue running tests, aborting the run.
 
 suiteScopedCannotBeCalledFromOutsideATest=`suiteScoped`` cannot be called from outside a test. Use a `lazy val` to store Suite-scoped resources in order to defer initialization of such resources until the start of a test.

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -24,6 +24,7 @@ import scala.collection.JavaConverters._
 import java.io.{PrintWriter, StringWriter, IOException}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
 import java.util.concurrent.{ExecutorService, Executors, LinkedBlockingQueue, ThreadFactory}
+import java.net.{ServerSocket, InetAddress}
 
 import org.scalatest.time.{Millis, Seconds, Span}
 import sbt.testing.{Event => SbtEvent, Framework => SbtFramework, Runner => SbtRunner, Status => SbtStatus, _}
@@ -665,7 +666,7 @@ class Framework extends SbtFramework {
     testSortingReporterTimeout: Span
   ) extends sbt.testing.Runner {
     val isDone = new AtomicBoolean(false)
-    val serverThread = new AtomicReference[Option[Thread]](None)
+    val serverRef = new AtomicReference[Option[(Thread, ServerSocket)]](None)
     val statusList = new LinkedBlockingQueue[Status]()
     val tracker = new Tracker
     val summaryCounter = new SummaryCounter
@@ -777,8 +778,9 @@ class Framework extends SbtFramework {
           }
         }
 
-        serverThread.get match {
-          case Some(thread) =>
+        serverRef.get match {
+          case Some((thread, serverSocket)) =>
+            serverSocket.close() // Close the server socket to unblock the server thread
             // Need to wait until the server thread is done
             thread.join()
           case None =>
@@ -816,7 +818,6 @@ class Framework extends SbtFramework {
     def remoteArgs: Array[String] = {
       import org.scalatest.events._
       import java.io.{ObjectInputStream, ObjectOutputStream}
-      import java.net.{ServerSocket, InetAddress}
 
       class SkeletonObjectInputStream(in: java.io.InputStream, loader: ClassLoader) extends ObjectInputStream(in) {
 
@@ -932,7 +933,7 @@ class Framework extends SbtFramework {
       val skeleton = new Skeleton()
       val thread = new Thread(skeleton)
       thread.start()
-      serverThread.set(Some(thread))
+      serverRef.set(Some((thread, skeleton.server)))
       Array("127.0.0.1", skeleton.port.toString)
       // Array(InetAddress.getLocalHost.getHostAddress, skeleton.port.toString)
     }

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 import java.io.{PrintWriter, StringWriter, IOException}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
 import java.util.concurrent.{ExecutorService, Executors, LinkedBlockingQueue, ThreadFactory}
-import java.net.{ServerSocket, InetAddress}
+import java.net.ServerSocket
 
 import org.scalatest.time.{Millis, Seconds, Span}
 import sbt.testing.{Event => SbtEvent, Framework => SbtFramework, Runner => SbtRunner, Status => SbtStatus, _}
@@ -918,7 +918,7 @@ class Framework extends SbtFramework {
               // RunStopped and RunAborted, are only knowable from the sub-process (they carry the actual
               // message/throwable that the main JVM cannot reproduce), so forward them to the reporters
               // and mark the run as terminated so `done` won't also fire RunCompleted.
-              case e: RunStarting => react() // just ignore test starting and continue
+              case e: RunStarting => react() // just ignore run starting and continue
               case e: RunCompleted => // Sub-process completed, just let the thread terminate
               case e: RunStopped => dispatchReporter(e); runTerminated.set(true)
               case e: RunAborted => dispatchReporter(e); runTerminated.set(true)

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 import java.io.{PrintWriter, StringWriter, IOException}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
 import java.util.concurrent.{ExecutorService, Executors, LinkedBlockingQueue, ThreadFactory}
-import java.net.{ServerSocket, InetAddress}
+import java.net.{ServerSocket, InetAddress, SocketException}
 
 import org.scalatest.time.{Millis, Seconds, Span}
 import sbt.testing.{Event => SbtEvent, Framework => SbtFramework, Runner => SbtRunner, Status => SbtStatus, _}
@@ -845,7 +845,8 @@ class Framework extends SbtFramework {
           }
           finally {
             is.get.close()
-            socket.get.close()
+            if (!socket.get.isClosed)  
+              socket.get.close()
 		      }
         }
 
@@ -912,8 +913,11 @@ class Framework extends SbtFramework {
                 react()
               }
               catch {
+                case _: SocketException =>
+                  // Do nothing, just let the thread terminate, this happens when `done` calls `serverSocket.close()`.
+
                 case t: IOException =>
-                  // Restart server socket
+                  // IO read error, let's try restart server socket to see if it fixes the problem, but only try 3 times, then give up and exit the process.
                   println(Resources.unableToReadSerializedEvent)
                   is.get.close()
                   socket.set(server.accept())

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -781,8 +781,8 @@ class Framework extends SbtFramework {
         serverRef.get match {
           case Some((thread, serverSocket)) =>
             serverSocket.close() // Close the server socket to unblock the server thread
-            // Need to wait until the server thread is done
-            thread.join()
+            // Need to wait until the server thread is done, wait for maximum of 15 seconds.
+            thread.join(15000)
           case None =>
         }
 

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -667,9 +667,6 @@ class Framework extends SbtFramework {
   ) extends sbt.testing.Runner {
     val isDone = new AtomicBoolean(false)
     val runTerminated = new AtomicBoolean(false)
-    // Set just before the server socket is closed in done(), so the Skeleton thread can tell a
-    // deliberate shutdown apart from a genuine read failure, such as the forked JVM dying.
-    val isShuttingDown = new AtomicBoolean(false)
     val serverRef = new AtomicReference[Option[(Thread, ServerSocket)]](None)
     val statusList = new LinkedBlockingQueue[Status]()
     val tracker = new Tracker
@@ -784,7 +781,6 @@ class Framework extends SbtFramework {
 
         serverRef.get match {
           case Some((thread, serverSocket)) =>
-            isShuttingDown.set(true)
             serverSocket.close() // Close the server socket to unblock the server thread
             // Need to wait until the server thread is done, wait for maximum of 15 seconds.
             thread.join(15000)
@@ -846,26 +842,25 @@ class Framework extends SbtFramework {
         lazy val is = new AtomicReference(new SkeletonObjectInputStream(socket.get.getInputStream, getClass.getClassLoader))
 
         def run(): Unit = {
-          val connected = 
+          val connected =
             try {
-              // Force the connection up front. Once established, the finally block below can close
-              // the stream and socket without re-running accept(), which would throw SocketException
-              // if done() has already closed the server socket.
+              // Force the connection up front. If the fork never connects, this accept() throws
+              // when done() closes the server socket, and there is nothing to read or clean up,
+              // so just let the thread terminate.
               is.get
               true
             } catch {
               case _: IOException => false
             }
-          try {
-            (new React(server)).tryReact()
-          }
-          finally {
-            if (connected) {
+          if (connected)
+            try {
+              (new React(server)).tryReact()
+            }
+            finally {
               is.get.close()
               if (!socket.get.isClosed)
                 socket.get.close()
             }
-          }
         }
 
         class React(server: ServerSocket) {
@@ -936,20 +931,14 @@ class Framework extends SbtFramework {
             }
             catch {
               case _: IOException =>
-                // A read failure raised after done() set isShuttingDown and closed the server
-                // socket is part of the normal shutdown, so just let the thread terminate. Any
-                // other read failure means the forked JVM is gone: ForkMain uses a single
-                // connection per fork group and never reconnects, so abort the run instead of
-                // retrying.
-                if (isShuttingDown.get) {
-                  // Do nothing, just let the thread terminate.
-                }
-                else {
-                  println(Resources.unableToReadSerializedEvent)
-                  println(Resources.unableToContinueRun)
-                  runTerminated.set(true)
-                  dispatchReporter(RunAborted(tracker.nextOrdinal(), Resources.unableToContinueRun, None))
-                }
+                // By the time we get here a connection was established, and closing the server
+                // socket in done() has no effect on the accepted socket we read from. So any
+                // read failure means the forked JVM is gone: ForkMain uses a single connection
+                // per fork group and never reconnects, so abort the run instead of retrying.
+                println(Resources.unableToReadSerializedEvent)
+                println(Resources.unableToContinueRun)
+                runTerminated.set(true)
+                dispatchReporter(RunAborted(tracker.nextOrdinal(), Resources.unableToContinueRun, None))
             }
         }
 

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 import java.io.{PrintWriter, StringWriter, IOException}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
 import java.util.concurrent.{ExecutorService, Executors, LinkedBlockingQueue, ThreadFactory}
-import java.net.{ServerSocket, InetAddress, SocketException}
+import java.net.{ServerSocket, InetAddress}
 
 import org.scalatest.time.{Millis, Seconds, Span}
 import sbt.testing.{Event => SbtEvent, Framework => SbtFramework, Runner => SbtRunner, Status => SbtStatus, _}
@@ -667,6 +667,9 @@ class Framework extends SbtFramework {
   ) extends sbt.testing.Runner {
     val isDone = new AtomicBoolean(false)
     val runTerminated = new AtomicBoolean(false)
+    // Set just before the server socket is closed in done(), so the Skeleton thread can tell a
+    // deliberate shutdown apart from a genuine read failure, such as the forked JVM dying.
+    val isShuttingDown = new AtomicBoolean(false)
     val serverRef = new AtomicReference[Option[(Thread, ServerSocket)]](None)
     val statusList = new LinkedBlockingQueue[Status]()
     val tracker = new Tracker
@@ -781,6 +784,7 @@ class Framework extends SbtFramework {
 
         serverRef.get match {
           case Some((thread, serverSocket)) =>
+            isShuttingDown.set(true)
             serverSocket.close() // Close the server socket to unblock the server thread
             // Need to wait until the server thread is done, wait for maximum of 15 seconds.
             thread.join(15000)
@@ -842,14 +846,26 @@ class Framework extends SbtFramework {
         lazy val is = new AtomicReference(new SkeletonObjectInputStream(socket.get.getInputStream, getClass.getClassLoader))
 
         def run(): Unit = {
+          val connected = 
+            try {
+              // Force the connection up front. Once established, the finally block below can close
+              // the stream and socket without re-running accept(), which would throw SocketException
+              // if done() has already closed the server socket.
+              is.get
+              true
+            } catch {
+              case _: IOException => false
+            }
           try {
-			      (new React(server)).tryReact(0)
+            (new React(server)).tryReact()
           }
           finally {
-            is.get.close()
-            if (!socket.get.isClosed)  
-              socket.get.close()
-		      }
+            if (connected) {
+              is.get.close()
+              if (!socket.get.isClosed)
+                socket.get.close()
+            }
+          }
         }
 
         class React(server: ServerSocket) {
@@ -914,28 +930,26 @@ class Framework extends SbtFramework {
             }
           }
 
-          @annotation.tailrec
-          final def tryReact(count: Int): Unit =
-            if (count < 3)
-              try {
-                react()
-              }
-              catch {
-                case _: SocketException =>
-                  // Do nothing, just let the thread terminate, this happens when `done` calls `serverSocket.close()`.
-
-                case t: IOException =>
-                  // IO read error, let's try restart server socket to see if it fixes the problem, but only try 3 times, then give up and abort the run.
+          final def tryReact(): Unit =
+            try {
+              react()
+            }
+            catch {
+              case _: IOException =>
+                // A read failure raised after done() set isShuttingDown and closed the server
+                // socket is part of the normal shutdown, so just let the thread terminate. Any
+                // other read failure means the forked JVM is gone: ForkMain uses a single
+                // connection per fork group and never reconnects, so abort the run instead of
+                // retrying.
+                if (isShuttingDown.get) {
+                  // Do nothing, just let the thread terminate.
+                }
+                else {
                   println(Resources.unableToReadSerializedEvent)
-                  is.get.close()
-                  socket.set(server.accept())
-                  is.set(new SkeletonObjectInputStream(socket.get.getInputStream, getClass.getClassLoader))
-                  tryReact(count + 1)
-              }
-            else {
-              println(Resources.unableToContinueRun)
-              runTerminated.set(true)
-              dispatchReporter(RunAborted(tracker.nextOrdinal(), Resources.unableToContinueRun, None))
+                  println(Resources.unableToContinueRun)
+                  runTerminated.set(true)
+                  dispatchReporter(RunAborted(tracker.nextOrdinal(), Resources.unableToContinueRun, None))
+                }
             }
         }
 
@@ -945,6 +959,7 @@ class Framework extends SbtFramework {
 
       val skeleton = new Skeleton()
       val thread = new Thread(skeleton)
+      thread.setDaemon(true)
       thread.start()
       serverRef.set(Some((thread, skeleton.server)))
       Array("127.0.0.1", skeleton.port.toString)

--- a/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/jvm/core/src/main/scala/org/scalatest/tools/Framework.scala
@@ -666,6 +666,7 @@ class Framework extends SbtFramework {
     testSortingReporterTimeout: Span
   ) extends sbt.testing.Runner {
     val isDone = new AtomicBoolean(false)
+    val runTerminated = new AtomicBoolean(false)
     val serverRef = new AtomicReference[Option[(Thread, ServerSocket)]](None)
     val statusList = new LinkedBlockingQueue[Status]()
     val tracker = new Tracker
@@ -789,7 +790,8 @@ class Framework extends SbtFramework {
         val duration = System.currentTimeMillis - runStartTime
         val summary = new Summary(summaryCounter.testsSucceededCount.get, summaryCounter.testsFailedCount.get, summaryCounter.testsIgnoredCount.get, summaryCounter.testsPendingCount.get,
                                   summaryCounter.testsCanceledCount.get, summaryCounter.suitesCompletedCount.get, summaryCounter.suitesAbortedCount.get, summaryCounter.scopesPendingCount.get)
-        dispatchReporter(RunCompleted(tracker.nextOrdinal(), Some(duration), Some(summary)))
+        if (!runTerminated.get)
+          dispatchReporter(RunCompleted(tracker.nextOrdinal(), Some(duration), Some(summary)))
         dispatchReporter.dispatchDisposeAndWaitUntilDone()
 
         execSvc.shutdown()
@@ -899,10 +901,16 @@ class Framework extends SbtFramework {
               case e: MarkupProvided => dispatchReporter(e); react()
               case e: AlertProvided => dispatchReporter(e); react()
               case e: NoteProvided => dispatchReporter(e); react()
+              // The main JVM owns the two "normal" run-level events: it fires RunStarting at runner
+              // creation and RunCompleted in `done`. The sub-process sends its own copies over the
+              // socket, so drop them here to avoid double-firing. The two "abnormal" terminal events,
+              // RunStopped and RunAborted, are only knowable from the sub-process (they carry the actual
+              // message/throwable that the main JVM cannot reproduce), so forward them to the reporters
+              // and mark the run as terminated so `done` won't also fire RunCompleted.
               case e: RunStarting => react() // just ignore test starting and continue
               case e: RunCompleted => // Sub-process completed, just let the thread terminate
-              case e: RunStopped => dispatchReporter(e)
-              case e: RunAborted => dispatchReporter(e)
+              case e: RunStopped => dispatchReporter(e); runTerminated.set(true)
+              case e: RunAborted => dispatchReporter(e); runTerminated.set(true)
             }
           }
 
@@ -917,7 +925,7 @@ class Framework extends SbtFramework {
                   // Do nothing, just let the thread terminate, this happens when `done` calls `serverSocket.close()`.
 
                 case t: IOException =>
-                  // IO read error, let's try restart server socket to see if it fixes the problem, but only try 3 times, then give up and exit the process.
+                  // IO read error, let's try restart server socket to see if it fixes the problem, but only try 3 times, then give up and abort the run.
                   println(Resources.unableToReadSerializedEvent)
                   is.get.close()
                   socket.set(server.accept())
@@ -926,7 +934,8 @@ class Framework extends SbtFramework {
               }
             else {
               println(Resources.unableToContinueRun)
-              System.exit(-1)
+              runTerminated.set(true)
+              dispatchReporter(RunAborted(tracker.nextOrdinal(), Resources.unableToContinueRun, None))
             }
         }
 

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/FrameworkSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/FrameworkSuite.scala
@@ -24,6 +24,8 @@ import java.io.File
 import Retries._
 import OptionValues._
 import org.scalatest.tagobjects.Flicker
+import java.net.Socket
+import java.io.ObjectOutputStream
 
 class FrameworkSuite extends AnyFunSuite {
 
@@ -1368,6 +1370,38 @@ class FrameworkSuite extends AnyFunSuite {
             assert(recordingRep.noteProvidedEventsReceived.size === 1)
           case _ => fail("Expected to find EventRecordingReporter, but not found.")
         }
+    }
+  }
+
+  test("Framework should fire RunAborted and not RunCompleted when the forked JVM dies mid-run", Retryable) {
+    val mainRunner = framework.runner(Array("-C", classOf[EventRecordingReporter].getName), Array.empty, testClassLoader)
+    makeSureDone(mainRunner) {
+      assert(mainRunner.isInstanceOf[org.scalatest.tools.Framework#ScalaTestRunner])
+      val mainScalatestRunner = mainRunner.asInstanceOf[org.scalatest.tools.Framework#ScalaTestRunner]
+      val recordingRep =
+        mainScalatestRunner.dispatchReporter.reporters.find(_.isInstanceOf[EventRecordingReporter]) match {
+          case Some(rep: EventRecordingReporter) => rep
+          case _ => fail("Expected to find EventRecordingReporter, but not found.")
+        }
+
+      // ForkMain uses a single connection per fork group and never reconnects, so a fork that
+      // dies mid-run makes the server side see EOF. Simulate it: connect and write the object
+      // stream header (as ForkMain does), then close the connection before sending any events.
+      val Array(host, portStr) = mainRunner.remoteArgs()
+      val socket = new Socket(host, portStr.toInt)
+      new ObjectOutputStream(socket.getOutputStream) // Writes the stream header
+      socket.close()
+
+      // Wait for the Skeleton thread to see the read failure and fire RunAborted before calling
+      // done(), otherwise done()'s server socket close would be classified as a normal shutdown.
+      val deadline = System.currentTimeMillis + 5000
+      while (System.currentTimeMillis < deadline && !recordingRep.eventsReceived.exists(_.isInstanceOf[org.scalatest.events.RunAborted]))
+        Thread.sleep(50)
+
+      mainScalatestRunner.done()
+
+      assert(recordingRep.eventsReceived.exists(_.isInstanceOf[org.scalatest.events.RunAborted]), "Expected a RunAborted event when the forked JVM dies mid-run, but none was fired.")
+      assert(!recordingRep.eventsReceived.exists(_.isInstanceOf[org.scalatest.events.RunCompleted]), "Expected no RunCompleted event after the run was aborted, but one was fired.")
     }
   }
 

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/FrameworkSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/FrameworkSuite.scala
@@ -1405,6 +1405,23 @@ class FrameworkSuite extends AnyFunSuite {
     }
   }
 
+  test("Framework.done should not block forever when no fork ever connects to remoteArgs", Retryable) {
+    val mainRunner = framework.runner(Array("-C", classOf[EventRecordingReporter].getName), Array.empty, testClassLoader)
+    makeSureDone(mainRunner) {
+      assert(mainRunner.isInstanceOf[org.scalatest.tools.Framework#ScalaTestRunner])
+      val mainScalatestRunner = mainRunner.asInstanceOf[org.scalatest.tools.Framework#ScalaTestRunner]
+      // Exactly the shape from https://github.com/scalatest/scalatest/issues/2434: remoteArgs()
+      // opens the server socket and starts the acceptor, then done() is called with no fork ever
+      // dialing back. done() must close the server socket, unblock accept(), and return.
+      assert(mainScalatestRunner.remoteArgs().length === 2)
+      val doneThread = new Thread(() => mainScalatestRunner.done())
+      doneThread.setDaemon(true)
+      doneThread.start()
+      doneThread.join(15000)
+      assert(!doneThread.isAlive, "done() is still blocked waiting for the acceptor thread; the server socket was not closed")
+    }
+  }
+
   test("SuitedAbored fired from nested suite should be reported as error correctly") {
     val runner = framework.runner(Array.empty, Array.empty, testClassLoader)
     try {

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/tools/FrameworkSuite.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/tools/FrameworkSuite.scala
@@ -1414,7 +1414,11 @@ class FrameworkSuite extends AnyFunSuite {
       // opens the server socket and starts the acceptor, then done() is called with no fork ever
       // dialing back. done() must close the server socket, unblock accept(), and return.
       assert(mainScalatestRunner.remoteArgs().length === 2)
-      val doneThread = new Thread(() => mainScalatestRunner.done())
+      val doneThread = new Thread(new Runnable {
+        def run(): Unit = {
+          mainScalatestRunner.done()
+        }
+      })
       doneThread.setDaemon(true)
       doneThread.start()
       doneThread.join(15000)


### PR DESCRIPTION
Close server socket before calling thread.join in Framework.scala, addressing blocks forever issue described in https://github.com/scalatest/scalatest/issues/2434 .