### PR TITLE
Preserve shrink structure through edges — carry List[RoseTree[T]] in Generator.initEdges/next

### DIFF
--- a/jvm/core/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
+++ b/jvm/core/src/main/scala/org/scalatest/enablers/PropCheckerAsserting.scala
@@ -187,7 +187,7 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
       val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
 
       @tailrec
-      def loop(succeededCount: Int, discardedCount: Int, edges: List[A], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
+      def loop(succeededCount: Int, discardedCount: Int, edges: List[RoseTree[A]], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
         val (size, nextInitialSizes, nextRnd) =
           initialSizes match {
             case head :: tail => (head, tail, rnd)
@@ -280,7 +280,7 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
       val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
 
       @tailrec
-      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[RoseTree[A]], bEdges: List[RoseTree[B]], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
         val (size, nextInitialSizes, rnd1) =
           initialSizes match {
             case head :: tail => (head, tail, rnd)
@@ -382,7 +382,7 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
       val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
 
       @tailrec
-      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[RoseTree[A]], bEdges: List[RoseTree[B]], cEdges: List[RoseTree[C]], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
         val (size, nextInitialSizes, rnd1) =
           initialSizes match {
             case head :: tail => (head, tail, rnd)
@@ -491,7 +491,7 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
       val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
 
       @tailrec
-      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[RoseTree[A]], bEdges: List[RoseTree[B]], cEdges: List[RoseTree[C]], dEdges: List[RoseTree[D]], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
         val (size, nextInitialSizes, rnd1) =
           initialSizes match {
             case head :: tail => (head, tail, rnd)
@@ -609,7 +609,7 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
       val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
 
       @tailrec
-      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], eEdges: List[E], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[RoseTree[A]], bEdges: List[RoseTree[B]], cEdges: List[RoseTree[C]], dEdges: List[RoseTree[D]], eEdges: List[RoseTree[E]], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
         val (size, nextInitialSizes, rnd1) =
           initialSizes match {
             case head :: tail => (head, tail, rnd)
@@ -733,7 +733,7 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
       val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
 
       @tailrec
-      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], eEdges: List[E], fEdges: List[F], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[RoseTree[A]], bEdges: List[RoseTree[B]], cEdges: List[RoseTree[C]], dEdges: List[RoseTree[D]], eEdges: List[RoseTree[E]], fEdges: List[RoseTree[F]], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): PropertyCheckResult = {
         val (size, nextInitialSizes, rnd1) =
           initialSizes match {
             case head :: tail => (head, tail, rnd)
@@ -969,13 +969,13 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
       */
     private def checkForAll[A](names: List[String], config: Parameter, genA: org.scalatest.prop.Generator[A])(fun: (A) => Future[T]): Future[PropertyCheckResult] = {
 
-      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, edges: List[A], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult], failedA: Option[A])
+      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, edges: List[RoseTree[A]], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult], failedA: Option[A])
 
       val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
       val minSize = config.minSize
       val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
 
-      def loop(succeededCount: Int, discardedCount: Int, edges: List[A], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
+      def loop(succeededCount: Int, discardedCount: Int, edges: List[RoseTree[A]], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
         val (size, nextInitialSizes, nextRnd) =
           initialSizes match {
             case head :: tail => (head, tail, rnd)
@@ -1118,13 +1118,13 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
       */
     private def checkForAll[A, B](names: List[String], config: Parameter, genA: org.scalatest.prop.Generator[A], genB: org.scalatest.prop.Generator[B])(fun: (A, B) => Future[T]): Future[PropertyCheckResult] = {
 
-      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult], failedAB: Option[(A, B)])
+      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, aEdges: List[RoseTree[A]], bEdges: List[RoseTree[B]], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult], failedAB: Option[(A, B)])
 
       val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
       val minSize = config.minSize
       val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
 
-      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[RoseTree[A]], bEdges: List[RoseTree[B]], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
         val (size, nextInitialSizes, nextRnd) =
           initialSizes match {
             case head :: tail => (head, tail, rnd)
@@ -1276,13 +1276,13 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
     private def checkForAll[A, B, C](names: List[String], config: Parameter, genA: org.scalatest.prop.Generator[A], genB: org.scalatest.prop.Generator[B],
                                      genC: org.scalatest.prop.Generator[C])(fun: (A, B, C) => Future[T]): Future[PropertyCheckResult] = {
 
-      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult], failedABC: Option[(A, B, C)])
+      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, aEdges: List[RoseTree[A]], bEdges: List[RoseTree[B]], cEdges: List[RoseTree[C]], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult], failedABC: Option[(A, B, C)])
 
       val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
       val minSize = config.minSize
       val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
 
-      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[RoseTree[A]], bEdges: List[RoseTree[B]], cEdges: List[RoseTree[C]], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
         val (size, nextInitialSizes, nextRnd) =
           initialSizes match {
             case head :: tail => (head, tail, rnd)
@@ -1440,13 +1440,13 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
     private def checkForAll[A, B, C, D](names: List[String], config: Parameter, genA: org.scalatest.prop.Generator[A], genB: org.scalatest.prop.Generator[B],
                                      genC: org.scalatest.prop.Generator[C], genD: org.scalatest.prop.Generator[D])(fun: (A, B, C, D) => Future[T]): Future[PropertyCheckResult] = {
 
-      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult], failedABCD: Option[(A, B, C, D)])
+      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, aEdges: List[RoseTree[A]], bEdges: List[RoseTree[B]], cEdges: List[RoseTree[C]], dEdges: List[RoseTree[D]], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult], failedABCD: Option[(A, B, C, D)])
 
       val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
       val minSize = config.minSize
       val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
 
-      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[RoseTree[A]], bEdges: List[RoseTree[B]], cEdges: List[RoseTree[C]], dEdges: List[RoseTree[D]], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
         val (size, nextInitialSizes, nextRnd) =
           initialSizes match {
             case head :: tail => (head, tail, rnd)
@@ -1612,13 +1612,13 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
     private def checkForAll[A, B, C, D, E](names: List[String], config: Parameter, genA: org.scalatest.prop.Generator[A], genB: org.scalatest.prop.Generator[B],
                                         genC: org.scalatest.prop.Generator[C], genD: org.scalatest.prop.Generator[D], genE: org.scalatest.prop.Generator[E])(fun: (A, B, C, D, E) => Future[T]): Future[PropertyCheckResult] = {
 
-      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], eEdges: List[E], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult], failedABCDE: Option[(A, B, C, D, E)])
+      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, aEdges: List[RoseTree[A]], bEdges: List[RoseTree[B]], cEdges: List[RoseTree[C]], dEdges: List[RoseTree[D]], eEdges: List[RoseTree[E]], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult], failedABCDE: Option[(A, B, C, D, E)])
 
       val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
       val minSize = config.minSize
       val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
 
-      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], eEdges: List[E], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[RoseTree[A]], bEdges: List[RoseTree[B]], cEdges: List[RoseTree[C]], dEdges: List[RoseTree[D]], eEdges: List[RoseTree[E]], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
         val (size, nextInitialSizes, nextRnd) =
           initialSizes match {
             case head :: tail => (head, tail, rnd)
@@ -1793,13 +1793,13 @@ object PropCheckerAsserting extends ExpectationPropCheckerAsserting {
                                            genC: org.scalatest.prop.Generator[C], genD: org.scalatest.prop.Generator[D], genE: org.scalatest.prop.Generator[E],
                                            genF: org.scalatest.prop.Generator[F])(fun: (A, B, C, D, E, F) => Future[T]): Future[PropertyCheckResult] = {
 
-      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], eEdges: List[E], fEdges: List[F], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult], failedABCDEF: Option[(A, B, C, D, E, F)])
+      case class AccumulatedResult(succeededCount: Int, discardedCount: Int, aEdges: List[RoseTree[A]], bEdges: List[RoseTree[B]], cEdges: List[RoseTree[C]], dEdges: List[RoseTree[D]], eEdges: List[RoseTree[E]], fEdges: List[RoseTree[F]], rnd: Randomizer, initialSizes: List[PosZInt], result: Option[PropertyCheckResult], failedABCDEF: Option[(A, B, C, D, E, F)])
 
       val maxDiscarded = Configuration.calculateMaxDiscarded(config.maxDiscardedFactor, config.minSuccessful)
       val minSize = config.minSize
       val maxSize = PosZInt.ensuringValid(minSize + config.sizeRange)
 
-      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[A], bEdges: List[B], cEdges: List[C], dEdges: List[D], eEdges: List[E], fEdges: List[F], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
+      def loop(succeededCount: Int, discardedCount: Int, aEdges: List[RoseTree[A]], bEdges: List[RoseTree[B]], cEdges: List[RoseTree[C]], dEdges: List[RoseTree[D]], eEdges: List[RoseTree[E]], fEdges: List[RoseTree[F]], rnd: Randomizer, initialSizes: List[PosZInt], initSeed: Long): Future[AccumulatedResult] = {
         val (size, nextInitialSizes, nextRnd) =
           initialSizes match {
             case head :: tail => (head, tail, rnd)

--- a/jvm/core/src/main/scala/org/scalatest/prop/CommonGenerators.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/CommonGenerators.scala
@@ -143,13 +143,21 @@ trait CommonGenerators {
     import ord.mkOrderingOps
     require(from <= to)
     new Generator[T] {
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[T], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[T]], Randomizer) = {
         // Start with the edges of the underlying generator:
         val (base, nextRnd) = gen.initEdges(maxLength, rnd)
         // Snip away anything out of range:
-        val valueEdges = base.filter(i => i >= from && i <= to)
-        // Add the boundaries as edges for our new filter:
-        val fromToEdges = (from :: to :: valueEdges).distinct // distinct in case from equals to, and/or overlaps a value edge
+        val valueEdges = base.filter(rt => rt.value >= from && rt.value <= to)
+        // Add the boundaries as edges for our new filter. Dedupe by value (in case from equals
+        // to, and/or overlaps a value edge); RoseTree uses referential equality, so fold manually.
+        val fromToEdges = {
+          val combined = Rose(from) :: Rose(to) :: valueEdges
+          combined.foldLeft((List.empty[RoseTree[T]], Set.empty[T])) {
+            case ((acc, seen), rt) =>
+              if (seen.contains(rt.value)) (acc, seen)
+              else (acc :+ rt, seen + rt.value)
+          }._1
+        }
         val (allEdges, nextNextRnd) = Randomizer.shuffle(fromToEdges, nextRnd)
         (allEdges.take(maxLength), nextNextRnd)
       }
@@ -2358,7 +2366,7 @@ trait CommonGenerators {
 
     val (initEdges, rnd1) = genOfA.initEdges(100, Randomizer.default)
     @tailrec
-    def loop(currentCount: Int, edges: List[A], rnd: Randomizer, acc: Map[String, PosZInt]): Map[String, PosZInt] = {
+    def loop(currentCount: Int, edges: List[RoseTree[A]], rnd: Randomizer, acc: Map[String, PosZInt]): Map[String, PosZInt] = {
       if (currentCount >= count) acc
       else {
         val (nextRoseTreeOfA, nextEdges, nextRnd) = genOfA.next(SizeParam(PosZInt(0), PosZInt(100), PosZInt(100)), edges, rnd) // TODO: I think this need to mimic forAll.
@@ -2402,7 +2410,7 @@ trait CommonGenerators {
     new Generator[T] {
       private lazy val underlying: Generator[T] = gen
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[T], Randomizer) = underlying.initEdges(maxLength, rnd)
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[T]], Randomizer) = underlying.initEdges(maxLength, rnd)
 
       override def canonicals: LazyListOrStream[RoseTree[T]] = underlying.canonicals
 

--- a/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
+++ b/jvm/core/src/main/scala/org/scalatest/prop/Generator.scala
@@ -145,6 +145,11 @@ trait Generator[T] { thisGeneratorOfT =>
     * idea to think about whether there are appropriate edge cases for this type. (By default, this is empty,
     * so you can get your Generator working first, and think about edge cases after that.)
     *
+    * Each edge case is returned as a [[RoseTree]], so that a Generator may, if it wishes, attach shrinking
+    * structure to an edge (for example, an Option Generator can wrap each inner edge in a rose tree that
+    * preserves the underlying element's shrinking behavior). Where the Generator has no special shrink
+    * structure for a given edge, it may simply wrap the value in a [[Rose]].
+    *
     * It is common, but not required, to randomize the order of the edge cases here. If so, you should
     * use the [[Randomizer.shuffle]] function for this, so that the order is reproducible if something fails.
     * If you don't use the [[Randomizer]], just return it unchanged as part of the returned tuple.
@@ -156,7 +161,7 @@ trait Generator[T] { thisGeneratorOfT =>
     * @param rnd the [[Randomizer]] that should be used if you want randomization of the edges
     * @return a Tuple: the list of edges, and the next [[Randomizer]]
     */
-  def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[T], Randomizer) = (Nil, rnd)
+  def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[T]], Randomizer) = (Nil, rnd)
 
   /**
     * Implementation that generates the next value of type `T` using the provided `SizeParam`,
@@ -213,10 +218,10 @@ trait Generator[T] { thisGeneratorOfT =>
     * @return a Tuple of the next value, the remaining edges, and the resulting [[Randomizer]],
     *         as described above.
     */
-  def next(szp: SizeParam, edges: List[T], rnd: Randomizer): (RoseTree[T], List[T], Randomizer) = 
-    edges.filter(e => isValid(e, szp)) match {
+  def next(szp: SizeParam, edges: List[RoseTree[T]], rnd: Randomizer): (RoseTree[T], List[RoseTree[T]], Randomizer) = 
+    edges.filter(rt => isValid(rt.value, szp)) match {
       case head :: tail =>
-        (roseTreeOfEdge(head, szp, isValid), tail, rnd)
+        (roseTreeOfEdge(head.value, szp, isValid), tail, rnd)
       case _ =>
         @tailrec
         def loop(count: Int, nextRnd: Randomizer): (RoseTree[T], Randomizer) = {
@@ -259,9 +264,9 @@ trait Generator[T] { thisGeneratorOfT =>
     */
   def map[U](f: T => U): Generator[U] =
     new Generator[U] { thisGeneratorOfU => 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[U], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[U]], Randomizer) = {
         val (listOfT, nextRnd) = thisGeneratorOfT.initEdges(maxLength, rnd)
-        (listOfT.map(f), nextRnd)
+        (listOfT.map(rt => rt.map(f)), nextRnd)
       }
       def nextImpl(szp: SizeParam, isValidFun: (U, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[U], Randomizer) = {
         val (nextRoseTreeOfT, _, nextRandomizer) = thisGeneratorOfT.next(szp, Nil, rnd)
@@ -281,7 +286,7 @@ trait Generator[T] { thisGeneratorOfT =>
   def mapInvertible[U](f: T => U, g: U => T): Generator[U] = {
     new Generator[U] { thisGeneratorOfU =>
       private val underlying: Generator[U] = thisGeneratorOfT.map(f)
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[U], Randomizer) = underlying.initEdges(maxLength, rnd)
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[U]], Randomizer) = underlying.initEdges(maxLength, rnd)
       def nextImpl(szp: SizeParam, isValidFun: (U, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[U], Randomizer) = underlying.nextImpl(szp, isValidFun, rnd)
       override def map[V](f: U => V): Generator[V] = underlying.map(f)
       override def flatMap[V](f: U => Generator[V]): Generator[V] = underlying.flatMap(f)
@@ -322,9 +327,9 @@ trait Generator[T] { thisGeneratorOfT =>
   def flatMap[U](f: T => Generator[U]): Generator[U] = {
     new Generator[U] {
       thisGeneratorOfU =>
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[U], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[U]], Randomizer) = {
         val (listOfT, nextRnd) = thisGeneratorOfT.initEdges(maxLength, rnd)
-        val listOfGenOfU: List[Generator[U]] = listOfT.map(f)
+        val listOfGenOfU: List[Generator[U]] = listOfT.map(rt => f(rt.value))
         // We only want at most maxLength edges. In cases where we are composing many generators,
         // The total space of the combinations can get huge. We want to stop as soon as we reach
         // maxLength, but we want over time to include points from the entire space of
@@ -335,12 +340,12 @@ trait Generator[T] { thisGeneratorOfT =>
             Randomizer.shuffle(listOfGenOfU, nextRnd)
           else
             (listOfGenOfU, nextRnd)
-        val (listOfU, nextNextNextRnd): (List[U], Randomizer) = {
+        val (listOfU, nextNextNextRnd): (List[RoseTree[U]], Randomizer) = {
           @tailrec
-          def loop(remainingGenOfU: List[Generator[U]], nRnd: Randomizer, acc: Set[U]): (List[U], Randomizer) = {
+          def loop(remainingGenOfU: List[Generator[U]], nRnd: Randomizer, acc: Map[U, RoseTree[U]]): (List[RoseTree[U]], Randomizer) = {
             val accSize = acc.size
             if (accSize >= maxLength.value) {
-              val accList = acc.toList
+              val accList = acc.values.toList
               val (shuffledListOfU, nnRnd) =
                 if (accSize > maxLength.value) {
                   // To try and touch all the possibilities over time, if the List from which we are about
@@ -355,12 +360,13 @@ trait Generator[T] { thisGeneratorOfT =>
               remainingGenOfU match {
                 case head :: tail =>
                   val (listOfU, nnRnd) = head.initEdges(maxLength, nRnd)
-                  loop(tail, nnRnd, acc ++ listOfU)
-                case _ => (acc.toList, nRnd)
+                  val newAcc = listOfU.foldLeft(acc) { case (a, rt) => a.updated(rt.value, rt) }
+                  loop(tail, nnRnd, newAcc)
+                case _ => (acc.values.toList, nRnd)
               }
           }
 
-          loop(listOfGenOfU, nextRnd, Set.empty)
+          loop(listOfGenOfU, nextRnd, Map.empty)
         }
         (listOfU, nextNextNextRnd)
       }
@@ -666,9 +672,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Byte], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[Byte]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(byteEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       
       override def roseTreeOfEdge(edge: Byte, sizeParam: SizeParam, isValidFun: (Byte, SizeParam) => Boolean): RoseTree[Byte] = {
@@ -735,9 +741,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Short], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[Short]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(shortEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: Short, sizeParam: SizeParam, isValidFun: (Short, SizeParam) => Boolean): RoseTree[Short] = NextRoseTree(edge)(sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (Short, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[Short], Randomizer) = {
@@ -799,9 +805,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Char], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[Char]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(charEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: Char, sizeParam: SizeParam, isValidFun: (Char, SizeParam) => Boolean): RoseTree[Char] = NextRoseTree(edge)(sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (Char, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[Char], Randomizer) = {
@@ -867,9 +873,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Int], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[Int]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(intEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: Int, sizeParam: SizeParam, isValidFun: (Int, SizeParam) => Boolean): RoseTree[Int] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (Int, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[Int], Randomizer) = {
@@ -930,9 +936,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Long], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[Long]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(longEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: Long, sizeParam: SizeParam, isValidFun: (Long, SizeParam) => Boolean): RoseTree[Long] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (Long, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[Long], Randomizer) = {
@@ -1031,8 +1037,8 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Float], Randomizer) = {
-        (floatEdges.take(maxLength), rnd)
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[Float]], Randomizer) = {
+        (floatEdges.take(maxLength).map(v => Rose(v)), rnd)
       }
       override def roseTreeOfEdge(edge: Float, sizeParam: SizeParam, isValidFun: (Float, SizeParam) => Boolean): RoseTree[Float] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (Float, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[Float], Randomizer) = {
@@ -1132,8 +1138,8 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Double], Randomizer) = {
-        (doubleEdges.take(maxLength), rnd)
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[Double]], Randomizer) = {
+        (doubleEdges.take(maxLength).map(v => Rose(v)), rnd)
       }
       override def roseTreeOfEdge(edge: Double, sizeParam: SizeParam, isValidFun: (Double, SizeParam) => Boolean): RoseTree[Double] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (Double, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[Double], Randomizer) = {
@@ -1190,9 +1196,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosInt], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosInt]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(posIntEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: PosInt, sizeParam: SizeParam, isValidFun: (PosInt, SizeParam) => Boolean): RoseTree[PosInt] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosInt, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosInt], Randomizer) = {
@@ -1250,9 +1256,9 @@ object Generator {
 //DOTTY-ONLY
 //DOTTY-ONLY   private val edges: List[PosInt] = List(PosInt.MinValue, PosInt.ensuringValid(2), PosInt.MaxValue)
 //DOTTY-ONLY
-//DOTTY-ONLY   override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosInt], Randomizer) = {
+//DOTTY-ONLY   override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosInt]], Randomizer) = {
 //DOTTY-ONLY     val (allEdges, nextRnd) = Randomizer.shuffle(edges, rnd)
-//DOTTY-ONLY     (allEdges.take(maxLength), nextRnd)
+//DOTTY-ONLY     (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
 //DOTTY-ONLY   }
 //DOTTY-ONLY
 //DOTTY-ONLY   override def roseTreeOfEdge(edge: PosInt, sizeParam: SizeParam, isValidFun: (PosInt, SizeParam) => Boolean): RoseTree[PosInt] =
@@ -1314,9 +1320,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZInt], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosZInt]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(posZIntEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: PosZInt, sizeParam: SizeParam, isValidFun: (PosZInt, SizeParam) => Boolean): RoseTree[PosZInt] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosZInt, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosZInt], Randomizer) = {
@@ -1369,9 +1375,9 @@ object Generator {
 //DOTTY-ONLY
 //DOTTY-ONLY     private val edges: List[opaquetypes.PosInts.PosZInt] = List(opaquetypes.PosInts.PosZInt.MinValue, opaquetypes.PosInts.PosZInt.ensuringValid(1), opaquetypes.PosInts.PosZInt.MaxValue)
 //DOTTY-ONLY
-//DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[opaquetypes.PosInts.PosZInt], Randomizer) = {
+//DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[opaquetypes.PosInts.PosZInt]], Randomizer) = {
 //DOTTY-ONLY       val (allEdges, nextRnd) = Randomizer.shuffle(edges, rnd)
-//DOTTY-ONLY       (allEdges.take(maxLength), nextRnd)
+//DOTTY-ONLY       (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
 //DOTTY-ONLY     }
 //DOTTY-ONLY
 //DOTTY-ONLY     override def roseTreeOfEdge(edge: opaquetypes.PosInts.PosZInt, sizeParam: SizeParam, isValidFun: (opaquetypes.PosInts.PosZInt, SizeParam) => Boolean): RoseTree[opaquetypes.PosInts.PosZInt] =
@@ -1437,9 +1443,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosLong], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosLong]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(posLongEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: PosLong, sizeParam: SizeParam, isValidFun: (PosLong, SizeParam) => Boolean): RoseTree[PosLong] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosLong, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosLong], Randomizer) = {
@@ -1495,9 +1501,9 @@ object Generator {
 //DOTTY-ONLY
 //DOTTY-ONLY   private val edges: List[PosLong] = List(PosLong.MinValue, PosLong.ensuringValid(2L), PosLong.MaxValue)
 //DOTTY-ONLY
-//DOTTY-ONLY   override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosLong], Randomizer) = {
+//DOTTY-ONLY   override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosLong]], Randomizer) = {
 //DOTTY-ONLY     val (allEdges, nextRnd) = Randomizer.shuffle(edges, rnd)
-//DOTTY-ONLY     (allEdges.take(maxLength), nextRnd)
+//DOTTY-ONLY     (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
 //DOTTY-ONLY   }
 //DOTTY-ONLY
 //DOTTY-ONLY   override def roseTreeOfEdge(edge: PosLong, sizeParam: SizeParam, isValidFun: (PosLong, SizeParam) => Boolean): RoseTree[PosLong] =
@@ -1559,9 +1565,9 @@ object Generator {
         }
       }
       
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZLong], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosZLong]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(posZLongEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: PosZLong, sizeParam: SizeParam, isValidFun: (PosZLong, SizeParam) => Boolean): RoseTree[PosZLong] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosZLong, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosZLong], Randomizer) = {
@@ -1617,9 +1623,9 @@ object Generator {
 //DOTTY-ONLY
 //DOTTY-ONLY     private val edges: List[PosZLong] = List(PosZLong.MinValue, PosZLong.ensuringValid(1L), PosZLong.MaxValue)
 //DOTTY-ONLY
-//DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZLong], Randomizer) = {
+//DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosZLong]], Randomizer) = {
 //DOTTY-ONLY       val (allEdges, nextRnd) = Randomizer.shuffle(edges, rnd)
-//DOTTY-ONLY       (allEdges.take(maxLength), nextRnd)
+//DOTTY-ONLY       (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
 //DOTTY-ONLY     }
 //DOTTY-ONLY
 //DOTTY-ONLY     override def roseTreeOfEdge(edge: PosZLong, sizeParam: SizeParam, isValidFun: (PosZLong, SizeParam) => Boolean): RoseTree[PosZLong] =
@@ -1698,9 +1704,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosFloat], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosFloat]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(posFloatEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: PosFloat, sizeParam: SizeParam, isValidFun: (PosFloat, SizeParam) => Boolean): RoseTree[PosFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosFloat], Randomizer) = {
@@ -1772,9 +1778,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosFiniteFloat], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosFiniteFloat]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(posFiniteFloatEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: PosFiniteFloat, sizeParam: SizeParam, isValidFun: (PosFiniteFloat, SizeParam) => Boolean): RoseTree[PosFiniteFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosFiniteFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosFiniteFloat], Randomizer) = {
@@ -1854,9 +1860,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[FiniteFloat], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[FiniteFloat]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(finiteFloatEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: FiniteFloat, sizeParam: SizeParam, isValidFun: (FiniteFloat, SizeParam) => Boolean): RoseTree[FiniteFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (FiniteFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[FiniteFloat], Randomizer) = {
@@ -1936,9 +1942,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[FiniteDouble], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[FiniteDouble]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(finiteDoubleEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: FiniteDouble, sizeParam: SizeParam, isValidFun: (FiniteDouble, SizeParam) => Boolean): RoseTree[FiniteDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (FiniteDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[FiniteDouble], Randomizer) = {
@@ -2022,9 +2028,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZFloat], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosZFloat]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(posZFloatEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: PosZFloat, sizeParam: SizeParam, isValidFun: (PosZFloat, SizeParam) => Boolean): RoseTree[PosZFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosZFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosZFloat], Randomizer) = {
@@ -2099,9 +2105,9 @@ object Generator {
 //DOTTY-ONLY
 //DOTTY-ONLY   private val edges: List[PosZFloat] = List(PosZFloat.ensuringValid(-0.0f), PosZFloat.ensuringValid(0.0f), PosZFloat.MinPositiveValue, PosZFloat.ensuringValid(1.0f), PosZFloat.MaxValue, PosZFloat.PositiveInfinity)
 //DOTTY-ONLY
-//DOTTY-ONLY   override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZFloat], Randomizer) = {
+//DOTTY-ONLY   override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosZFloat]], Randomizer) = {
 //DOTTY-ONLY     val (allEdges, nextRnd) = Randomizer.shuffle(edges, rnd)
-//DOTTY-ONLY     (allEdges.take(maxLength), nextRnd)
+//DOTTY-ONLY     (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
 //DOTTY-ONLY   }
 //DOTTY-ONLY
 //DOTTY-ONLY   override def roseTreeOfEdge(edge: PosZFloat, sizeParam: SizeParam, isValidFun: (PosZFloat, SizeParam) => Boolean): RoseTree[PosZFloat] = NextRoseTree(edge, sizeParam, isValidFun)
@@ -2172,9 +2178,9 @@ object Generator {
 //DOTTY-ONLY
 //DOTTY-ONLY     private val edges: List[PosFloat] = List(PosFloat.ensuringValid(Float.MinPositiveValue), PosFloat.ensuringValid(1.0f), PosFloat.ensuringValid(Float.MaxValue), PosFloat.ensuringValid(Float.PositiveInfinity))
 //DOTTY-ONLY
-//DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosFloat], Randomizer) = {
+//DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosFloat]], Randomizer) = {
 //DOTTY-ONLY       val (allEdges, nextRnd) = Randomizer.shuffle(edges, rnd)
-//DOTTY-ONLY       (allEdges.take(maxLength), nextRnd)
+//DOTTY-ONLY       (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
 //DOTTY-ONLY     }
 //DOTTY-ONLY
 //DOTTY-ONLY     override def roseTreeOfEdge(edge: PosFloat, sizeParam: SizeParam, isValidFun: (PosFloat, SizeParam) => Boolean): RoseTree[PosFloat] =
@@ -2254,9 +2260,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZFiniteFloat], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosZFiniteFloat]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(posZFiniteFloatEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: PosZFiniteFloat, sizeParam: SizeParam, isValidFun: (PosZFiniteFloat, SizeParam) => Boolean): RoseTree[PosZFiniteFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosZFiniteFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosZFiniteFloat], Randomizer) = {
@@ -2323,9 +2329,9 @@ object Generator {
 //DOTTY-ONLY     // finite edges only (no infinities)
 //DOTTY-ONLY     private val edges: List[PosZFiniteFloat] = List(PosZFiniteFloat.ensuringValid(Float.MinPositiveValue), PosZFiniteFloat.ensuringValid(1.0f), PosZFiniteFloat.ensuringValid(Float.MaxValue))
 //DOTTY-ONLY
-//DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZFiniteFloat], Randomizer) = {
+//DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosZFiniteFloat]], Randomizer) = {
 //DOTTY-ONLY       val (allEdges, nextRnd) = Randomizer.shuffle(edges, rnd)
-//DOTTY-ONLY       (allEdges.take(maxLength), nextRnd)
+//DOTTY-ONLY       (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
 //DOTTY-ONLY     }
 //DOTTY-ONLY
 //DOTTY-ONLY     override def roseTreeOfEdge(edge: PosZFiniteFloat, sizeParam: SizeParam, isValidFun: (PosZFiniteFloat, SizeParam) => Boolean): RoseTree[PosZFiniteFloat] =
@@ -2396,9 +2402,9 @@ object Generator {
 //DOTTY-ONLY
 //DOTTY-ONLY     private val edges: List[PosFiniteFloat] = List(PosFiniteFloat.MinValue, PosFiniteFloat.ensuringValid(1.0f), PosFiniteFloat.MaxValue)
 //DOTTY-ONLY
-//DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosFiniteFloat], Randomizer) = {
+//DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosFiniteFloat]], Randomizer) = {
 //DOTTY-ONLY       val (allEdges, nextRnd) = Randomizer.shuffle(edges, rnd)
-//DOTTY-ONLY       (allEdges.take(maxLength), nextRnd)
+//DOTTY-ONLY       (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
 //DOTTY-ONLY     }
 //DOTTY-ONLY
 //DOTTY-ONLY     override def roseTreeOfEdge(edge: PosFiniteFloat, sizeParam: SizeParam, isValidFun: (PosFiniteFloat, SizeParam) => Boolean): RoseTree[PosFiniteFloat] =
@@ -2479,9 +2485,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosDouble], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosDouble]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(posDoubleEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: PosDouble, sizeParam: SizeParam, isValidFun: (PosDouble, SizeParam) => Boolean): RoseTree[PosDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosDouble], Randomizer) = {
@@ -2548,9 +2554,9 @@ object Generator {
   //DOTTY-ONLY
   //DOTTY-ONLY     private val edges: List[PosDouble] = List(PosDouble.ensuringValid(Double.MinPositiveValue), PosDouble.ensuringValid(1.0), PosDouble.ensuringValid(Double.MaxValue), PosDouble.ensuringValid(Double.PositiveInfinity))
   //DOTTY-ONLY
-  //DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosDouble], Randomizer) = {
+  //DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosDouble]], Randomizer) = {
   //DOTTY-ONLY       val (allEdges, nextRnd) = Randomizer.shuffle(edges, rnd)
-  //DOTTY-ONLY       (allEdges.take(maxLength), nextRnd)
+  //DOTTY-ONLY       (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
   //DOTTY-ONLY     }
   //DOTTY-ONLY
   //DOTTY-ONLY     override def roseTreeOfEdge(edge: PosDouble, sizeParam: SizeParam, isValidFun: (PosDouble, SizeParam) => Boolean): RoseTree[PosDouble] =
@@ -2628,9 +2634,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosFiniteDouble], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosFiniteDouble]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(posFiniteDoubleEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: PosFiniteDouble, sizeParam: SizeParam, isValidFun: (PosFiniteDouble, SizeParam) => Boolean): RoseTree[PosFiniteDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosFiniteDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosFiniteDouble], Randomizer) = {
@@ -2714,9 +2720,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZDouble], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosZDouble]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(posZDoubleEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: PosZDouble, sizeParam: SizeParam, isValidFun: (PosZDouble, SizeParam) => Boolean): RoseTree[PosZDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosZDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosZDouble], Randomizer) = {
@@ -2776,9 +2782,9 @@ object Generator {
   //DOTTY-ONLY
   //DOTTY-ONLY     private val edges: List[PosZDouble] = List(PosZDouble.ensuringValid(0.0), PosZDouble.ensuringValid(1.0), PosZDouble.ensuringValid(Double.MaxValue), PosZDouble.ensuringValid(Double.PositiveInfinity))
   //DOTTY-ONLY
-  //DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZDouble], Randomizer) = {
+  //DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosZDouble]], Randomizer) = {
   //DOTTY-ONLY       val (allEdges, nextRnd) = Randomizer.shuffle(edges, rnd)
-  //DOTTY-ONLY       (allEdges.take(maxLength), nextRnd)
+  //DOTTY-ONLY       (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
   //DOTTY-ONLY     }
   //DOTTY-ONLY
   //DOTTY-ONLY     override def roseTreeOfEdge(edge: PosZDouble, sizeParam: SizeParam, isValidFun: (PosZDouble, SizeParam) => Boolean): RoseTree[PosZDouble] =
@@ -2864,9 +2870,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZFiniteDouble], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosZFiniteDouble]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(posZFiniteDoubleEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: PosZFiniteDouble, sizeParam: SizeParam, isValidFun: (PosZFiniteDouble, SizeParam) => Boolean): RoseTree[PosZFiniteDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (PosZFiniteDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[PosZFiniteDouble], Randomizer) = {
@@ -2932,9 +2938,9 @@ object Generator {
   //DOTTY-ONLY
   //DOTTY-ONLY     private val edges: List[PosZFiniteDouble] = List(PosZFiniteDouble.MinValue, PosZFiniteDouble.MinPositiveValue, PosZFiniteDouble.ensuringValid(1.0), PosZFiniteDouble.MaxValue)
   //DOTTY-ONLY
-  //DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[PosZFiniteDouble], Randomizer) = {
+  //DOTTY-ONLY     override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[PosZFiniteDouble]], Randomizer) = {
   //DOTTY-ONLY       val (allEdges, nextRnd) = Randomizer.shuffle(edges, rnd)
-  //DOTTY-ONLY       (allEdges.take(maxLength), nextRnd)
+  //DOTTY-ONLY       (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
   //DOTTY-ONLY     }
   //DOTTY-ONLY
   //DOTTY-ONLY     override def roseTreeOfEdge(edge: PosZFiniteDouble, sizeParam: SizeParam, isValidFun: (PosZFiniteDouble, SizeParam) => Boolean): RoseTree[PosZFiniteDouble] =
@@ -3027,9 +3033,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroDouble], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NonZeroDouble]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(nonZeroDoubleEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NonZeroDouble, sizeParam: SizeParam, isValidFun: (NonZeroDouble, SizeParam) => Boolean): RoseTree[NonZeroDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NonZeroDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NonZeroDouble], Randomizer) = {
@@ -3110,9 +3116,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroFiniteDouble], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NonZeroFiniteDouble]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(nonZeroFiniteDoubleEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NonZeroFiniteDouble, sizeParam: SizeParam, isValidFun: (NonZeroFiniteDouble, SizeParam) => Boolean): RoseTree[NonZeroFiniteDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NonZeroFiniteDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NonZeroFiniteDouble], Randomizer) = {
@@ -3198,9 +3204,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroFloat], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NonZeroFloat]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(nonZeroFloatEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NonZeroFloat, sizeParam: SizeParam, isValidFun: (NonZeroFloat, SizeParam) => Boolean): RoseTree[NonZeroFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NonZeroFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NonZeroFloat], Randomizer) = {
@@ -3280,9 +3286,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroFiniteFloat], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NonZeroFiniteFloat]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(nonZeroFiniteFloatEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NonZeroFiniteFloat, sizeParam: SizeParam, isValidFun: (NonZeroFiniteFloat, SizeParam) => Boolean): RoseTree[NonZeroFiniteFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NonZeroFiniteFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NonZeroFiniteFloat], Randomizer) = {
@@ -3338,9 +3344,9 @@ object Generator {
         }
       } // TODO Confirm OK without Roses. I.e., will the last one have an empty shrinks method?
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroInt], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NonZeroInt]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(nonZeroIntEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NonZeroInt, sizeParam: SizeParam, isValidFun: (NonZeroInt, SizeParam) => Boolean): RoseTree[NonZeroInt] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NonZeroInt, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NonZeroInt], Randomizer) = {
@@ -3396,9 +3402,9 @@ object Generator {
         }
       } // TODO Confirm OK without Roses. I.e., will the last one have an empty shrinks method?
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NonZeroLong], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NonZeroLong]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(nonZeroLongEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NonZeroLong, sizeParam: SizeParam, isValidFun: (NonZeroLong, SizeParam) => Boolean): RoseTree[NonZeroLong] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NonZeroLong, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NonZeroLong], Randomizer) = {
@@ -3474,9 +3480,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegDouble], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NegDouble]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(negDoubleEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NegDouble, sizeParam: SizeParam, isValidFun: (NegDouble, SizeParam) => Boolean): RoseTree[NegDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegDouble], Randomizer) = {
@@ -3548,9 +3554,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegFiniteDouble], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NegFiniteDouble]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(negFiniteDoubleEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NegFiniteDouble, sizeParam: SizeParam, isValidFun: (NegFiniteDouble, SizeParam) => Boolean): RoseTree[NegFiniteDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegFiniteDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegFiniteDouble], Randomizer) = {
@@ -3626,9 +3632,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegFloat], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NegFloat]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(negFloatEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NegFloat, sizeParam: SizeParam, isValidFun: (NegFloat, SizeParam) => Boolean): RoseTree[NegFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegFloat], Randomizer) = {
@@ -3700,9 +3706,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegFiniteFloat], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NegFiniteFloat]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(negFiniteFloatEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NegFiniteFloat, sizeParam: SizeParam, isValidFun: (NegFiniteFloat, SizeParam) => Boolean): RoseTree[NegFiniteFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegFiniteFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegFiniteFloat], Randomizer) = {
@@ -3760,9 +3766,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegInt], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NegInt]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(negIntEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NegInt, sizeParam: SizeParam, isValidFun: (NegInt, SizeParam) => Boolean): RoseTree[NegInt] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegInt, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegInt], Randomizer) = {
@@ -3820,9 +3826,9 @@ object Generator {
         }
       } // TODO: Confirm OK with no Roses.
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegLong], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NegLong]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(negLongEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NegLong, sizeParam: SizeParam, isValidFun: (NegLong, SizeParam) => Boolean): RoseTree[NegLong] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegLong, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegLong], Randomizer) = {
@@ -3906,9 +3912,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZDouble], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NegZDouble]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(negZDoubleEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NegZDouble, sizeParam: SizeParam, isValidFun: (NegZDouble, SizeParam) => Boolean): RoseTree[NegZDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegZDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegZDouble], Randomizer) = {
@@ -3988,9 +3994,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZFiniteDouble], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NegZFiniteDouble]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(negZFiniteDoubleEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NegZFiniteDouble, sizeParam: SizeParam, isValidFun: (NegZFiniteDouble, SizeParam) => Boolean): RoseTree[NegZFiniteDouble] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegZFiniteDouble, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegZFiniteDouble], Randomizer) = {
@@ -4074,9 +4080,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZFloat], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NegZFloat]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(negZFloatEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NegZFloat, sizeParam: SizeParam, isValidFun: (NegZFloat, SizeParam) => Boolean): RoseTree[NegZFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegZFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegZFloat], Randomizer) = {
@@ -4156,9 +4162,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZFiniteFloat], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NegZFiniteFloat]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(negZFiniteFloatEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NegZFiniteFloat, sizeParam: SizeParam, isValidFun: (NegZFiniteFloat, SizeParam) => Boolean): RoseTree[NegZFiniteFloat] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegZFiniteFloat, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegZFiniteFloat], Randomizer) = {
@@ -4216,9 +4222,9 @@ object Generator {
         }
       } // TODO Confirm OK with no Rose.
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZInt], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NegZInt]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(negZIntEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NegZInt, sizeParam: SizeParam, isValidFun: (NegZInt, SizeParam) => Boolean): RoseTree[NegZInt] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegZInt, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegZInt], Randomizer) = {
@@ -4276,9 +4282,9 @@ object Generator {
         }
       } // TODO Confirm OK no Rose.
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NegZLong], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NegZLong]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(negZLongEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NegZLong, sizeParam: SizeParam, isValidFun: (NegZLong, SizeParam) => Boolean): RoseTree[NegZLong] = NextRoseTree(edge, sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NegZLong, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NegZLong], Randomizer) = {
@@ -4336,9 +4342,9 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[NumericChar], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[NumericChar]], Randomizer) = {
         val (allEdges, nextRnd) = Randomizer.shuffle(numericCharEdges, rnd)
-        (allEdges.take(maxLength), nextRnd)
+        (allEdges.take(maxLength).map(v => Rose(v)), nextRnd)
       }
       override def roseTreeOfEdge(edge: NumericChar, sizeParam: SizeParam, isValidFun: (NumericChar, SizeParam) => Boolean): RoseTree[NumericChar] = NextRoseTree(edge)(sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (NumericChar, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[NumericChar], Randomizer) = {
@@ -4411,8 +4417,8 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[String], Randomizer) = {
-        (stringEdges.take(maxLength), rnd)
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[String]], Randomizer) = {
+        (stringEdges.take(maxLength).map(v => Rose(v)), rnd)
       }
       override def roseTreeOfEdge(edge: String, sizeParam: SizeParam, isValidFun: (String, SizeParam) => Boolean): RoseTree[String] = NextRoseTree(edge)(sizeParam, isValidFun)
       def nextImpl(szp: SizeParam, isValidFun: (String, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[String], Randomizer) = {
@@ -4475,8 +4481,8 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[List[T]], Randomizer) = {
-        (listEdges.take(maxLength), rnd)
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[List[T]]], Randomizer) = {
+        (listEdges.take(maxLength).map(v => Rose(v)), rnd)
       }
 
       override def roseTreeOfEdge(edge: List[T], sizeParam: SizeParam, isValidFun: (List[T], SizeParam) => Boolean): RoseTree[List[T]] = NextRoseTree(edge, sizeParam, isValidFun)
@@ -4563,9 +4569,9 @@ object Generator {
   // SKIP-DOTTY-END
   //DOTTY-ONLY def function0Generator[T](implicit genOfT: Generator[T]): Generator[() => T] = {
     new Generator[() => T] { thisGeneratorOfFunction0 =>
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[() => T], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[() => T]], Randomizer) = {
         val (edgesOfT, nextRnd) = genOfT.initEdges(maxLength, rnd)
-        val edges = edgesOfT.map(t => PrettyFunction0(t))
+        val edges = edgesOfT.map(rt => rt.map(t => PrettyFunction0(t)))
         (edges, nextRnd)
       }
       def nextImpl(szp: SizeParam, isValidFun: (() => T, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[() => T], Randomizer) = {
@@ -5713,11 +5719,11 @@ object Generator {
 
     new Generator[Option[T]] {
 
-      // TODO: Ah, maybe edges should return List[RoseTree[Option[T]], Randomizer] instead. Then it could be shrunken.
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Option[T]], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[Option[T]]], Randomizer) = {
         // Subtract one from length, and we'll wrap those in Somes. Subtract one so that None can be the first edge.
+        // Each inner edge is carried as a RoseTree so it preserves the underlying element's shrinking behavior.
         val (edgesOfT, nextRnd) = genOfT.initEdges(if (maxLength > 0) PosZInt.ensuringValid((maxLength - 1)) else 0, rnd)
-        val edges = None :: edgesOfT.map(t => Some(t))
+        val edges = Rose(None: Option[T]) :: edgesOfT.map(rt => rt.map(t => Some(t): Option[T]))
         (edges, nextRnd)
       }
 
@@ -5801,20 +5807,20 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[G Or B], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[G Or B]], Randomizer) = {
         val (edgesOfG, nextRnd) = genOfG.initEdges(maxLength, rnd)
         val (edgesOfB, nextNextRnd) = genOfB.initEdges(maxLength, nextRnd)
         // Fill up to maxLength, favoring Good over Bad if maxLength is odd. Else just dividing it
         // down the middle, half Good, half Bad. And filling in with the other if one side runs out.
         @tailrec
-        def loop(count: Int, remainingG: List[G], remainingB: List[B], acc: List[G Or B]): List[G Or B] = {
+        def loop(count: Int, remainingG: List[RoseTree[G]], remainingB: List[RoseTree[B]], acc: List[RoseTree[G Or B]]): List[RoseTree[G Or B]] = {
           (count, remainingG, remainingB) match {
             case (0, _, _) => acc
             case (_, Nil, Nil) => acc
-            case (c, gHead :: gTail, Nil) => loop(c - 1, gTail, Nil, Good(gHead) :: acc)
-            case (c, Nil, bHead :: bTail) => loop(c - 1, Nil, bTail, Bad(bHead) :: acc)
-            case (c, gHead :: gTail, _) if c % 2 == 0 => loop(c - 1, gTail, remainingB, Good(gHead) :: acc)
-            case (c, _, bHead :: bTail) => loop(c - 1, remainingG, bTail, Bad(bHead) :: acc)
+            case (c, gHead :: gTail, Nil) => loop(c - 1, gTail, Nil, gHead.map(g => Good(g): G Or B) :: acc)
+            case (c, Nil, bHead :: bTail) => loop(c - 1, Nil, bTail, bHead.map(b => Bad(b): G Or B) :: acc)
+            case (c, gHead :: gTail, _) if c % 2 == 0 => loop(c - 1, gTail, remainingB, gHead.map(g => Good(g): G Or B) :: acc)
+            case (c, _, bHead :: bTail) => loop(c - 1, remainingG, bTail, bHead.map(b => Bad(b): G Or B) :: acc)
           }
         }
         (loop(maxLength, edgesOfG, edgesOfB, Nil), nextNextRnd)
@@ -5901,20 +5907,20 @@ object Generator {
         }
       }
 
-      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[Either[L, R]], Randomizer) = {
+      override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[Either[L, R]]], Randomizer) = {
         val (edgesOfL, nextRnd) = genOfL.initEdges(maxLength, rnd)
         val (edgesOfR, nextNextRnd) = genOfR.initEdges(maxLength, nextRnd)
         // Fill up to maxLength, favoring Right over Left if maxLength is odd. Else just dividing it
         // down the middle, half Right, half Left. And filling in with the other if one side runs out.
         @tailrec
-        def loop(count: Int, remainingR: List[R], remainingL: List[L], acc: List[Either[L, R]]): List[Either[L, R]] = {
+        def loop(count: Int, remainingR: List[RoseTree[R]], remainingL: List[RoseTree[L]], acc: List[RoseTree[Either[L, R]]]): List[RoseTree[Either[L, R]]] = {
           (count, remainingR, remainingL) match {
             case (0, _, _) => acc
             case (_, Nil, Nil) => acc
-            case (c, rHead :: rTail, Nil) => loop(c - 1, rTail, Nil, Right(rHead) :: acc)
-            case (c, Nil, lHead :: lTail) => loop(c - 1, Nil, lTail, Left(lHead) :: acc)
-            case (c, rHead :: rTail, _) if c % 2 == 0 => loop(c - 1, rTail, remainingL, Right(rHead) :: acc)
-            case (c, _, lHead :: lTail) => loop(c - 1, remainingR, lTail, Left(lHead) :: acc)
+            case (c, rHead :: rTail, Nil) => loop(c - 1, rTail, Nil, rHead.map(r => Right(r): Either[L, R]) :: acc)
+            case (c, Nil, lHead :: lTail) => loop(c - 1, Nil, lTail, lHead.map(l => Left(l): Either[L, R]) :: acc)
+            case (c, rHead :: rTail, _) if c % 2 == 0 => loop(c - 1, rTail, remainingL, rHead.map(r => Right(r): Either[L, R]) :: acc)
+            case (c, _, lHead :: lTail) => loop(c - 1, remainingR, lTail, lHead.map(l => Left(l): Either[L, R]) :: acc)
           }
         }
         (loop(maxLength, edgesOfR, edgesOfL, Nil), nextNextRnd)

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/CommonGeneratorsSpec.scala
@@ -113,7 +113,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[Byte] = bytesBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -123,7 +123,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = bytes.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = bytes.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -136,7 +136,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[Byte] = bytesBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -190,7 +190,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[Short] = shortsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -200,7 +200,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = shorts.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = shorts.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -213,7 +213,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[Short] = shortsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -267,7 +267,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[Int] = intsBetween(min, max) 
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -277,7 +277,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = ints.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = ints.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         // sortedEdges: List[Int] = List(-2147483648, -1, 0, 1, 2147483647)
         val sortedEdges = edges.sorted
         // res5: List[List[Int]] = List(List(-2147483648, -1), List(-2147483648, 0), List(-2147483648, 1),
@@ -294,7 +294,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[Int] = intsBetween(from, to) 
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -348,7 +348,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[Long] = longsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -358,7 +358,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = longs.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = longs.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -371,7 +371,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[Long] = longsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -425,7 +425,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[Char] = charsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -435,7 +435,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = chars.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = chars.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -448,7 +448,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[Char] = charsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -502,7 +502,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[Float] = floatsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -512,7 +512,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = floats.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = floats.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -525,7 +525,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[Float] = floatsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -579,7 +579,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[Double] = doublesBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -589,7 +589,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = doubles.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = doubles.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -602,7 +602,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[Double] = doublesBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -659,7 +659,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[PosInt] = posIntsBetween(min, max) 
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should (have length 1 or have length 2)
           edges should contain (min)
           edges should contain (max)
@@ -669,7 +669,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = posInts.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = posInts.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         // sortedEdges: List[Int] = List(-2147483648, -1, 0, 1, 2147483647)
         val sortedEdges = edges.sorted
         // res5: List[List[Int]] = List(List(-2147483648, -1), List(-2147483648, 0), List(-2147483648, 1),
@@ -686,7 +686,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[PosInt] = posIntsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -740,7 +740,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[PosLong] = posLongsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -750,7 +750,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = posLongs.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = posLongs.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -763,7 +763,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[PosLong] = posLongsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -817,7 +817,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[PosFloat] = posFloatsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -827,7 +827,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = posFloats.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = posFloats.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -840,7 +840,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[PosFloat] = posFloatsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -894,7 +894,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[PosFiniteFloat] = posFiniteFloatsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -904,7 +904,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = posFiniteFloats.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = posFiniteFloats.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -917,7 +917,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[PosFiniteFloat] = posFiniteFloatsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -971,7 +971,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[PosDouble] = posDoublesBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -982,7 +982,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = posDoubles.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = posDoubles.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -995,7 +995,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[PosDouble] = posDoublesBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -1049,7 +1049,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[PosFiniteDouble] = posFiniteDoublesBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -1060,7 +1060,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = posFiniteDoubles.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = posFiniteDoubles.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -1073,7 +1073,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[PosFiniteDouble] = posFiniteDoublesBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -1128,7 +1128,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[PosZInt] = posZIntsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should (have length 1 or have length 2 or have length 3)
           edges should contain (min)
           edges should contain (max)
@@ -1138,7 +1138,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = posZInts.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = posZInts.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -1151,7 +1151,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[PosZInt] = posZIntsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -1205,7 +1205,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[PosZLong] = posZLongsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -1215,7 +1215,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = posZLongs.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = posZLongs.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -1228,7 +1228,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[PosZLong] = posZLongsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -1282,7 +1282,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[PosZFloat] = posZFloatsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -1292,7 +1292,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = posZFloats.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = posZFloats.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -1305,7 +1305,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[PosZFloat] = posZFloatsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -1359,7 +1359,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[PosZFiniteFloat] = posZFiniteFloatsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -1369,7 +1369,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = posZFiniteFloats.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = posZFiniteFloats.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -1382,7 +1382,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[PosZFiniteFloat] = posZFiniteFloatsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -1436,7 +1436,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[PosZDouble] = posZDoublesBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -1447,7 +1447,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = posZDoubles.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = posZDoubles.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -1460,7 +1460,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[PosZDouble] = posZDoublesBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -1514,7 +1514,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[PosZFiniteDouble] = posZFiniteDoublesBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -1525,7 +1525,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = posZFiniteDoubles.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = posZFiniteDoubles.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -1538,7 +1538,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[PosZFiniteDouble] = posZFiniteDoublesBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -1595,7 +1595,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NegInt] = negIntsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should (have length 1 or have length 2)
           edges should contain (min)
           edges should contain (max)
@@ -1605,7 +1605,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = negInts.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = negInts.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -1618,7 +1618,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NegInt] = negIntsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -1672,7 +1672,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NegLong] = negLongsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -1682,7 +1682,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = negLongs.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = negLongs.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -1695,7 +1695,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NegLong] = negLongsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -1749,7 +1749,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NegFloat] = negFloatsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -1759,7 +1759,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = negFloats.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = negFloats.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -1772,7 +1772,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NegFloat] = negFloatsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -1826,7 +1826,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NegFiniteFloat] = negFiniteFloatsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -1836,7 +1836,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = negFiniteFloats.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = negFiniteFloats.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -1849,7 +1849,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NegFiniteFloat] = negFiniteFloatsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -1903,7 +1903,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NegDouble] = negDoublesBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -1914,7 +1914,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = negDoubles.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = negDoubles.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -1927,7 +1927,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NegDouble] = negDoublesBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -1981,7 +1981,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NegFiniteDouble] = negFiniteDoublesBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -1992,7 +1992,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = negFiniteDoubles.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = negFiniteDoubles.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -2005,7 +2005,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NegFiniteDouble] = negFiniteDoublesBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -2060,7 +2060,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NegZInt] = negZIntsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should (have length 1 or have length 2 or have length 3)
           edges should contain (min)
           edges should contain (max)
@@ -2070,7 +2070,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = negZInts.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = negZInts.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -2083,7 +2083,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NegZInt] = negZIntsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -2137,7 +2137,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NegZLong] = negZLongsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -2147,7 +2147,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = negZLongs.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = negZLongs.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -2160,7 +2160,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NegZLong] = negZLongsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -2214,7 +2214,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NegZFloat] = negZFloatsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -2224,7 +2224,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = negZFloats.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = negZFloats.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -2237,7 +2237,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NegZFloat] = negZFloatsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -2291,7 +2291,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NegZFiniteFloat] = negZFiniteFloatsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -2301,7 +2301,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = negZFiniteFloats.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = negZFiniteFloats.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -2314,7 +2314,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NegZFiniteFloat] = negZFiniteFloatsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -2368,7 +2368,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NegZDouble] = negZDoublesBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -2379,7 +2379,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = negZDoubles.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = negZDoubles.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -2392,7 +2392,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NegZDouble] = negZDoublesBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -2446,7 +2446,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NegZFiniteDouble] = negZFiniteDoublesBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -2457,7 +2457,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = negZFiniteDoubles.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = negZFiniteDoubles.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -2470,7 +2470,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NegZFiniteDouble] = negZFiniteDoublesBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -2527,7 +2527,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NonZeroInt] = nonZeroIntsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should (have length 1 or have length 2 or have length 3 or have length 4)
           edges should contain (min)
           edges should contain (max)
@@ -2537,7 +2537,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = nonZeroInts.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = nonZeroInts.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -2550,7 +2550,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NonZeroInt] = nonZeroIntsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -2604,7 +2604,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NonZeroLong] = nonZeroLongsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -2614,7 +2614,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = nonZeroLongs.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = nonZeroLongs.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -2627,7 +2627,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NonZeroLong] = nonZeroLongsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -2681,7 +2681,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NonZeroFloat] = nonZeroFloatsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -2691,7 +2691,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = nonZeroFloats.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = nonZeroFloats.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -2704,7 +2704,7 @@ class CommonGeneratorsSpec extends AnyWordSpec with Matchers {
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NonZeroFloat] = nonZeroFloatsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -2778,7 +2778,7 @@ If it doesn't show up for a while, please delete this comment.
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NonZeroFiniteFloat] = nonZeroFiniteFloatsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -2788,7 +2788,7 @@ If it doesn't show up for a while, please delete this comment.
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = nonZeroFiniteFloats.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = nonZeroFiniteFloats.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -2801,7 +2801,7 @@ If it doesn't show up for a while, please delete this comment.
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NonZeroFiniteFloat] = nonZeroFiniteFloatsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -2855,7 +2855,7 @@ If it doesn't show up for a while, please delete this comment.
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NonZeroDouble] = nonZeroDoublesBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -2866,7 +2866,7 @@ If it doesn't show up for a while, please delete this comment.
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = nonZeroDoubles.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = nonZeroDoubles.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -2879,7 +2879,7 @@ If it doesn't show up for a while, please delete this comment.
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NonZeroDouble] = nonZeroDoublesBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -2933,7 +2933,7 @@ If it doesn't show up for a while, please delete this comment.
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[NonZeroFiniteDouble] = nonZeroFiniteDoublesBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -2944,7 +2944,7 @@ If it doesn't show up for a while, please delete this comment.
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = nonZeroFiniteDoubles.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = nonZeroFiniteDoubles.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -2957,7 +2957,7 @@ If it doesn't show up for a while, please delete this comment.
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[NonZeroFiniteDouble] = nonZeroFiniteDoublesBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -3011,7 +3011,7 @@ If it doesn't show up for a while, please delete this comment.
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[FiniteFloat] = finiteFloatsBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -3021,7 +3021,7 @@ If it doesn't show up for a while, please delete this comment.
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = finiteFloats.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = finiteFloats.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -3034,7 +3034,7 @@ If it doesn't show up for a while, please delete this comment.
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[FiniteFloat] = finiteFloatsBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -3088,7 +3088,7 @@ If it doesn't show up for a while, please delete this comment.
 
         forAll (minMaxPairs) { case (min, max) =>
           val minMaxGen: Generator[FiniteDouble] = finiteDoublesBetween(min, max)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges.length should (be >= 1 or be <= 7)
           edges should contain (min)
           edges should contain (max)
@@ -3099,7 +3099,7 @@ If it doesn't show up for a while, please delete this comment.
 
         import org.scalatest.Inspectors._
 
-        val (edges, rnd1) = finiteDoubles.initEdges(100, Randomizer.default)
+        val (edges, rnd1) = { val t = finiteDoubles.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
         val sortedEdges = edges.sorted
         val combos = sortedEdges.combinations(2).toList
 
@@ -3112,7 +3112,7 @@ If it doesn't show up for a while, please delete this comment.
         forAll (combos) { case List(from, to) =>
           val requiredEdges = included(from, to)
           val minMaxGen: Generator[FiniteDouble] = finiteDoublesBetween(from, to)
-          val (edges, _) = minMaxGen.initEdges(100, Randomizer.default)
+          val (edges, _) = { val t = minMaxGen.initEdges(100, Randomizer.default); (t._1.map(_.value), t._2) }
           edges should contain allElementsOf requiredEdges
           val outOfBoundsEdges = sortedEdges.filter(i => i < from || i > to)
           edges should contain noElementsOf outOfBoundsEdges
@@ -3278,7 +3278,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3292,7 +3292,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3306,7 +3306,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3320,7 +3320,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3334,7 +3334,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3348,7 +3348,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3362,7 +3362,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3376,7 +3376,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3399,7 +3399,7 @@ If it doesn't show up for a while, please delete this comment.
       val rnd = Randomizer.default
       val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
       val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-      implicitGenEdges shouldEqual namedGenEdges
+      implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
       val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
       val namedGenSamples = samplesForGen(namedGen, 100, rnd)
       implicitGenSamples shouldEqual namedGenSamples
@@ -3432,7 +3432,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3530,7 +3530,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3544,7 +3544,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3558,7 +3558,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3572,7 +3572,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3586,7 +3586,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3600,7 +3600,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3614,7 +3614,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3628,7 +3628,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3642,7 +3642,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3656,7 +3656,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3670,7 +3670,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3684,7 +3684,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3698,7 +3698,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -3712,7 +3712,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -3726,7 +3726,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -3740,7 +3740,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -3754,7 +3754,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -3768,7 +3768,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -3782,7 +3782,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -3796,7 +3796,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -3810,7 +3810,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -3824,7 +3824,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -3838,7 +3838,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -3852,7 +3852,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -3866,7 +3866,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3880,7 +3880,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3894,7 +3894,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3908,7 +3908,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3922,7 +3922,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3936,7 +3936,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3950,7 +3950,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3964,7 +3964,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3978,7 +3978,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -3992,7 +3992,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4006,7 +4006,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4020,7 +4020,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4034,7 +4034,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4048,7 +4048,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4062,7 +4062,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4076,7 +4076,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4090,7 +4090,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4104,7 +4104,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4118,7 +4118,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4132,7 +4132,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4146,7 +4146,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4160,7 +4160,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4174,7 +4174,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4188,7 +4188,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4202,7 +4202,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4216,7 +4216,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4230,7 +4230,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4244,7 +4244,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4258,7 +4258,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4272,7 +4272,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4286,7 +4286,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4300,7 +4300,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4314,7 +4314,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4328,7 +4328,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4342,7 +4342,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4356,7 +4356,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4370,7 +4370,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4384,7 +4384,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4398,7 +4398,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4412,7 +4412,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4426,7 +4426,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4440,7 +4440,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges.map(_.value) shouldEqual namedGenEdges
+        implicitGenEdges.map(rt => rt.value.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples.map(_.value) shouldEqual namedGenSamples
@@ -4455,7 +4455,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4469,7 +4469,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4483,7 +4483,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4497,7 +4497,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4511,7 +4511,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4525,7 +4525,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4539,7 +4539,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4553,7 +4553,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4567,7 +4567,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4581,7 +4581,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4595,7 +4595,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4609,7 +4609,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4623,7 +4623,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4637,7 +4637,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4651,7 +4651,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4665,7 +4665,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4679,7 +4679,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4693,7 +4693,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4707,7 +4707,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4721,7 +4721,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4735,7 +4735,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4749,7 +4749,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4763,7 +4763,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 1, rnd)
         val namedGenSamples = samplesForGen(namedGen, 1, rnd)
         // We can't actually compare the functions themselves, which don't have
@@ -4783,7 +4783,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         // We can't actually compare the functions themselves, which don't have
@@ -4804,7 +4804,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4818,7 +4818,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4832,7 +4832,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4846,7 +4846,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -4860,7 +4860,7 @@ If it doesn't show up for a while, please delete this comment.
         val rnd = Randomizer.default
         val (implicitGenEdges, _) = implicitGen.initEdges(100, rnd)
         val (namedGenEdges, _) = namedGen.initEdges(100, rnd)
-        implicitGenEdges shouldEqual namedGenEdges
+        implicitGenEdges.map(_.value) shouldEqual namedGenEdges.map(_.value)
         val implicitGenSamples = samplesForGen(implicitGen, 100, rnd)
         val namedGenSamples = samplesForGen(namedGen, 100, rnd)
         implicitGenSamples shouldEqual namedGenSamples
@@ -5487,7 +5487,7 @@ If it doesn't show up for a while, please delete this comment.
       // maxLength: PosZInt, rnd: Randomizer): (List[T], Randomizer) = (Nil, rnd)
       val (lazyEdges, _) = lazyGen.initEdges(100, stableRnd)
       val (eagerEdges, _) = eagerGen.initEdges(100, stableRnd)
-      lazyEdges shouldEqual eagerEdges
+      lazyEdges.map(_.value) shouldEqual eagerEdges.map(_.value)
 
       // (Iterator[T], Randomizer)
       val lazyCanonicalsIt = lazyGen.canonicals

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/GeneratorSpec.scala
@@ -228,13 +228,13 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       initEdges.length should equal (initEdges1.length * initEdges2.length)
 
-      val comboLists: List[List[Int]] = initEdges1.combinations(2).toList
+      val comboLists: List[List[Int]] = initEdges1.map(_.value).combinations(2).toList
       val comboPairs: List[(Int, Int)] = comboLists.map(xs => (xs(0), xs(1)))
       val plusReversedPairs: List[(Int, Int)] = comboPairs flatMap { case (x, y) => List((x, y), (y, x)) }
-      val sameValuePairs: List[(Int, Int)] = initEdges1.map(i => (i, i))
+      val sameValuePairs: List[(Int, Int)] = initEdges1.map(rt => (rt.value, rt.value))
       val expectedInitEdges: List[(Int, Int)] = plusReversedPairs ++ sameValuePairs
 
-      initEdges should contain theSameElementsAs expectedInitEdges
+      initEdges.map(_.value) should contain theSameElementsAs expectedInitEdges
 
       val (tup1, e1, r1) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
       val (tup2, e2, r2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = e1, rnd = r1)
@@ -325,7 +325,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = byteGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[Byte], ae1: List[Byte], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[Byte], ae1: List[RoseTree[Byte]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -375,7 +375,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.byteGenerator.filter(_ > 5)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(30.toByte), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(30.toByte, SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(15.toByte, 7.toByte)
@@ -415,7 +415,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = shortGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[Short], ae1: List[Short], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[Short], ae1: List[RoseTree[Short]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -465,7 +465,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.shortGenerator.filter(_ > 5)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(30.toShort), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(30.toShort, SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(15.toShort, 7.toShort)
@@ -505,7 +505,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = intGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[Int], ae1: List[Int], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[Int], ae1: List[RoseTree[Int]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -552,7 +552,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.intGenerator.filter(_ > 5)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(30), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(30, SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(15, 7)
@@ -592,7 +592,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = longGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[Long], ae1: List[Long], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[Long], ae1: List[RoseTree[Long]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -647,7 +647,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.longGenerator.filter(_ > 5L)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(30L), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(30L, SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(15L, 7L)
@@ -687,7 +687,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = charGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[Char], ae1: List[Char], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[Char], ae1: List[RoseTree[Char]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val edges = List(a1, a2)
         edges.map(_.value) should contain (Char.MinValue)
@@ -725,14 +725,14 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         }
         import org.scalatest.Inspectors
         Inspectors.forAll (expectedChars) { (c: Char) =>
-          val (shrinkRoseTree, _, _) = generator.next(SizeParam(1, 0, 1), List(c), Randomizer.default)
+          val (shrinkRoseTree, _, _) = generator.next(SizeParam(1, 0, 1), List(generator.roseTreeOfEdge(c, SizeParam(1, 0, 1), generator.isValid)), Randomizer.default)
           val shrinks: LazyListOrStream[Char] = shrinkRoseTree.shrinks.map(_.value)
           shrinks shouldEqual expectedChars.drop(expectedChars.indexOf(c) + 1)
         }
       }
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.charGenerator.filter(c => c.toLower == c)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List('9'), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge('9', SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List('8', '7', '6', '5', '4', '3', '2', '1', '0', 
@@ -769,7 +769,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = floatGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[Float], ae1: List[Float], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[Float], ae1: List[RoseTree[Float]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -857,7 +857,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.floatGenerator.filter(_ > 5.0f)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(40.0f), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(40.0f, SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(6.0f)
@@ -889,7 +889,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = doubleGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[Double], ae1: List[Double], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[Double], ae1: List[RoseTree[Double]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -946,7 +946,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.doubleGenerator.filter(_ > 5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(40.0), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(40.0, SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(6.0)
@@ -1116,7 +1116,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = posIntGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[PosInt], ae1: List[PosInt], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[PosInt], ae1: List[RoseTree[PosInt]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val edges = List(a1, a2).map(_.value)
         edges should contain (PosInt(1))
@@ -1158,7 +1158,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.posIntGenerator.filter(_.value > 5)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(PosInt(30)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(PosInt(30), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosInt(15), PosInt(7))
@@ -1198,7 +1198,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = posZIntGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[PosZInt], ae1: List[PosZInt], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[PosZInt], ae1: List[RoseTree[PosZInt]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val edges = List(a1, a2, a3).map(_.value)
@@ -1242,7 +1242,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.posZIntGenerator.filter(_.value > 5)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(PosZInt(30)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(PosZInt(30), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosZInt(15), PosZInt(7))
@@ -1282,7 +1282,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = posLongGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[PosLong], ae1: List[PosLong], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[PosLong], ae1: List[RoseTree[PosLong]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val edges = List(a1, a2).map(_.value)
         edges should contain (PosLong(1L))
@@ -1323,7 +1323,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.posLongGenerator.filter(_.value > 5)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(PosLong(30L)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(PosLong(30L), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosLong(15L), PosLong(7L))
@@ -1363,7 +1363,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = posZLongGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[PosZLong], ae1: List[PosZLong], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[PosZLong], ae1: List[RoseTree[PosZLong]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val edges = List(a1, a2, a3).map(_.value)
@@ -1407,7 +1407,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.posZLongGenerator.filter(_.value > 5)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(PosZLong(30L)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(PosZLong(30L), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosZLong(15L), PosZLong(7L))
@@ -1447,7 +1447,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = posFloatGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[PosFloat], ae1: List[PosFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[PosFloat], ae1: List[RoseTree[PosFloat]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -1494,7 +1494,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.posFloatGenerator.filter(_ > 5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(PosFloat(40.0f)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(PosFloat(40.0f), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosFloat(6.0f))
@@ -1534,7 +1534,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = posFiniteFloatGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[PosFiniteFloat], ae1: List[PosFiniteFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[PosFiniteFloat], ae1: List[RoseTree[PosFiniteFloat]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val edges = List(a1, a2, a3).map(_.value)
@@ -1578,7 +1578,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.posFiniteFloatGenerator.filter(_ > 5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(PosFiniteFloat(40.0f)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(PosFiniteFloat(40.0f), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosFiniteFloat(6.0f))
@@ -1618,7 +1618,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = posZFloatGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[PosZFloat], ae1: List[PosZFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[PosZFloat], ae1: List[RoseTree[PosZFloat]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -1669,7 +1669,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.posZFloatGenerator.filter(_ > 5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(PosZFloat(40.0f)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(PosZFloat(40.0f), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosZFloat(6.0f))
@@ -1709,7 +1709,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = posZFiniteFloatGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[PosZFiniteFloat], ae1: List[PosZFiniteFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[PosZFiniteFloat], ae1: List[RoseTree[PosZFiniteFloat]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -1758,7 +1758,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.posZFiniteFloatGenerator.filter(_ > 5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(PosZFiniteFloat(40.0f)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(PosZFiniteFloat(40.0f), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosZFiniteFloat(6.0f))
@@ -1798,7 +1798,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = posDoubleGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[PosDouble], ae1: List[PosDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[PosDouble], ae1: List[RoseTree[PosDouble]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -1845,7 +1845,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.posDoubleGenerator.filter(_ > 5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(PosDouble(40.0)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(PosDouble(40.0), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosDouble(6.0))
@@ -1885,7 +1885,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = posFiniteDoubleGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[PosFiniteDouble], ae1: List[PosFiniteDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[PosFiniteDouble], ae1: List[RoseTree[PosFiniteDouble]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val edges = List(a1, a2, a3).map(_.value)
@@ -1931,7 +1931,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.posFiniteDoubleGenerator.filter(_ > 5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(PosFiniteDouble(40.0)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(PosFiniteDouble(40.0), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosFiniteDouble(6.0))
@@ -1971,7 +1971,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = posZDoubleGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[PosZDouble], ae1: List[PosZDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[PosZDouble], ae1: List[RoseTree[PosZDouble]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -2022,7 +2022,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.posZDoubleGenerator.filter(_ > 5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(PosZDouble(40.0)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(PosZDouble(40.0), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosZDouble(6.0))
@@ -2062,7 +2062,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = posZFiniteDoubleGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[PosZFiniteDouble], ae1: List[PosZFiniteDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[PosZFiniteDouble], ae1: List[RoseTree[PosZFiniteDouble]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -2111,7 +2111,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.posZFiniteDoubleGenerator.filter(_ > 5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(PosZFiniteDouble(40.0)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(PosZFiniteDouble(40.0), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(PosZFiniteDouble(6.0))
@@ -2151,7 +2151,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = negIntGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NegInt], ae1: List[NegInt], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NegInt], ae1: List[RoseTree[NegInt]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val edges = List(a1, a2).map(_.value)
         edges should contain (NegInt(-1))
@@ -2193,7 +2193,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.negIntGenerator.filter(_ < -5)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NegInt(-30)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NegInt(-30), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegInt(-15), NegInt(-7))
@@ -2233,7 +2233,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = negZIntGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NegZInt], ae1: List[NegZInt], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NegZInt], ae1: List[RoseTree[NegZInt]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val edges = List(a1, a2, a3).map(_.value)
@@ -2277,7 +2277,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.negZIntGenerator.filter(_ < -5)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NegInt(-30)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NegInt(-30), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegZInt(-15), NegZInt(-7))
@@ -2317,7 +2317,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = negLongGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NegLong], ae1: List[NegLong], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NegLong], ae1: List[RoseTree[NegLong]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val edges = List(a1, a2).map(_.value)
         edges should contain (NegLong(-1L))
@@ -2359,7 +2359,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.negLongGenerator.filter(_ < -5)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NegLong(-30L)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NegLong(-30L), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegLong(-15L), NegLong(-7L))
@@ -2399,7 +2399,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = negZLongGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NegZLong], ae1: List[NegZLong], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NegZLong], ae1: List[RoseTree[NegZLong]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val edges = List(a1, a2, a3).map(_.value)
@@ -2443,7 +2443,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.negZLongGenerator.filter(_ < -5)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NegZLong(-30L)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NegZLong(-30L), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegZLong(-15L), NegZLong(-7L))
@@ -2483,7 +2483,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = negFloatGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NegFloat], ae1: List[NegFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NegFloat], ae1: List[RoseTree[NegFloat]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -2530,7 +2530,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.negFloatGenerator.filter(_ < -5.0f)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NegFloat(-40.0f)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NegFloat(-40.0f), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegFloat(-6.0f))
@@ -2570,7 +2570,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = negFiniteFloatGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NegFiniteFloat], ae1: List[NegFiniteFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NegFiniteFloat], ae1: List[RoseTree[NegFiniteFloat]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val edges = List(a1, a2, a3).map(_.value)
@@ -2617,7 +2617,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.negFiniteFloatGenerator.filter(_ < -5.0f)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NegFiniteFloat(-40.0f)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NegFiniteFloat(-40.0f), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegFiniteFloat(-6.0f))
@@ -2657,7 +2657,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = negZFloatGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NegZFloat], ae1: List[NegZFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NegZFloat], ae1: List[RoseTree[NegZFloat]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -2708,7 +2708,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.negZFloatGenerator.filter(_ < -5.0f)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NegZFloat(-40.0f)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NegZFloat(-40.0f), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegZFloat(-6.0f))
@@ -2748,7 +2748,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = negZFiniteFloatGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NegZFiniteFloat], ae1: List[NegZFiniteFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NegZFiniteFloat], ae1: List[RoseTree[NegZFiniteFloat]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -2797,7 +2797,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.negZFiniteFloatGenerator.filter(_ < -5.0f)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NegZFiniteFloat(-40.0f)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NegZFiniteFloat(-40.0f), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegZFiniteFloat(-6.0f))
@@ -2837,7 +2837,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = negDoubleGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NegDouble], ae1: List[NegDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NegDouble], ae1: List[RoseTree[NegDouble]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -2884,7 +2884,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.negDoubleGenerator.filter(_ < -5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NegDouble(-40.0)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NegDouble(-40.0), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegDouble(-6.0))
@@ -2924,7 +2924,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = negFiniteDoubleGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NegFiniteDouble], ae1: List[NegFiniteDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NegFiniteDouble], ae1: List[RoseTree[NegFiniteDouble]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val edges = List(a1, a2, a3).map(_.value)
@@ -2969,7 +2969,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.negFiniteDoubleGenerator.filter(_ < -5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NegFiniteDouble(-40.0)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NegFiniteDouble(-40.0), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegFiniteDouble(-6.0))
@@ -3009,7 +3009,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = negZDoubleGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NegZDouble], ae1: List[NegZDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NegZDouble], ae1: List[RoseTree[NegZDouble]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -3060,7 +3060,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.negZDoubleGenerator.filter(_ < -5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NegZDouble(-40.0)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NegZDouble(-40.0), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegZDouble(-6.0))
@@ -3100,7 +3100,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = negZFiniteDoubleGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NegZFiniteDouble], ae1: List[NegZFiniteDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NegZFiniteDouble], ae1: List[RoseTree[NegZFiniteDouble]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -3149,7 +3149,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.negZFiniteDoubleGenerator.filter(_ < -5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NegZFiniteDouble(-40.0)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NegZFiniteDouble(-40.0), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NegZFiniteDouble(-6.0))
@@ -3189,7 +3189,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = nonZeroIntGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NonZeroInt], ae1: List[NonZeroInt], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NonZeroInt], ae1: List[RoseTree[NonZeroInt]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -3238,7 +3238,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.nonZeroIntGenerator.filter(_ > 5)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NonZeroInt(30)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NonZeroInt(30), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NonZeroInt(15), NonZeroInt(7))
@@ -3278,7 +3278,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = nonZeroLongGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NonZeroLong], ae1: List[NonZeroLong], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NonZeroLong], ae1: List[RoseTree[NonZeroLong]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -3327,7 +3327,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.nonZeroLongGenerator.filter(_ > 5L)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NonZeroLong(30L)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NonZeroLong(30L), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NonZeroLong(15L), NonZeroLong(7L))
@@ -3367,7 +3367,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = nonZeroFloatGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NonZeroFloat], ae1: List[NonZeroFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NonZeroFloat], ae1: List[RoseTree[NonZeroFloat]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -3425,7 +3425,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.nonZeroFloatGenerator.filter(_ > 5.0f)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NonZeroFloat(40.0f)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NonZeroFloat(40.0f), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NonZeroFloat(6.0f))
@@ -3465,7 +3465,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = nonZeroFiniteFloatGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NonZeroFiniteFloat], ae1: List[NonZeroFiniteFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NonZeroFiniteFloat], ae1: List[RoseTree[NonZeroFiniteFloat]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -3519,7 +3519,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.nonZeroFiniteFloatGenerator.filter(_ > 5.0f)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NonZeroFiniteFloat(40.0f)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NonZeroFiniteFloat(40.0f), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NonZeroFiniteFloat(6.0f))
@@ -3559,7 +3559,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = nonZeroDoubleGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NonZeroDouble], ae1: List[NonZeroDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NonZeroDouble], ae1: List[RoseTree[NonZeroDouble]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -3617,7 +3617,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.nonZeroDoubleGenerator.filter(_ > 5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NonZeroDouble(40.0)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NonZeroDouble(40.0), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NonZeroDouble(6.0))
@@ -3657,7 +3657,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = nonZeroFiniteDoubleGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[NonZeroFiniteDouble], ae1: List[NonZeroFiniteDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[NonZeroFiniteDouble], ae1: List[RoseTree[NonZeroFiniteDouble]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -3711,7 +3711,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.nonZeroFiniteDoubleGenerator.filter(_ > 5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NonZeroFiniteDouble(40.0)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NonZeroFiniteDouble(40.0), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NonZeroFiniteDouble(6.0))
@@ -3751,7 +3751,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = finiteFloatGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[FiniteFloat], ae1: List[FiniteFloat], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[FiniteFloat], ae1: List[RoseTree[FiniteFloat]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -3806,7 +3806,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.finiteFloatGenerator.filter(_ > 5.0f)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(FiniteFloat(40.0f)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(FiniteFloat(40.0f), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(FiniteFloat(6.0f))
@@ -3846,7 +3846,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         import Generator._
         val gen = finiteDoubleGenerator
         val (initEdges, ier) = gen.initEdges(10, Randomizer.default)
-        val (a1: RoseTree[FiniteDouble], ae1: List[FiniteDouble], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
+        val (a1: RoseTree[FiniteDouble], ae1: List[RoseTree[FiniteDouble]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = initEdges, rnd = ier)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, ae3, ar3) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val (a4, ae4, ar4) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae3, rnd = ar3)
@@ -3901,7 +3901,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.finiteDoubleGenerator.filter(_ > 5.0)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(FiniteDouble(40.0)), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(FiniteDouble(40.0), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(FiniteDouble(6.0))
@@ -3981,7 +3981,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.numericCharGenerator.filter(_.value.toString.toInt > 5)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(NumericChar('9')), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(NumericChar('9'), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List(NumericChar('8'), NumericChar('7'), NumericChar('6'))
@@ -4052,7 +4052,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.stringGenerator.filter(_.length > 5)
-        val (rs, _, _) = aGen.next(SizeParam(1, 99, 100), List("one two three four five"), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 99, 100), List(aGen.roseTreeOfEdge("one two three four five", SizeParam(1, 99, 100), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not be empty
         shrinkees.toList shouldBe List("ee four five", "one two thr", "wo thr")
@@ -4088,8 +4088,8 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val (intEdges, _) = baseGen.initEdges(100, rnd)
         val (optEdges, _) = gen.initEdges(100, rnd)
 
-        optEdges should contain (None)
-        optEdges.filter(_.isDefined).map(_.get) should contain theSameElementsAs intEdges
+        optEdges.map(_.value) should contain (None: Option[Int])
+        optEdges.map(_.value).filter(_.isDefined).map(_.get) should contain theSameElementsAs intEdges.map(_.value)
       }
 
       it("should use the base type for canonicals") {
@@ -4158,14 +4158,14 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val gen = optionGenerator[Int]
         val rnd = Randomizer.default
 
-        val (optShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(None), rnd)
+        val (optShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(gen.roseTreeOfEdge(None, SizeParam(1, 0, 1), gen.isValid)), rnd)
 
         assert(optShrink.shrinks.isEmpty)
       }
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.optionGenerator[String].filter(_.nonEmpty)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(Some("test")), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Some("test"), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not contain (None)
 
@@ -4191,7 +4191,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val (bEdges, _) = bGen.initEdges(100, rnd)
         val (orEdges, _) = gen.initEdges(100, rnd)
 
-        orEdges should contain theSameElementsAs(gEdges.map(Good(_)) ++ bEdges.map(Bad(_)))
+        orEdges.map(_.value) should contain theSameElementsAs(gEdges.map(_.value).map(Good(_)) ++ bEdges.map(_.value).map(Bad(_)))
       }
 
       it("should use the base types for canonicals") {
@@ -4250,10 +4250,10 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val gen = orGenerator[Int, Long]
 
         val rnd = Randomizer.default
-        val (gShrink, _, _) = gGen.next(SizeParam(1, 0, 1), List(1000), rnd)
-        val (bShrink, _, _) = bGen.next(SizeParam(1, 0, 1), List(2000L), rnd)
-        val (orGoodShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(Good(1000)), rnd)
-        val (orBadShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(Bad(2000L)), rnd)
+        val (gShrink, _, _) = gGen.next(SizeParam(1, 0, 1), List(gGen.roseTreeOfEdge(1000, SizeParam(1, 0, 1), gGen.isValid)), rnd)
+        val (bShrink, _, _) = bGen.next(SizeParam(1, 0, 1), List(bGen.roseTreeOfEdge(2000L, SizeParam(1, 0, 1), bGen.isValid)), rnd)
+        val (orGoodShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(gen.roseTreeOfEdge(Good(1000), SizeParam(1, 0, 1), gen.isValid)), rnd)
+        val (orBadShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(gen.roseTreeOfEdge(Bad(2000L), SizeParam(1, 0, 1), gen.isValid)), rnd)
 
         orGoodShrink.shrinks.map(_.value) should contain theSameElementsAs(gShrink.shrinks.map(_.value).map(Good(_)).toList)
         orBadShrink.shrinks.map(_.value) should contain theSameElementsAs(bShrink.shrinks.map(_.value).map(Bad(_)).toList)
@@ -4270,12 +4270,12 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
         val rnd = Randomizer.default
         
-        val (orGoodShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(Good(1000)), rnd)
+        val (orGoodShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(gen.roseTreeOfEdge(Good(1000), SizeParam(1, 0, 1), gen.isValid)), rnd)
         val orGoodShrinkees = orGoodShrink.shrinks.map(_.value)
         orGoodShrinkees should not be empty
         orGoodShrinkees.toList shouldBe List(Good(500), Good(250))
 
-        val (orBadShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(Bad(2000L)), rnd)
+        val (orBadShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(gen.roseTreeOfEdge(Bad(2000L), SizeParam(1, 0, 1), gen.isValid)), rnd)
         val orBadShrinkees = orBadShrink.shrinks.map(_.value)
         orBadShrinkees should not be empty
         orBadShrinkees.toList shouldBe List(Bad(1000L), Bad(500L), Bad(250L))
@@ -4306,7 +4306,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val (lEdges, _) = lGen.initEdges(100, rnd)
         val (eitherEdges, _) = gen.initEdges(100, rnd)
 
-        eitherEdges should contain theSameElementsAs(rEdges.map(Right(_)) ++ lEdges.map(Left(_)))
+        eitherEdges.map(_.value) should contain theSameElementsAs(rEdges.map(_.value).map(Right(_)) ++ lEdges.map(_.value).map(Left(_)))
       }
 
       it("should use the base types for canonicals") {
@@ -4362,10 +4362,10 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val gen = eitherGenerator[Long, Int]
 
         val rnd = Randomizer.default
-        val (rShrink, _, _) = rGen.next(SizeParam(1, 0, 1), List(1000), rnd)
-        val (lShrink, _, _) = lGen.next(SizeParam(1, 0, 1), List(2000L), rnd)
-        val (eitherRightShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(Right(1000)), rnd)
-        val (eitherLeftShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(Left(2000L)), rnd)
+        val (rShrink, _, _) = rGen.next(SizeParam(1, 0, 1), List(rGen.roseTreeOfEdge(1000, SizeParam(1, 0, 1), rGen.isValid)), rnd)
+        val (lShrink, _, _) = lGen.next(SizeParam(1, 0, 1), List(lGen.roseTreeOfEdge(2000L, SizeParam(1, 0, 1), lGen.isValid)), rnd)
+        val (eitherRightShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(gen.roseTreeOfEdge(Right(1000), SizeParam(1, 0, 1), gen.isValid)), rnd)
+        val (eitherLeftShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(gen.roseTreeOfEdge(Left(2000L), SizeParam(1, 0, 1), gen.isValid)), rnd)
 
         eitherRightShrink.shrinks.map(_.value) should contain theSameElementsAs(rShrink.shrinks.map(_.value).map(Right(_)).toList)
         eitherLeftShrink.shrinks.map(_.value) should contain theSameElementsAs(lShrink.shrinks.map(_.value).map(Left(_)).toList)
@@ -4382,12 +4382,12 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
         val rnd = Randomizer.default
         
-        val (orLeftShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(Left(1000)), rnd)
+        val (orLeftShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(gen.roseTreeOfEdge(Left(1000), SizeParam(1, 0, 1), gen.isValid)), rnd)
         val orLeftShrinkees = orLeftShrink.shrinks.map(_.value)
         orLeftShrinkees should not be empty
         orLeftShrinkees.toList shouldBe List(Left(500), Left(250))
 
-        val (orRightShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(Right(2000L)), rnd)
+        val (orRightShrink, _, _) = gen.next(SizeParam(1, 0, 1), List(gen.roseTreeOfEdge(Right(2000L), SizeParam(1, 0, 1), gen.isValid)), rnd)
         val orRightShrinkees = orRightShrink.shrinks.map(_.value)
         orRightShrinkees should not be empty
         orRightShrinkees.toList shouldBe List(Right(1000L), Right(500L), Right(250L))
@@ -4426,7 +4426,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       val intCanonicals = intCanonicalsIt.toList
       forAll { (xs: F[Int]) =>
         // pass in List(xs) as only edge case so the generator will generate rose tree with the specified value.
-        val (shrinkRoseTree, _, _) = generator.next(SizeParam(1, 0, 1), List(xs), Randomizer.default)
+        val (shrinkRoseTree, _, _) = generator.next(SizeParam(1, 0, 1), List(generator.roseTreeOfEdge(xs, SizeParam(1, 0, 1), generator.isValid)), Randomizer.default)
         val shrinks: LazyListOrStream[F[Int]] = shrinkRoseTree.shrinks.map(_.value).reverse
         if (xs.isEmpty)
           shrinks shouldBe empty
@@ -4565,12 +4565,12 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       it("should not exhibit this bug in List shrinking") {
         val lstGen = implicitly[Generator[List[List[Int]]]]
         val xss = List(List(100, 200, 300, 400, 300))
-        lstGen.next(SizeParam(1, 0, 1), List(xss), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
+        lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(xss, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
       }
       it("should return an empty LazyListOrStream when asked to shrink a List of size 0") {
         val lstGen = implicitly[Generator[List[Int]]]
         val xs = List.empty[Int]
-        lstGen.next(SizeParam(1, 0, 1), List(xs), Randomizer.default)._1.shrinks.map(_.value) shouldBe empty
+        lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(xs, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value) shouldBe empty
       }
       it("should shrink List with an algo towards empty List") {
         import GeneratorDrivenPropertyChecks._
@@ -4591,17 +4591,17 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following size determined by havingSize method") {
         val aGen= Generator.listGenerator[Int].havingSize(5)
-        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(List(3, 99)), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(List(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         all(shrinkees) should have size 5
       }
       it("should produce shrinkees following length determined by havingLength method") {
         val aGen= Generator.vectorGenerator[Int].havingLength(5)
-        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(Vector(3, 99)), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Vector(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         all(shrinkees) should have length 5
       }
       it("should produce shrinkees following sizes determined by havingSizesBetween method") {
         val aGen= Generator.vectorGenerator[Int].havingSizesBetween(2, 5)
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(Vector(3, 99)), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Vector(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.size >= 4)
           shrinkees should not be empty
@@ -4611,7 +4611,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following sizes determined by havingLengthsBetween method") {
         val aGen= Generator.vectorGenerator[Int].havingLengthsBetween(2, 5)
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(Vector(3, 99)), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Vector(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.length >= 4)
           shrinkees should not be empty
@@ -4621,7 +4621,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following sizes determined by havingSizesDeterminedBy method") {
         val aGen= Generator.vectorGenerator[Int].havingSizesDeterminedBy(s => SizeParam(2, 3, 5))
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(Vector(3, 99)), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Vector(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.size >= 4)
           shrinkees should not be empty
@@ -4631,7 +4631,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following sizes determined by havingLengthsDeterminedBy method") {
         val aGen= Generator.vectorGenerator[Int].havingLengthsDeterminedBy(s => SizeParam(2, 3, 5))
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(Vector(3, 99)), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Vector(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.length >= 4)
           shrinkees should not be empty
@@ -4645,7 +4645,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         // for example, that that one doesn't show up in the shrinks output, because it would be the original list-to-shrink.
         val lstGen = implicitly[Generator[List[Int]]]
         val listToShrink = List.fill(16)(99)
-        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(listToShrink), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(listToShrink, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a list generator whose canonical method uses the canonical method of the underlying T") {
@@ -4670,7 +4670,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
 
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.listGenerator[String].filter(_.nonEmpty)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(List("1", "2", "3", "4")), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(List("1", "2", "3", "4"), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not contain (List.empty[String])
 
@@ -4700,7 +4700,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val (function0EdgesIt, _) = function0s.initEdges(100, rnd1)
         val intEdges = intEdgesIt.toList
         val function0Edges = function0EdgesIt.toList
-        function0Edges.map(f => f()) should contain theSameElementsAs intEdges
+        function0Edges.map(rt => rt.value()) should contain theSameElementsAs intEdges.map(_.value)
       }
       it("should offer an implicit provider for constant function0's that returns the canonicals of the result type") {
         val ints = Generator.intGenerator
@@ -4806,7 +4806,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce Vector[T] edge values first in random order") {
         val gen = Generator.vectorGenerator[Int]
-        val (a1: RoseTree[Vector[Int]], ae1: List[Vector[Int]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = List(Vector.empty[Int], Vector(1, 2), Vector(3, 4, 5)), rnd = Randomizer.default)
+        val (a1: RoseTree[Vector[Int]], ae1: List[RoseTree[Vector[Int]]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = List(Rose(Vector.empty[Int]), Rose(Vector(1, 2)), Rose(Vector(3, 4, 5))), rnd = Randomizer.default)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val edges = List(a1, a2, a3).map(_.value)
@@ -4897,7 +4897,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       it("should not exhibit this bug in Vector shrinking") {
         val vectorGen = implicitly[Generator[Vector[Vector[Int]]]]
         val xss = Vector(Vector(100, 200, 300, 400, 300))
-        vectorGen.next(SizeParam(1, 0, 1), List(xss), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
+        vectorGen.next(SizeParam(1, 0, 1), List(vectorGen.roseTreeOfEdge(xss, SizeParam(1, 0, 1), vectorGen.isValid)), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
       }
       it("should shrink Vector with an algo towards empty Vector") {
         import GeneratorDrivenPropertyChecks._
@@ -4918,17 +4918,17 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following size determined by havingSize method") {
         val aGen= Generator.vectorGenerator[Int].havingSize(5)
-        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(Vector(3, 99)), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Vector(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         all(shrinkees) should have size 5
       }
       it("should produce shrinkees following length determined by havingLength method") {
         val aGen= Generator.vectorGenerator[Int].havingLength(5)
-        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(Vector(3, 99)), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Vector(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         all(shrinkees) should have length 5
       }
       it("should produce shrinkees following sizes determined by havingSizesBetween method") {
         val aGen= Generator.vectorGenerator[Int].havingSizesBetween(2, 5)
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(Vector(3, 99)), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Vector(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.size >= 4)
           shrinkees should not be empty
@@ -4938,7 +4938,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following sizes determined by havingLengthsBetween method") {
         val aGen= Generator.vectorGenerator[Int].havingLengthsBetween(2, 5)
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(Vector(3, 99)), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Vector(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.length >= 4)
           shrinkees should not be empty
@@ -4948,7 +4948,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following sizes determined by havingSizesDeterminedBy method") {
         val aGen= Generator.vectorGenerator[Int].havingSizesDeterminedBy(s => SizeParam(2, 3, 5))
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(Vector(3, 99)), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Vector(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.size >= 4)
           shrinkees should not be empty
@@ -4958,7 +4958,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following sizes determined by havingLengthsDeterminedBy method") {
         val aGen= Generator.vectorGenerator[Int].havingLengthsDeterminedBy(s => SizeParam(2, 3, 5))
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(Vector(3, 99)), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Vector(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.length >= 4)
           shrinkees should not be empty
@@ -4969,11 +4969,11 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       it("should return an empty LazyListOrStream when asked to shrink a Vector of size 0") {
         val lstGen = implicitly[Generator[Vector[Int]]]
         val xs = Vector.empty[Int]
-        lstGen.next(SizeParam(1, 0, 1), List(xs), Randomizer.default)._1.shrinks shouldBe empty
+        lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(xs, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks shouldBe empty
       }
       it("should return an LazyListOrStream that does not repeat canonicals when asked to shrink a Vector of size 2 that includes canonicals") {
         val lstGen = implicitly[Generator[Vector[Int]]]
-        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(Vector(3, 99)), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(Vector(3, 99), SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         shrinkees.distinct should contain theSameElementsAs shrinkees
       }
       it("should return an LazyListOrStream that does not repeat the passed list-to-shink even if that list has a power of 2 length") {
@@ -4982,7 +4982,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         // for example, that that one doesn't show up in the shrinks output, because it would be the original list-to-shrink.
         val lstGen = implicitly[Generator[Vector[Int]]]
         val listToShrink = Vector.fill(16)(99)
-        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(listToShrink), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(listToShrink, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a Vector generator whose canonical method uses the canonical method of the underlying T") {
@@ -5005,7 +5005,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.vectorGenerator[String].filter(_.nonEmpty)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(Vector("1", "2", "3", "4")), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Vector("1", "2", "3", "4"), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not contain (Vector.empty[String])
 
@@ -5042,7 +5042,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce Set[T] edge values first in random order") {
         val gen = Generator.setGenerator[Int]
-        val (a1: RoseTree[Set[Int]], ae1: List[Set[Int]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = List(Set.empty[Int], Set(1, 2), Set(3, 4, 5)), rnd = Randomizer.default)
+        val (a1: RoseTree[Set[Int]], ae1: List[RoseTree[Set[Int]]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = List(Rose(Set.empty[Int]), Rose(Set(1, 2)), Rose(Set(3, 4, 5))), rnd = Randomizer.default)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val edges = List(a1, a2, a3).map(_.value)
@@ -5093,7 +5093,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       it("should not exhibit this bug in Set shrinking") {
         val setGen = implicitly[Generator[Set[Set[Int]]]]
         val xss = Set(Set(100, 200, 300, 400, 300))
-        setGen.next(SizeParam(1, 0, 1), List(xss), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
+        setGen.next(SizeParam(1, 0, 1), List(setGen.roseTreeOfEdge(xss, SizeParam(1, 0, 1), setGen.isValid)), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
       }
       it("should shrink Set with an algo towards empty Set") {
         import GeneratorDrivenPropertyChecks._
@@ -5114,12 +5114,12 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following size determined by havingSize method") {
         val aGen= Generator.setGenerator[Int].havingSize(5)
-        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(Set(3, 99)), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Set(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         all(shrinkees) should have size 5
       }
       it("should produce shrinkees following sizes determined by havingSizesBetween method") {
         val aGen= Generator.setGenerator[Int].havingSizesBetween(2, 5)
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(Set(3, 99)), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Set(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.size >= 4)
           shrinkees should not be empty
@@ -5129,7 +5129,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following sizes determined by havingSizesDeterminedBy method") {
         val aGen= Generator.setGenerator[Int].havingSizesDeterminedBy(s => SizeParam(2, 3, 5))
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(Set(3, 99)), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Set(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.size >= 4)
           shrinkees should not be empty
@@ -5140,11 +5140,11 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       it("should return an empty LazyListOrStream when asked to shrink a Set of size 0") {
         val lstGen = implicitly[Generator[Set[Int]]]
         val xs = Set.empty[Int]
-        lstGen.next(SizeParam(1, 0, 1), List(xs), Randomizer.default)._1.shrinks.map(_.value).toSet shouldBe empty
+        lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(xs, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value).toSet shouldBe empty
       }
       it("should return an LazyListOrStream that does not repeat canonicals when asked to shrink a Set of size 2 that includes canonicals") {
         val lstGen = implicitly[Generator[Set[Int]]]
-        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(Set(3, 99)), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(Set(3, 99), SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         shrinkees.distinct should contain theSameElementsAs shrinkees
       }
       it("should return an LazyListOrStream that does not repeat the passed set-to-shink even if that set has a power of 2 length") {
@@ -5155,7 +5155,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val listToShrink: Set[Int] = (Set.empty[Int] /: (1 to 16)) { (set, n) =>
           set + n
         }
-        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(listToShrink), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(listToShrink, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a Set generator whose canonical method uses the canonical method of the underlying T") {
@@ -5178,7 +5178,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.setGenerator[String].filter(_.nonEmpty)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(Set("1", "2", "3", "4")), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Set("1", "2", "3", "4"), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not contain (Set.empty[String])
 
@@ -5215,7 +5215,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce SortedSet[T] edge values first in random order") {
         val gen = Generator.sortedSetGenerator[Int]
-        val (a1: RoseTree[SortedSet[Int]], ae1: List[SortedSet[Int]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = List(SortedSet.empty[Int], SortedSet(1, 2), SortedSet(3, 4, 5)), rnd = Randomizer.default)
+        val (a1: RoseTree[SortedSet[Int]], ae1: List[RoseTree[SortedSet[Int]]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = List(Rose(SortedSet.empty[Int]), Rose(SortedSet(1, 2)), Rose(SortedSet(3, 4, 5))), rnd = Randomizer.default)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val edges = List(a1, a2, a3).map(_.value)
@@ -5267,7 +5267,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         implicit val ordering: Ordering[SortedSet[Int]] = Ordering.by[SortedSet[Int], Int](_.size)
         val setGen = implicitly[Generator[SortedSet[SortedSet[Int]]]]
         val xss = SortedSet(SortedSet(100, 200, 300, 400, 300))
-        setGen.next(SizeParam(1, 0, 1), List(xss), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
+        setGen.next(SizeParam(1, 0, 1), List(setGen.roseTreeOfEdge(xss, SizeParam(1, 0, 1), setGen.isValid)), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
       }
       it("should shrink Set with an algo towards empty Set") {
         import GeneratorDrivenPropertyChecks._
@@ -5288,12 +5288,12 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following size determined by havingSize method") {
         val aGen= Generator.sortedSetGenerator[Int].havingSize(5)
-        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(SortedSet(3, 99)), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(SortedSet(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         all(shrinkees) should have size 5
       }
       it("should produce shrinkees following sizes determined by havingSizesBetween method") {
         val aGen= Generator.sortedSetGenerator[Int].havingSizesBetween(2, 5)
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(SortedSet(3, 99)), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(SortedSet(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.size >= 4)
           shrinkees should not be empty
@@ -5303,7 +5303,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following sizes determined by havingSizesDeterminedBy method") {
         val aGen= Generator.sortedSetGenerator[Int].havingSizesDeterminedBy(s => SizeParam(2, 3, 5))
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(SortedSet(3, 99)), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(SortedSet(3, 99), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.size >= 4)
           shrinkees should not be empty
@@ -5314,11 +5314,11 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       it("should return an empty LazyListOrStream when asked to shrink a SortedSet of size 0") {
         val lstGen = implicitly[Generator[SortedSet[Int]]]
         val xs = SortedSet.empty[Int]
-        lstGen.next(SizeParam(1, 0, 1), List(xs), Randomizer.default)._1.shrinks.map(_.value).toSet shouldBe empty
+        lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(xs, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value).toSet shouldBe empty
       }
       it("should return an LazyListOrStream that does not repeat canonicals when asked to shrink a SortedSet of size 2 that includes canonicals") {
         val lstGen = implicitly[Generator[SortedSet[Int]]]
-        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(SortedSet(3, 99)), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(SortedSet(3, 99), SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         shrinkees.distinct should contain theSameElementsAs shrinkees
       }
       it("should return an LazyListOrStream that does not repeat the passed set-to-shink even if that set has a power of 2 length") {
@@ -5329,7 +5329,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val listToShrink: SortedSet[Int] = (SortedSet.empty[Int] /: (1 to 16)) { (set, n) =>
           set + n
         }
-        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(listToShrink), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(listToShrink, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a Set generator whose canonical method uses the canonical method of the underlying T") {
@@ -5352,7 +5352,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.sortedSetGenerator[String].filter(_.nonEmpty)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(SortedSet("1", "2", "3", "4")), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(SortedSet("1", "2", "3", "4"), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not contain (Set.empty[String])
 
@@ -5389,7 +5389,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce Map[K, V] edge values first in random order") {
         val gen = Generator.mapGenerator[Int, String]
-        val (a1: RoseTree[Map[Int, String]], ae1: List[Map[Int, String]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = List(Map.empty[Int, String], Map(1 -> "one", 2 -> "two"), Map(3 -> "three", 4 -> "four", 5 -> "five")), rnd = Randomizer.default)
+        val (a1: RoseTree[Map[Int, String]], ae1: List[RoseTree[Map[Int, String]]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = List(Rose(Map.empty[Int, String]), Rose(Map(1 -> "one", 2 -> "two")), Rose(Map(3 -> "three", 4 -> "four", 5 -> "five"))), rnd = Randomizer.default)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val edges = List(a1, a2, a3).map(_.value)
@@ -5440,7 +5440,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       it("should not exhibit this bug in Map shrinking") {
         val mapGen = implicitly[Generator[Map[Map[Int, String], String]]]
         val xss = Map(Map(100 -> "100", 200 -> "200", 300 -> "300", 400 -> "400", 500 -> "500") -> "test")
-        mapGen.next(SizeParam(1, 0, 1), List(xss), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
+        mapGen.next(SizeParam(1, 0, 1), List(mapGen.roseTreeOfEdge(xss, SizeParam(1, 0, 1), mapGen.isValid)), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
       }
       it("should shrink Map with an algo towards empty Map") {
         import GeneratorDrivenPropertyChecks._
@@ -5461,12 +5461,12 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following size determined by havingSize method") {
         val aGen= Generator.mapGenerator[Int, String].havingSize(5)
-        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(Map(3 -> "three", 99 -> "ninety nine")), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Map(3 -> "three", 99 -> "ninety nine"), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         all(shrinkees) should have size 5
       }
       it("should produce shrinkees following sizes determined by havingSizesBetween method") {
         val aGen= Generator.mapGenerator[Int, String].havingSizesBetween(2, 5)
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(Map(3 -> "three", 99 -> "ninety nine")), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Map(3 -> "three", 99 -> "ninety nine"), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.size >= 4)
           shrinkees should not be empty
@@ -5476,7 +5476,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following sizes determined by havingSizesDeterminedBy method") {
         val aGen= Generator.mapGenerator[Int, String].havingSizesDeterminedBy(s => SizeParam(2, 3, 5))
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(Map(3 -> "three", 99 -> "ninety nine")), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Map(3 -> "three", 99 -> "ninety nine"), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.size >= 4)
           shrinkees should not be empty
@@ -5487,11 +5487,11 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       it("should return an empty LazyListOrStream when asked to shrink a Map of size 0") {
         val lstGen = implicitly[Generator[Map[PosInt, Int]]]
         val xs = Map.empty[PosInt, Int]
-        lstGen.next(SizeParam(1, 0, 1), List(xs), Randomizer.default)._1.shrinks.map(_.value).toSet shouldBe empty
+        lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(xs, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value).toSet shouldBe empty
       }
       it("should return an LazyListOrStream that does not repeat canonicals when asked to shrink a Map of size 2 that includes canonicals") {
         val lstGen = implicitly[Generator[Map[PosInt, Int]]]
-        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(Map(PosInt(3) -> 3, PosInt(2) -> 2, PosInt(99) -> 99)), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(Map(PosInt(3) -> 3, PosInt(2) -> 2, PosInt(99) -> 99), SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         shrinkees.distinct should contain theSameElementsAs shrinkees
       }
       it("should return an LazyListOrStream that does not repeat the passed map-to-shink even if that set has a power of 2 length") {
@@ -5502,7 +5502,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val listToShrink: Map[PosInt, Int] = (Map.empty[PosInt, Int] /: (1 to 16)) { (map, n) =>
           map + (PosInt.ensuringValid(n) -> n)
         }
-        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(listToShrink), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(listToShrink, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a Map generator whose canonical method uses the canonical method of the underlying types") {
@@ -5525,7 +5525,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.mapGenerator[Int, String].filter(_.nonEmpty)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(Map(1 -> "1", 2 -> "2", 3 -> "3", 4 -> "4")), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(Map(1 -> "1", 2 -> "2", 3 -> "3", 4 -> "4"), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not contain (Set.empty[String])
 
@@ -5562,7 +5562,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce SortedMap[K, V] edge values first in random order") {
         val gen = Generator.sortedMapGenerator[Int, String]
-        val (a1: RoseTree[SortedMap[Int, String]], ae1: List[SortedMap[Int, String]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = List(SortedMap.empty[Int, String], SortedMap(1 -> "one", 2 -> "two"), SortedMap(3 -> "three", 4 -> "four", 5 -> "five")), rnd = Randomizer.default)
+        val (a1: RoseTree[SortedMap[Int, String]], ae1: List[RoseTree[SortedMap[Int, String]]], ar1: Randomizer) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = List(Rose(SortedMap.empty[Int, String]), Rose(SortedMap(1 -> "one", 2 -> "two")), Rose(SortedMap(3 -> "three", 4 -> "four", 5 -> "five"))), rnd = Randomizer.default)
         val (a2, ae2, ar2) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae1, rnd = ar1)
         val (a3, _, _) = gen.next(szp = SizeParam(PosZInt(0), 100, 100), edges = ae2, rnd = ar2)
         val edges = List(a1, a2, a3).map(_.value)
@@ -5614,7 +5614,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         implicit val ordering: Ordering[SortedMap[Int, String]] = Ordering.by[SortedMap[Int, String], Int](_.size)
         val mapGen = implicitly[Generator[SortedMap[SortedMap[Int, String], String]]]
         val xss = SortedMap(SortedMap(100 -> "100", 200 -> "200", 300 -> "300", 400 -> "400", 500 -> "500") -> "test")
-        mapGen.next(SizeParam(1, 0, 1), List(xss), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
+        mapGen.next(SizeParam(1, 0, 1), List(mapGen.roseTreeOfEdge(xss, SizeParam(1, 0, 1), mapGen.isValid)), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
       }
       it("should shrink SortedMap with an algo towards empty SortedMap") {
         import GeneratorDrivenPropertyChecks._
@@ -5635,12 +5635,12 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following size determined by havingSize method") {
         val aGen= Generator.sortedMapGenerator[Int, String].havingSize(5)
-        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(SortedMap(3 -> "three", 99 -> "ninety nine")), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(SortedMap(3 -> "three", 99 -> "ninety nine"), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         all(shrinkees) should have size 5
       }
       it("should produce shrinkees following sizes determined by havingSizesBetween method") {
         val aGen= Generator.sortedMapGenerator[Int, String].havingSizesBetween(2, 5)
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(SortedMap(3 -> "three", 99 -> "ninety nine")), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(SortedMap(3 -> "three", 99 -> "ninety nine"), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.size >= 4)
           shrinkees should not be empty
@@ -5650,7 +5650,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following sizes determined by havingSizesDeterminedBy method") {
         val aGen= Generator.mapGenerator[Int, String].havingSizesDeterminedBy(s => SizeParam(2, 3, 5))
-        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(SortedMap(3 -> "three", 99 -> "ninety nine")), Randomizer.default)
+        val (v, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(SortedMap(3 -> "three", 99 -> "ninety nine"), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = v.shrinks.map(_.value)
         if (v.value.size >= 4)
           shrinkees should not be empty
@@ -5661,11 +5661,11 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       it("should return an empty LazyListOrStream when asked to shrink a SortedMap of size 0") {
         val lstGen = implicitly[Generator[SortedMap[PosInt, Int]]]
         val xs = SortedMap.empty[PosInt, Int]
-        lstGen.next(SizeParam(1, 0, 1), List(xs), Randomizer.default)._1.shrinks.map(_.value).toSet shouldBe empty
+        lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(xs, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value).toSet shouldBe empty
       }
       it("should return an LazyListOrStream that does not repeat canonicals when asked to shrink a SortedMap of size 2 that includes canonicals") {
         val lstGen = implicitly[Generator[SortedMap[PosInt, Int]]]
-        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(SortedMap(PosInt(3) -> 3, PosInt(2) -> 2, PosInt(99) -> 99)), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(SortedMap(PosInt(3) -> 3, PosInt(2) -> 2, PosInt(99) -> 99), SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         shrinkees.distinct should contain theSameElementsAs shrinkees
       }
       it("should return an LazyListOrStream that does not repeat the passed SortedMap-to-shink even if that SortedMap has a power of 2 length") {
@@ -5676,7 +5676,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
         val listToShrink: SortedMap[PosInt, Int] = (SortedMap.empty[PosInt, Int] /: (1 to 16)) { (map, n) =>
           map + (PosInt.ensuringValid(n) -> n)
         }
-        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(listToShrink), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(listToShrink, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a SortedMap generator whose canonical method uses the canonical method of the underlying types") {
@@ -5699,7 +5699,7 @@ class GeneratorSpec extends AnyFunSpec with Matchers {
       }
       it("should produce shrinkees following constraint determined by filter method") {
         val aGen= Generator.sortedMapGenerator[Int, String].filter(_.nonEmpty)
-        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(SortedMap(1 -> "1", 2 -> "2", 3 -> "3", 4 -> "4")), Randomizer.default)
+        val (rs, _, _) = aGen.next(SizeParam(1, 0, 1), List(aGen.roseTreeOfEdge(SortedMap(1 -> "1", 2 -> "2", 3 -> "3", 4 -> "4"), SizeParam(1, 0, 1), aGen.isValid)), Randomizer.default)
         val shrinkees = rs.shrinks.map(_.value)
         shrinkees should not contain (Set.empty[String])
 

--- a/jvm/scalatest-test/src/test/scala/org/scalatest/prop/HavingLengthsBetweenSpec.scala
+++ b/jvm/scalatest-test/src/test/scala/org/scalatest/prop/HavingLengthsBetweenSpec.scala
@@ -47,7 +47,7 @@ class HavingLengthsBetweenSpec extends AnyFunSpec with Matchers {
         import CommonGenerators.lists
         val lstGen = lists[List[Int]].havingLengthsBetween(0, 77)
         val xss = List(List(100, 200, 300, 400, 300))
-        lstGen.next(SizeParam(1, 0, 1), List(xss), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
+        lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(xss, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
       }
       it("should shrink Lists using strategery") {
         import GeneratorDrivenPropertyChecks._
@@ -57,7 +57,7 @@ class HavingLengthsBetweenSpec extends AnyFunSpec with Matchers {
         forAll (lists[Int].havingLengthsBetween(0, 78)) { (xs: List[Int]) =>
           val generator = lists[Int]
           // pass in List(xs) as only edge case so the generator will generate rose tree with the specified value.
-          val (shrinkRt, _, _) = generator.next(SizeParam(1, 1, 1), List(xs), Randomizer.default) //generator.shrink(xs, Randomizer.default)
+          val (shrinkRt, _, _) = generator.next(SizeParam(1, 1, 1), List(generator.roseTreeOfEdge(xs, SizeParam(1, 1, 1), generator.isValid)), Randomizer.default) //generator.shrink(xs, Randomizer.default)
           val shrinks: LazyListOrStream[List[Int]] = shrinkRt.shrinks.map(_.value).reverse
           if (xs.isEmpty)
             shrinks shouldBe empty
@@ -74,12 +74,12 @@ class HavingLengthsBetweenSpec extends AnyFunSpec with Matchers {
         import CommonGenerators.lists
         val lstGen = lists[Int].havingLengthsBetween(0, 99)
         val xs = List.empty[Int]
-        lstGen.next(SizeParam(1, 0, 1), List(xs), Randomizer.default)._1.shrinks.map(_.value) shouldBe empty
+        lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(xs, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value) shouldBe empty
       }
       it("should return an Iterator that does not repeat canonicals when asked to shrink a List of size 2 that includes canonicals") {
         import CommonGenerators.lists
         val lstGen = lists[Int].havingLengthsBetween(0, 66)
-        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(List(3, 99)), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(List(3, 99), SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         shrinkees.distinct should contain theSameElementsAs shrinkees
       }
       it("should return an Iterator that does not repeat the passed list-to-shink even if that list has a power of 2 length") {
@@ -89,7 +89,7 @@ class HavingLengthsBetweenSpec extends AnyFunSpec with Matchers {
         import CommonGenerators.lists
         val lstGen = lists[Int].havingLengthsBetween(0, 77)
         val listToShrink = List.fill(16)(99)
-        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(listToShrink), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(listToShrink, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a list generator whose canonical method uses the canonical method of the underlying T if min is 0 or 1") {
@@ -150,7 +150,7 @@ class HavingLengthsBetweenSpec extends AnyFunSpec with Matchers {
         import CommonGenerators.lists
         val lstGen = lists[List[Int]].havingLengthsBetween(5, 77)
         val xss = List(List(100, 200, 300, 400, 300))
-        lstGen.next(SizeParam(1, 0, 1), List(xss), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
+        lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(xss, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value) should not contain xss
       }
       it("should shrink Lists using strategery") {
         import GeneratorDrivenPropertyChecks._
@@ -160,7 +160,7 @@ class HavingLengthsBetweenSpec extends AnyFunSpec with Matchers {
         forAll (lists[Int].havingLengthsBetween(5, 78)) { (xs: List[Int]) =>
           val generator = lists[Int]
           // pass in List(xs) as only edge case so the generator will generate rose tree with the specified value.
-          val (shrinkRt, _, _) = generator.next(SizeParam(1, 1, 1), List(xs), Randomizer.default)
+          val (shrinkRt, _, _) = generator.next(SizeParam(1, 1, 1), List(generator.roseTreeOfEdge(xs, SizeParam(1, 1, 1), generator.isValid)), Randomizer.default)
           val shrinks: LazyListOrStream[List[Int]] = shrinkRt.shrinks.map(_.value).reverse
           if (xs.isEmpty)
             shrinks shouldBe empty
@@ -177,12 +177,12 @@ class HavingLengthsBetweenSpec extends AnyFunSpec with Matchers {
         import CommonGenerators.lists
         val lstGen = lists[Int].havingLengthsBetween(5, 99)
         val xs = List.empty[Int]
-        lstGen.next(SizeParam(0, 0, 0), List(xs), Randomizer.default)._1.shrinks.map(_.value) shouldBe empty
+        lstGen.next(SizeParam(0, 0, 0), List(lstGen.roseTreeOfEdge(xs, SizeParam(0, 0, 0), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value) shouldBe empty
       }
       it("should return an Iterator that does not repeat canonicals when asked to shrink a List of size 2 that includes canonicals") {
         import CommonGenerators.lists
         val lstGen = lists[Int].havingLengthsBetween(5, 66)
-        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(List(3, 99)), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(List(3, 99), SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         shrinkees.distinct should contain theSameElementsAs shrinkees
       }
       it("should return an Iterator that does not repeat the passed list-to-shink even if that list has a power of 2 length") {
@@ -192,7 +192,7 @@ class HavingLengthsBetweenSpec extends AnyFunSpec with Matchers {
         import CommonGenerators.lists
         val lstGen = lists[Int].havingLengthsBetween(5, 77)
         val listToShrink = List.fill(16)(99)
-        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(listToShrink), Randomizer.default)._1.shrinks.map(_.value)
+        val shrinkees = lstGen.next(SizeParam(1, 0, 1), List(lstGen.roseTreeOfEdge(listToShrink, SizeParam(1, 0, 1), lstGen.isValid)), Randomizer.default)._1.shrinks.map(_.value)
         shrinkees.distinct should not contain listToShrink
       }
       it("should offer a list generator whose canonical method is empty if from is greater than 1") {

--- a/project/GenGen.scala
+++ b/project/GenGen.scala
@@ -3609,7 +3609,7 @@ $okayAssertions$
       |  }
       |
       |  def nextImpl(szp: SizeParam, isValidFun: ($lastType$, SizeParam) => Boolean, rnd: Randomizer): (RoseTree[$lastType$], Randomizer) = underlying.nextImpl(szp, isValidFun, rnd)
-      |  override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[$lastType$], Randomizer) = underlying.initEdges(maxLength, rnd)
+      |  override def initEdges(maxLength: PosZInt, rnd: Randomizer): (List[RoseTree[$lastType$]], Randomizer) = underlying.initEdges(maxLength, rnd)
       |  override def map[Z](f: ($lastType$) => Z): Generator[Z] = underlying.map(f)
       |  override def flatMap[Z](f: ($lastType$) => Generator[Z]): Generator[Z] = underlying.flatMap(f)
       |  override def canonicals: LazyListOrStream[RoseTree[$lastType$]] = underlying.canonicals


### PR DESCRIPTION
## Summary
Refactor Generator.initEdges and Generator.next to carry List[RoseTree[T]] edges instead of bare List[T], so that composite generators — most notably the Option generator — preserve their shrink structure through edges.
Previously, edge handling only recorded the head value of each edge (List[T]), discarding the underlying RoseTree. This meant that when an edge was generated as part of a composed generator (e.g. a Some(...) inside an Option), its associated shrinks were lost once the edge flowed through the composition. By threading the full RoseTree[T] along each edge, composed generators now shrink edges correctly, matching the behavior of next.

## What changed
- Generator.initEdges and Generator.next now return/carry List[RoseTree[T]] for edges rather than List[T].
- Updated all generator implementations that override or consume these methods (in Generator.scala, CommonGenerators.scala, and PropCheckerAsserting.scala) to produce and propagate the richer edge type.
- Regenerated the GeneratorFor* templates (project/GenGen.scala) to reflect the new edge type.
- Added/updated edge tests in CommonGeneratorsSpec.scala, GeneratorSpec.scala, and HavingLengthsBetweenSpec.scala, including a regression test confirming that an edge value now shrinks to its canonical form (e.g. 2147483647 → 3).
- Fixes an intermittent shrink bug where an edge's shrink chain was broken after composition.